### PR TITLE
Update cppwinrt.h to use the new C++/WinRT 2.0 exception translation techniques

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,14 @@ if (NOT DEFINED WIL_BUILD_VERSION)
     set(WIL_BUILD_VERSION "0.0.0")
 endif()
 
+# Detect the Windows SDK version. If we're using the Visual Studio generator, this will be provided for us. Otherwise
+# we'll need to assume that this value comes from the command line (e.g. through the VS command prompt)
+if (DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+    set(WIL_WINDOWS_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+else()
+    # This has a trailing backslash for whatever reason...
+    string(REGEX REPLACE "\\\\$" "" WIL_WINDOWS_SDK_VERSION "$ENV{WindowsSDKVersion}")
+endif()
+
 add_subdirectory(packaging)
 add_subdirectory(tests)

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -16,47 +16,70 @@
 #include <unknwn.h>
 #include <hstring.h>
 
-#ifdef CPPWINRT_VERSION
-#error Please include wil/cppwinrt.h before including any C++/WinRT headers
-#endif
-
-#ifdef __WIL_RESULTMACROS_INCLUDED
-#error Please include wil/cppwinrt.h before including result_macros.h
-#endif
-
-#ifdef WINRT_EXTERNAL_CATCH_CLAUSE
-#error C++/WinRT external catch clause already defined outside of WIL
-#endif
-
 // WIL and C++/WinRT use two different exception types for communicating HRESULT failures. Thus, both libraries need to
-// understand how to translate these exception types into the correct HRESULT values at the ABI boundary. C++/WinRT
-// accomplishes this by injecting the WINRT_EXTERNAL_CATCH_CLAUSE macro - that WIL defines below - into its exception
-// handler. WIL accomplishes this by detecting this file's inclusion in result_macros.h and modifies its behavior to
-// account for the C++/WinRT exception type.
+// understand how to translate these exception types into the correct HRESULT values at the ABI boundary. Prior to
+// C++/WinRT "2.0" this was accomplished by injecting the WINRT_EXTERNAL_CATCH_CLAUSE macro - that WIL defines below -
+// into its exception handler (winrt::to_hresult). Starting with C++/WinRT "2.0" this mechanism has shifted to a global
+// function pointer - winrt_to_hresult_handler - that WIL sets automatically when this header is included and
+// 'RESULT_SUPPRESS_STATIC_INITIALIZERS' is not defined.
 
+/// @cond
+namespace wil::details
+{
+    // Since the C++/WinRT version macro is a string...
+    inline constexpr int major_version_from_string(const char* versionString)
+    {
+        int result = 0;
+        auto str = versionString;
+        while ((*str >= '0') && (*str <= '9'))
+        {
+            result = result * 10 + (*str - '0');
+            ++str;
+        }
+
+        return result;
+    }
+}
+/// @endcond
+
+#ifdef CPPWINRT_VERSION
+// Prior to C++/WinRT "2.0" this header needed to be included before 'winrt/base.h' so that our definition of
+// 'WINRT_EXTERNAL_CATCH_CLAUSE' would get picked up in the implementation of 'winrt::to_hresult'. This is no longer
+// problematic, so only emit an error when using a version of C++/WinRT prior to 2.0
+static_assert(::wil::details::major_version_from_string(CPPWINRT_VERSION) >= 2,
+    "Please include wil/cppwinrt.h before including any C++/WinRT headers");
+#endif
+
+// NOTE: Will eventually be removed once C++/WinRT 2.0 use can be assumed
+#ifdef WINRT_EXTERNAL_CATCH_CLAUSE
+#define __WI_CONFLICTING_WINRT_EXTERNAL_CATCH_CLAUSE 1
+#else
 #define WINRT_EXTERNAL_CATCH_CLAUSE                                             \
     catch (const wil::ResultException& e)                                       \
     {                                                                           \
         return winrt::hresult_error(e.GetErrorCode(), winrt::to_hstring(e.what())).to_abi();  \
     }
-
-namespace wil::details
-{
-    // Due to header dependency issues, result_macros.h cannot reference winrt::hresult_error, so instead declare
-    // functions that we can define after including base.h
-    HRESULT __stdcall ResultFromCppWinRTException(
-        _Inout_updates_opt_(debugStringChars) PWSTR debugString,
-        _When_(debugString != nullptr, _Pre_satisfies_(debugStringChars > 0)) size_t debugStringChars) WI_NOEXCEPT;
-}
+#endif
 
 #include "result_macros.h"
 #include <winrt/base.h>
 
+#if __WI_CONFLICTING_WINRT_EXTERNAL_CATCH_CLAUSE
+static_assert(::wil::details::major_version_from_string(CPPWINRT_VERSION) >= 2,
+    "C++/WinRT external catch clause already defined outside of WIL");
+#endif
+
+// In C++/WinRT 2.0 and beyond, this function pointer exists. In earlier versions it does not. It's much easier to avoid
+// linker errors than it is to SFINAE on variable existence, so we declare the variable here, but are careful not to
+// use it unless the version of C++/WinRT is high enough
+extern std::int32_t(__stdcall* winrt_to_hresult_handler)(void*) noexcept;
+
+/// @cond
 namespace wil::details
 {
     inline HRESULT __stdcall ResultFromCppWinRTException(
         _Inout_updates_opt_(debugStringChars) PWSTR debugString,
-        _When_(debugString != nullptr, _Pre_satisfies_(debugStringChars > 0)) size_t debugStringChars) WI_NOEXCEPT
+        _When_(debugString != nullptr, _Pre_satisfies_(debugStringChars > 0)) size_t debugStringChars) noexcept
     {
         try
         {
@@ -78,9 +101,40 @@ namespace wil::details
         }
     }
 }
+/// @endcond
 
 namespace wil
 {
+    inline std::int32_t __stdcall winrt_to_hresult(void* returnAddress) noexcept
+    {
+        // C++/WinRT only gives us the return address (caller), so pass along an empty 'DiagnosticsInfo' since we don't
+        // have accurate file/line/etc. information
+        return static_cast<std::int32_t>(details::ReportFailure_CaughtException(__R_DIAGNOSTICS_RA(DiagnosticsInfo{}, returnAddress), FailureType::Return));
+    }
+
+    inline void WilInitialize_CppWinRT()
+    {
+        details::g_pfnResultFromCaughtException_CppWinRt = details::ResultFromCppWinRTException;
+        if constexpr (details::major_version_from_string(CPPWINRT_VERSION) >= 2)
+        {
+            WI_ASSERT(winrt_to_hresult_handler == nullptr);
+            winrt_to_hresult_handler = winrt_to_hresult;
+        }
+    }
+
+    /// @cond
+    namespace details
+    {
+#ifndef RESULT_SUPPRESS_STATIC_INITIALIZERS
+        WI_HEADER_INITITALIZATION_FUNCTION(WilInitialize_CppWinRT, []
+        {
+            ::wil::WilInitialize_CppWinRT();
+            return 1;
+        });
+#endif
+    }
+    /// @endcond
+
     // Provides an overload of verify_hresult so that the WIL macros can recognize winrt::hresult as a valid "hresult" type.
     inline long verify_hresult(winrt::hresult hr) noexcept
     {

--- a/tests/CppWinRT20Tests.cpp
+++ b/tests/CppWinRT20Tests.cpp
@@ -1,0 +1,28 @@
+
+#include "common.h"
+
+// Prior to C++/WinRT 2.0 this would cause issues since we're not including wil/cppwinrt.h in this translation unit.
+// However, since we're going to link into the same executable as 'CppWinRTTests.cpp', the 'winrt_to_hresult_handler'
+// global function pointer should be set, so these should all run successfully
+
+#include <winrt/base.h>
+#include <wil/result.h>
+
+TEST_CASE("CppWinRTTests::CppWinRT20Test", "[cppwinrt]")
+{
+    auto test = [](HRESULT hr)
+    {
+        try
+        {
+            THROW_HR(hr);
+        }
+        catch (...)
+        {
+            REQUIRE(hr == winrt::to_hresult());
+        }
+    };
+
+    test(E_OUTOFMEMORY);
+    test(E_INVALIDARG);
+    test(E_UNEXPECTED);
+}

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -3,6 +3,25 @@
 
 #include <wil/cppwinrt.h>
 
+// HRESULT values that C++/WinRT throws as something other than winrt::hresult_error - e.g. a type derived from
+// winrt::hresult_error, std::*, etc.
+static const HRESULT cppwinrt_mapped_hresults[] =
+{
+    E_ACCESSDENIED,
+    RPC_E_WRONG_THREAD,
+    E_NOTIMPL,
+    E_INVALIDARG,
+    E_BOUNDS,
+    E_NOINTERFACE,
+    CLASS_E_CLASSNOTAVAILABLE,
+    E_CHANGED_STATE,
+    E_ILLEGAL_METHOD_CALL,
+    E_ILLEGAL_STATE_CHANGE,
+    E_ILLEGAL_DELEGATE_ASSIGNMENT,
+    HRESULT_FROM_WIN32(ERROR_CANCELLED),
+    E_OUTOFMEMORY,
+};
+
 TEST_CASE("CppWinRTTests::WilToCppWinRTExceptionTranslationTest", "[cppwinrt]")
 {
     auto test = [](HRESULT hr)
@@ -17,11 +36,13 @@ TEST_CASE("CppWinRTTests::WilToCppWinRTExceptionTranslationTest", "[cppwinrt]")
         }
     };
 
+    for (auto hr : cppwinrt_mapped_hresults)
+    {
+        test(hr);
+    }
+
+    // A non-mapped HRESULT
     test(E_UNEXPECTED);
-    test(E_ACCESSDENIED);
-    test(E_INVALIDARG);
-    test(E_HANDLE);
-    test(E_OUTOFMEMORY);
 }
 
 TEST_CASE("CppWinRTTests::CppWinRTToWilExceptionTranslationTest", "[cppwinrt]")
@@ -38,11 +59,13 @@ TEST_CASE("CppWinRTTests::CppWinRTToWilExceptionTranslationTest", "[cppwinrt]")
         }
     };
 
+    for (auto hr : cppwinrt_mapped_hresults)
+    {
+        test(hr);
+    }
+
+    // A non-mapped HRESULT
     test(E_UNEXPECTED);
-    test(E_ACCESSDENIED);
-    test(E_INVALIDARG);
-    test(E_HANDLE);
-    test(E_OUTOFMEMORY);
 }
 
 TEST_CASE("CppWinRTTests::ResultFromExceptionDebugTest", "[cppwinrt]")
@@ -56,19 +79,44 @@ TEST_CASE("CppWinRTTests::ResultFromExceptionDebugTest", "[cppwinrt]")
         REQUIRE(hr == result);
     };
 
-    // Anything from SupportedExceptions::Known or SupportedExceptions::All should give back the same HRESULT
-    test(E_UNEXPECTED, wil::SupportedExceptions::Known);
-    test(E_ACCESSDENIED, wil::SupportedExceptions::Known);
-    test(E_INVALIDARG, wil::SupportedExceptions::All);
-    test(E_HANDLE, wil::SupportedExceptions::All);
+    for (auto hr : cppwinrt_mapped_hresults)
+    {
+        test(hr, wil::SupportedExceptions::Known);
+        test(hr, wil::SupportedExceptions::All);
+    }
 
-    // OOM gets translated to bad_alloc, which should always give back E_OUTOFMEMORY
-    test(E_OUTOFMEMORY, wil::SupportedExceptions::All);
-    test(E_OUTOFMEMORY, wil::SupportedExceptions::Known);
-    test(E_OUTOFMEMORY, wil::SupportedExceptions::ThrownOrAlloc);
+    // A non-mapped HRESULT
+    test(E_UNEXPECTED, wil::SupportedExceptions::Known);
+    test(E_UNEXPECTED, wil::SupportedExceptions::All);
 
     // Uncomment any of the following to validate SEH failfast
     //test(E_UNEXPECTED, wil::SupportedExceptions::None);
     //test(E_ACCESSDENIED, wil::SupportedExceptions::Thrown);
     //test(E_INVALIDARG, wil::SupportedExceptions::ThrownOrAlloc);
+}
+
+TEST_CASE("CppWinRTTests::CppWinRTConsistencyTest", "[cppwinrt]")
+{
+    // Since setting 'winrt_to_hresult_handler' opts us into _all_ C++/WinRT exception translation handling, we need to
+    // make sure that we preserve behavior, at least with 'check_hresult', especially when C++/WinRT maps a particular
+    // HRESULT value to a different exception type
+    auto test = [](HRESULT hr)
+    {
+        try
+        {
+            winrt::check_hresult(hr);
+        }
+        catch (...)
+        {
+            REQUIRE(hr == winrt::to_hresult());
+        }
+    };
+
+    for (auto hr : cppwinrt_mapped_hresults)
+    {
+        test(hr);
+    }
+
+    // A non-mapped HRESULT
+    test(E_UNEXPECTED);
 }

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -119,4 +119,26 @@ TEST_CASE("CppWinRTTests::CppWinRTConsistencyTest", "[cppwinrt]")
 
     // A non-mapped HRESULT
     test(E_UNEXPECTED);
+
+    // C++/WinRT also maps a few std::* exceptions to various HRESULTs. We should preserve this behavior
+    try
+    {
+        throw std::out_of_range("oopsie");
+    }
+    catch (...)
+    {
+        REQUIRE(winrt::to_hresult() == E_BOUNDS);
+    }
+
+    try
+    {
+        throw std::invalid_argument("daisy");
+    }
+    catch (...)
+    {
+        REQUIRE(winrt::to_hresult() == E_INVALIDARG);
+    }
+
+    // NOTE: C++/WinRT maps other 'std::exception' derived exceptions to E_FAIL, however we preserve the WIL behavior
+    // that such exceptions become HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION)
 }

--- a/tests/cpplatest/CMakeLists.txt
+++ b/tests/cpplatest/CMakeLists.txt
@@ -6,6 +6,11 @@ set(CMAKE_CXX_STANDARD 17)
 project(witest.cpplatest)
 add_executable(witest.cpplatest)
 
+# Semi-arbitrary insiders SDK version selected that uses C++/WinRT "2.0"
+if ("${WIL_WINDOWS_SDK_VERSION}" VERSION_GREATER_EQUAL "10.0.18878.0")
+    target_sources(witest.cpplatest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRT20Tests.cpp)
+endif()
+
 target_sources(witest.cpplatest PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRTTests.cpp


### PR DESCRIPTION
There's a few changes here:
* Updates WIL to use a global function pointer for `winrt::hresult_error` -> `HRESULT` translation for the WIL helpers (`ResultFromCaughtException`, etc.). This is done unconditionally and independently of the C++/WinRT version
* Updates WIL to set `winrt_to_hresult_handler` if the C++/WinRT version is >= 2.0. We still define `WINRT_EXTERNAL_CATCH_CLAUSE` since it's non-trivial to conditionalize that, but C++/WinRT should (soon) feel free to remove support for that macro.

I was also tempted to add support for `SupportedExceptions::Thrown` and `SupportedExceptions::ThrownOrAlloc` to match the behavior for `Platform::Exception`, but eventually decided not to since C++/WinRT seems to translate some errors to `std::*` exceptions. Currently this is only `std::bad_alloc` for `E_OUTOFMEMORY` - so in theory supporting `SupportedExceptions::ThrownOrAlloc` should be fine - but still opted to keep things as-is.

There's also a minor loss in functionality. `winrt::to_hresult` translates a few more `std::*` exceptions (e.g. `std::invalid_argument`); the difference is that now those will get mapped as `HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION)`. Shouldn't be hard to go in add support for these in WIL, if desired.

fixes #42 (well, technically only fixes it for newer SDK versions ;))