### PR TITLE
Fix undefined behavior when str_concat_nothrow is called with a type that's convertible to std::wstring (non-reference)

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -1683,6 +1683,14 @@ namespace wil
             result = maker.release();
             return S_OK;
         }
+
+        // NOTE: 'Strings' must all be PCWSTR, or convertible to PCWSTR, but C++ doesn't allow us to express that cleanly
+        template <typename string_type, typename... Strings>
+        HRESULT str_build_nothrow(string_type& result, Strings... strings)
+        {
+            PCWSTR localStrings[] = { strings... };
+            return str_build_nothrow(result, localStrings, sizeof...(Strings));
+        }
     }
 
     // Concatenate any number of strings together and store it in an automatically allocated string.  If a string is present
@@ -1691,9 +1699,7 @@ namespace wil
     HRESULT str_concat_nothrow(string_type& buffer, const strings&... str)
     {
         static_assert(sizeof...(str) > 0, "attempting to concatenate no strings");
-        // Strings to concat include whatever is stored in result (if anything), followed by the arguments
-        PCWSTR localStrings[] = { details::string_maker<string_type>::get(buffer), str_raw_ptr(str)... };
-        return details::str_build_nothrow(buffer, localStrings, ARRAYSIZE(localStrings));
+        return details::str_build_nothrow(buffer, details::string_maker<string_type>::get(buffer), str_raw_ptr(str)...);
     }
 
 #ifdef WIL_ENABLE_EXCEPTIONS

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -323,10 +323,20 @@ struct has_operator_pwstr
 };
 
 #ifdef WIL_ENABLE_EXCEPTIONS
-struct has_operator_wstr
+struct has_operator_wstr_ref
 {
     std::wstring value;
     operator const std::wstring&() const
+    {
+        return value;
+    }
+};
+
+// E.g. mimics something like std::filesystem::path
+struct has_operator_wstr
+{
+    std::wstring value;
+    operator std::wstring() const
     {
         return value;
     }
@@ -352,22 +362,24 @@ TEST_CASE("FileSystemTests::VerifyStrConcat", "[filesystem]")
         has_operator_pwstr test7{ test7Buffer };
 
 #ifdef WIL_ENABLE_EXCEPTIONS
-        has_operator_wstr test8{ L"Test8" };
+        has_operator_wstr_ref test8{ L"Test8" };
+        has_operator_wstr test9{ L"Test9" };
 #else
         PCWSTR test8 = L"Test8";
+        PCWSTR test9 = L"Test9";
 #endif
-        PCWSTR expectedStr = L"Test1Test2Test3Test4Test5Test6Test7Test8";
+        PCWSTR expectedStr = L"Test1Test2Test3Test4Test5Test6Test7Test8Test9";
 
 #ifdef WIL_ENABLE_EXCEPTIONS
-        auto combinedString = wil::str_concat<wil::unique_cotaskmem_string>(test1, test2, test3, test4, test5, test6, test7, test8);
+        auto combinedString = wil::str_concat<wil::unique_cotaskmem_string>(test1, test2, test3, test4, test5, test6, test7, test8, test9);
         REQUIRE(CompareStringOrdinal(combinedString.get(), -1, expectedStr, -1, TRUE) == CSTR_EQUAL);
 #endif
 
         wil::unique_cotaskmem_string combinedStringNT;
-        REQUIRE_SUCCEEDED(wil::str_concat_nothrow(combinedStringNT, test1, test2, test3, test4, test5, test6, test7, test8));
+        REQUIRE_SUCCEEDED(wil::str_concat_nothrow(combinedStringNT, test1, test2, test3, test4, test5, test6, test7, test8, test9));
         REQUIRE(CompareStringOrdinal(combinedStringNT.get(), -1, expectedStr, -1, TRUE) == CSTR_EQUAL);
 
-        auto combinedStringFF = wil::str_concat_failfast<wil::unique_cotaskmem_string>(test1, test2, test3, test4, test5, test6, test7, test8);
+        auto combinedStringFF = wil::str_concat_failfast<wil::unique_cotaskmem_string>(test1, test2, test3, test4, test5, test6, test7, test8, test9);
         REQUIRE(CompareStringOrdinal(combinedStringFF.get(), -1, expectedStr, -1, TRUE) == CSTR_EQUAL);
     }
 


### PR DESCRIPTION
See the bug for more info on the issue. This change updates `str_concat_nothrow` so that `str_raw_ptr` appears in a function call expression and any temporaries that may be created are not destroyed until the `str_build_nothrow` call returns.

fixes #16 