### PR TITLE
Add RPC context handle wrapper

### DIFF
--- a/include/wil/rpc_helpers.h
+++ b/include/wil/rpc_helpers.h
@@ -158,7 +158,7 @@ namespace wil
     // HRESULT OpenFoo([in] handle_t binding, [out] FOO_CONTEXT*);
     // HRESULT UseFoo([in] FOO_CONTEXT context;
     // void CloseFoo([in, out] PFOO_CONTEXT);
-    using unique_foo_context = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseFoo), CloseFoo>;
+    using unique_foo_context = wil::unique_rpc_context_handle<FOO_CONTEXT, decltype(&CloseFoo), CloseFoo>;
     unique_foo_context context;
     RETURN_IF_FAILED(wil::invoke_rpc_nothrow(OpenFoo, m_binding.get(), context.put()));
     RETURN_IF_FAILED(wil::invoke_rpc_nothrow(UseFoo, context.get()));
@@ -166,7 +166,7 @@ namespace wil
     ~~~
     */
     template<typename TContext, typename close_fn_t, close_fn_t close_fn>
-    using unique_context_handle = unique_any<TContext, decltype(&details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close), details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close>;
+    using unique_rpc_context_handle = unique_any<TContext, decltype(&details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close), details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close>;
 
 #ifdef WIL_ENABLE_EXCEPTIONS
     /** Invokes an RPC method, mapping structured exceptions to C++ exceptions

--- a/include/wil/rpc_helpers.h
+++ b/include/wil/rpc_helpers.h
@@ -48,7 +48,6 @@ namespace wil
         {
             return IS_ERROR(code) ? code : __HRESULT_FROM_WIN32(code);
         }
-
     }
     /// @endcond
 
@@ -131,6 +130,43 @@ namespace wil
         }
         RpcEndExcept
     }
+
+    namespace details
+    {
+        // Provides an adapter around calling the context-handle-close method on an
+        // RPC interface, which itself is an RPC call.
+        template<typename TStorage, typename close_fn_t, close_fn_t close_fn>
+        struct rpc_closer_t
+        {
+            static void Close(TStorage arg) WI_NOEXCEPT
+            {
+                LOG_IF_FAILED(invoke_rpc_nothrow(close_fn, &arg));
+            }
+        };
+    }
+
+    /** Manages explicit RPC context handles
+    Explicit RPC context handles are used in many RPC interfaces. Most interfaces with
+    context handles have an explicit `FooClose([in, out] CONTEXT*)` method that lets
+    the server close out the context handle. As the close method itself is an RPC call,
+    it can fail and raise a structured exception.
+
+    This type routes the context-handle-specific `Close` call through the `invoke_rpc_nothrow`
+    helper, ensuring correct cleanup and lifecycle management.
+    ~~~
+    // Assume the interface has two methods:
+    // HRESULT OpenFoo([in] handle_t binding, [out] FOO_CONTEXT*);
+    // HRESULT UseFoo([in] FOO_CONTEXT context;
+    // void CloseFoo([in, out] PFOO_CONTEXT);
+    using unique_foo_context = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseFoo), CloseFoo>;
+    unique_foo_context context;
+    RETURN_IF_FAILED(wil::invoke_rpc_nothrow(OpenFoo, m_binding.get(), context.put()));
+    RETURN_IF_FAILED(wil::invoke_rpc_nothrow(UseFoo, context.get()));
+    context.reset();
+    ~~~
+    */
+    template<typename TContext, typename close_fn_t, close_fn_t close_fn>
+    using unique_context_handle = unique_any<TContext, decltype(&details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close), details::rpc_closer_t<TContext, close_fn_t, close_fn>::Close>;
 
 #ifdef WIL_ENABLE_EXCEPTIONS
     /** Invokes an RPC method, mapping structured exceptions to C++ exceptions

--- a/tests/Rpc.cpp
+++ b/tests/Rpc.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Rpc::NonThrowing", "[rpc]")
 
     SECTION("Context Handles")
     {
-        using foo_context_t = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseContextHandle), CloseContextHandle>;
+        using foo_context_t = wil::unique_rpc_context_handle<FOO_CONTEXT, decltype(&CloseContextHandle), CloseContextHandle>;
         foo_context_t ctx;
         auto tempBinding = reinterpret_cast<handle_t>(-5);
         REQUIRE_SUCCEEDED(wil::invoke_rpc_nothrow(AcquireContextHandle, tempBinding, ctx.put()));
@@ -79,7 +79,7 @@ TEST_CASE("Rpc::NonThrowing", "[rpc]")
 
     SECTION("Context Handles Close Raised")
     {
-        using foo_context_t = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseContextHandleRaise), CloseContextHandleRaise>;
+        using foo_context_t = wil::unique_rpc_context_handle<FOO_CONTEXT, decltype(&CloseContextHandleRaise), CloseContextHandleRaise>;
         foo_context_t ctx{ reinterpret_cast<FOO_CONTEXT>(42) };
         ctx.reset();
     }

--- a/tests/Rpc.cpp
+++ b/tests/Rpc.cpp
@@ -10,6 +10,25 @@ void RpcMethodReturnsVoid(ULONG toRaise)
     }
 }
 
+struct FOO_CONTEXT_T {};
+typedef FOO_CONTEXT_T* FOO_CONTEXT;
+typedef FOO_CONTEXT* PFOO_CONTEXT;
+
+void CloseContextHandle(_Inout_ PFOO_CONTEXT)
+{
+}
+
+void CloseContextHandleRaise(_Inout_ PFOO_CONTEXT)
+{
+    return RpcMethodReturnsVoid(RPC_X_BAD_STUB_DATA);
+}
+
+HRESULT AcquireContextHandle(_In_ handle_t binding, _Out_ PFOO_CONTEXT context)
+{
+    *context = reinterpret_cast<FOO_CONTEXT>(binding);
+    return S_OK;
+}
+
 HRESULT RpcMethodReturnsHResult(HRESULT toReturn, ULONG toRaise)
 {
     RpcMethodReturnsVoid(toRaise);
@@ -26,11 +45,11 @@ TEST_CASE("Rpc::NonThrowing", "[rpc]")
 {
     SECTION("Success paths")
     {
-        REQUIRE(wil::invoke_rpc_nothrow(RpcMethodReturnsVoid, 0UL) == S_OK);
-        REQUIRE(wil::invoke_rpc_nothrow(RpcMethodReturnsHResult, S_OK, 0UL) == S_OK);
+        REQUIRE_SUCCEEDED(wil::invoke_rpc_nothrow(RpcMethodReturnsVoid, 0UL));
+        REQUIRE_SUCCEEDED(wil::invoke_rpc_nothrow(RpcMethodReturnsHResult, S_OK, 0UL));
 
         GUID tmp{};
-        REQUIRE(wil::invoke_rpc_result_nothrow(tmp, RpcMethodReturnsGuid, 0UL) == S_OK);
+        REQUIRE_SUCCEEDED(wil::invoke_rpc_result_nothrow(tmp, RpcMethodReturnsGuid, 0UL));
         REQUIRE(tmp == __uuidof(IUnknown));
     }
 
@@ -46,6 +65,23 @@ TEST_CASE("Rpc::NonThrowing", "[rpc]")
 
         GUID tmp{};
         REQUIRE(wil::invoke_rpc_result_nothrow(tmp, RpcMethodReturnsGuid, RPC_S_CALL_FAILED) == HRESULT_FROM_WIN32(RPC_S_CALL_FAILED));
+    }
+
+    SECTION("Context Handles")
+    {
+        using foo_context_t = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseContextHandle), CloseContextHandle>;
+        foo_context_t ctx;
+        auto tempBinding = reinterpret_cast<handle_t>(-5);
+        REQUIRE_SUCCEEDED(wil::invoke_rpc_nothrow(AcquireContextHandle, tempBinding, ctx.put()));
+        REQUIRE(ctx.get() == reinterpret_cast<FOO_CONTEXT>(tempBinding));
+        ctx.reset();
+    }
+
+    SECTION("Context Handles Close Raised")
+    {
+        using foo_context_t = wil::unique_context_handle<FOO_CONTEXT, decltype(&CloseContextHandleRaise), CloseContextHandleRaise>;
+        foo_context_t ctx{ reinterpret_cast<FOO_CONTEXT>(42) };
+        ctx.reset();
     }
 }
 


### PR DESCRIPTION
Here's an rpc-specific expansion of `wil::unique_any` that wraps a context handle and ensures the call to any `Close` method (which is itself an RPC call) is properly guarded against infrastructure failures.