### PR TITLE
Add put() to smart types exposing an operator&

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -380,10 +380,21 @@ namespace wil
         //! apparent, prefer to scope variables as close to use as possible (generally avoiding use of the same com_ptr variable in successive calls to
         //! receive an output interface).
         //! @see addressof
-        pointer* operator&() WI_NOEXCEPT
+        pointer* put() WI_NOEXCEPT
         {
             reset();
             return &m_ptr;
+        }
+
+        //! Returns the address of the internal pointer (releases ownership of the pointer BEFORE returning the address).
+        //! The pointer is explicitly released to prevent accidental leaks of the pointer.  Coding standards generally indicate that
+        //! there is little valid `_Inout_` use of `IInterface**`, making this safe to do under typical use.  Since this behavior is not always immediately
+        //! apparent, prefer to scope variables as close to use as possible (generally avoiding use of the same com_ptr variable in successive calls to
+        //! receive an output interface).
+        //! @see addressof
+        pointer* operator&() WI_NOEXCEPT
+        {
+            return put();
         }
 
         //! Returns the address of the internal pointer (does not release the pointer; should not be used for `_Out_` parameters)

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -380,6 +380,11 @@ namespace wil
         //! apparent, prefer to scope variables as close to use as possible (generally avoiding use of the same com_ptr variable in successive calls to
         //! receive an output interface).
         //! @see addressof
+        //! ~~~~
+        //! STDAPI GetMuffin(IMuffin **muffin);
+        //! wil::com_ptr<IMuffin> myMuffin;
+        //! THROW_IF_FAILED(GetMuffin(myMuffin.put()));
+        //! ~~~~
         pointer* put() WI_NOEXCEPT
         {
             reset();

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -292,6 +292,11 @@ namespace wil
             return storage_t::is_valid();
         }
 
+        //! ~~~~
+        //! BOOL OpenOrCreateWaffle(PCWSTR name, HWAFFLE* handle);
+        //! wil::unique_any<HWAFFLE, decltype(&::CloseWaffle), ::CloseWaffle> waffle;
+        //! RETURN_IF_WIN32_BOOL_FALSE(OpenOrCreateWaffle(L"tasty.yum", waffle.put()));
+        //! ~~~~
         pointer_storage *put() WI_NOEXCEPT
         {
             static_assert(wistd::is_same<typename policy::pointer_access, details::pointer_access_all>::value, "operator & is not available for this handle");

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -292,11 +292,16 @@ namespace wil
             return storage_t::is_valid();
         }
 
-        pointer_storage *operator&() WI_NOEXCEPT
+        pointer_storage *put() WI_NOEXCEPT
         {
             static_assert(wistd::is_same<typename policy::pointer_access, details::pointer_access_all>::value, "operator & is not available for this handle");
             storage_t::reset();
             return storage_t::addressof();
+        }
+
+        pointer_storage *operator&() WI_NOEXCEPT
+        {
+            return put();
         }
 
         pointer get() const WI_NOEXCEPT
@@ -1097,10 +1102,15 @@ namespace wil
             return &m_ptr;
         }
 
-        pointer* operator&() WI_NOEXCEPT
+        pointer* put() WI_NOEXCEPT
         {
             reset();
             return addressof();
+        }
+
+        pointer* operator&() WI_NOEXCEPT
+        {
+            return put();
         }
 
         size_type* size_address() WI_NOEXCEPT
@@ -1413,10 +1423,16 @@ namespace wil
         }
 
         //! Releases the held token and allows attaching a new token; associate must be called first
-        token_t* operator&() WI_NOEXCEPT
+        token_t* put() WI_NOEXCEPT
         {
             reset(invalid_token);
             return addressof();
+        }
+
+        //! Releases the held token and allows attaching a new token; associate must be called first
+        token_t* operator&() WI_NOEXCEPT
+        {
+            return put();
         }
 
         //! Retrieves the token
@@ -1533,10 +1549,17 @@ namespace wil
 
         //! Releases the held interface (first performing the interface call if required)
         //! and allows attaching a new interface
-        interface_t** operator&() WI_NOEXCEPT
+        interface_t** put() WI_NOEXCEPT
         {
             reset();
             return addressof();
+        }
+
+        //! Releases the held interface (first performing the interface call if required)
+        //! and allows attaching a new interface
+        interface_t** operator&() WI_NOEXCEPT
+        {
+            return put();
         }
 
         unique_com_call(const unique_com_call&) = delete;
@@ -2013,11 +2036,16 @@ namespace wil {
             return storage_t::is_valid();
         }
 
-        pointer_storage *operator&()
+        pointer_storage *put()
         {
             static_assert(wistd::is_same<typename policy::pointer_access, details::pointer_access_all>::value, "operator & is not available for this handle");
             storage_t::reset();
             return storage_t::addressof();
+        }
+
+        pointer_storage *operator&()
+        {
+            return put();
         }
 
         pointer get() const WI_NOEXCEPT

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -295,6 +295,18 @@ TEST_CASE("ComTests::Test_Address", "[com][com_ptr]")
         REQUIRE((*pFakePtr) == &helper);
     }
 
+    SECTION("put")
+    {
+        wil::com_ptr_nothrow<IUnknownFake> ptr(&helper);
+        IUnknownFake::Clear();
+
+        pFakePtr = ptr.put();
+        REQUIRE(IUnknownFake::GetRelease() == 1);
+        REQUIRE(IUnknownFake::GetAddRef() == 0);
+        REQUIRE((*pFakePtr) == nullptr);
+        REQUIRE(ptr == nullptr);
+    }
+
     SECTION("Address operator")
     {
         wil::com_ptr_nothrow<IUnknownFake> ptr(&helper);
@@ -711,6 +723,16 @@ void TestSmartPointer(const Ptr& ptr1, const Ptr& ptr2)
         REQUIRE(p1.get() == ptr1.get());
         p1.reset();
         *(p1.addressof()) = p2.detach();
+        REQUIRE(p1.get() == ptr2.get());
+    }
+
+    SECTION("put")
+    {
+        auto p1 = ptr1;
+        auto p2 = ptr2;
+        p1.put();
+        REQUIRE_FALSE(p1);
+        *p1.put() = p2.detach();
         REQUIRE(p1.get() == ptr2.get());
     }
 

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -310,13 +310,21 @@ TEST_CASE("ResourceTests::VerifyUniqueComCall", "[resource][unique_com_call]")
     REQUIRE(*call1.addressof() == nullptr);
 
     call1.reset(&fake1);
-
     fake2.closes = 0;
     fake2.refs = 1;
     *(&call1) = &fake2;
     REQUIRE(!fake1.has_ref());
     REQUIRE(fake1.called());
     REQUIRE(fake2.has_ref());
+
+    call1.reset(&fake1);
+    fake2.closes = 0;
+    fake2.refs = 1;
+    *call1.put() = &fake2;
+    REQUIRE(!fake1.has_ref());
+    REQUIRE(fake1.called());
+    REQUIRE(fake2.has_ref());
+
     call1.reset();
     REQUIRE(!fake2.has_ref());
     REQUIRE(fake2.called());


### PR DESCRIPTION
This makes the interface feel more natural to C++/WinRT users, makes discovery of the feature easier (it shows up in Intellisense) as well as being explicit about the operation instead of implicit, so easier to notice when reading code because `operator&` normally isn't stateful.