### PR TITLE
Work around Clang x86 Debug build issue

### DIFF
--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -50,8 +50,15 @@
 //*****************************************************************************
 
 #ifdef RESULT_DEBUG
-#define WI_ASSERT(condition)                                (__WI_ANALYSIS_ASSUME(condition), ((!(condition)) ? (__annotation(L"Debug", L"AssertFail", L#condition), DbgRaiseAssertionFailure(), FALSE) : TRUE))
-#define WI_ASSERT_MSG(condition, msg)                       (__WI_ANALYSIS_ASSUME(condition), ((!(condition)) ? (__annotation(L"Debug", L"AssertFail", L##msg), DbgRaiseAssertionFailure(), FALSE) : TRUE))
+#if defined(__clang__) && defined(_WIN32)
+// Clang currently mis-handles '__annotation' for 32-bit - https://bugs.llvm.org/show_bug.cgi?id=41890
+#define __WI_ASSERT_FAIL_ANNOTATION(msg) (void)0
+#else
+#define __WI_ASSERT_FAIL_ANNOTATION(msg) __annotation(L"Debug", L"AssertFail", msg)
+#endif
+
+#define WI_ASSERT(condition)                                (__WI_ANALYSIS_ASSUME(condition), ((!(condition)) ? (__WI_ASSERT_FAIL_ANNOTATION(L"" #condition), DbgRaiseAssertionFailure(), FALSE) : TRUE))
+#define WI_ASSERT_MSG(condition, msg)                       (__WI_ANALYSIS_ASSUME(condition), ((!(condition)) ? (__WI_ASSERT_FAIL_ANNOTATION(L##msg), DbgRaiseAssertionFailure(), FALSE) : TRUE))
 #define WI_ASSERT_NOASSUME                                  WI_ASSERT
 #define WI_ASSERT_MSG_NOASSUME                              WI_ASSERT_MSG
 #define WI_VERIFY                                           WI_ASSERT

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -17,6 +17,8 @@ steps:
     call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
     if %ERRORLEVEL% NEQ 0 goto :eof
     
+    call scripts\init.cmd -c clang -g ninja -b debug --fast
+    if %ERRORLEVEL% NEQ 0 goto :eof
     call scripts\init.cmd -c msvc -g ninja -b debug --fast
     if %ERRORLEVEL% NEQ 0 goto :eof
     

--- a/scripts/init_all.cmd
+++ b/scripts/init_all.cmd
@@ -2,12 +2,8 @@
 
 :: NOTE: Architecture is picked up from the command window, so we can't control that here :(
 
-:: TODO: https://github.com/Microsoft/wil/issues/7 - There's currently a bug where Clang and/or the linker chokes when
-::       trying to compile the tests for 32-bit debug, so skip for now
-if "%Platform%"=="x86" goto :skip_clang_x86_debug
 call %~dp0\init.cmd -c clang -g ninja -b debug %*
 if %ERRORLEVEL% NEQ 0 ( goto :eof )
-:skip_clang_x86_debug
 call %~dp0\init.cmd -c clang -g ninja -b relwithdebinfo %*
 if %ERRORLEVEL% NEQ 0 ( goto :eof )
 


### PR DESCRIPTION
Thanks to @tiagomacarios for pointing out that this is related to the use of `__annotation`. This change makes it so that the `WI_ASSERT`, etc. macros avoid using `_annotation` when building for 32-bit debug with Clang.

fixes #7 