### PR TITLE
Copy definition of placement new to <wil/wistd_memory.h>

### DIFF
--- a/include/wil/wistd_memory.h
+++ b/include/wil/wistd_memory.h
@@ -1035,4 +1035,38 @@ namespace wistd     // ("Windows Implementation" std)
 }
 /// @endcond
 
+#pragma warning(push)
+#pragma warning(disable: 4577) // 'noexcept' used with no exception handling mode specified
+#pragma warning(disable: 4514) // 'operator new': unreferenced inline function has been removed
+#ifndef __PLACEMENT_NEW_INLINE
+    #define __PLACEMENT_NEW_INLINE
+    _Ret_notnull_ _Post_writable_byte_size_(_Size) _Post_satisfies_(return == _Where)
+    inline void* __CRTDECL operator new(size_t _Size, _Writable_bytes_(_Size) void* _Where) noexcept
+    {
+        (void)_Size;
+        return _Where;
+    }
+
+    inline void __CRTDECL operator delete(void*, void*) noexcept
+    {
+        return;
+    }
+#endif
+
+#ifndef __PLACEMENT_VEC_NEW_INLINE
+    #define __PLACEMENT_VEC_NEW_INLINE
+    _Ret_notnull_ _Post_writable_byte_size_(_Size) _Post_satisfies_(return == _Where)
+    inline void* __CRTDECL operator new[](size_t _Size,
+        _Writable_bytes_(_Size) void* _Where) noexcept
+    {
+        (void)_Size;
+        return _Where;
+    }
+
+    inline void __CRTDECL operator delete[](void*, void*) noexcept
+    {
+    }
+#endif
+#pragma warning(pop)
+
 #endif  // _WISTD_MEMORY_H_


### PR DESCRIPTION
Elsewhere in WIL, placement `new` is used regardless of whether `<new>` is included or not. Since we can't safely `#include <new>`, we copy its definition of placement `new` (and placement `new[]`) into `<wil/wisdt_memory.h>`