### PR TITLE
Sync build fixes

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -62,7 +62,7 @@
 #endif
 
 #if defined(_MSVC_LANG)
-#define __WI_SUPPRESS_4127_S __pragma(warning(push)) __pragma(warning(disable:4127)) __pragma(warning(disable:26498))
+#define __WI_SUPPRESS_4127_S __pragma(warning(push)) __pragma(warning(disable:4127)) __pragma(warning(disable:26498)) __pragma(warning(disable:4245))
 #define __WI_SUPPRESS_4127_E __pragma(warning(pop))
 #define __WI_SUPPRESS_NULLPTR_ANALYSIS __pragma(warning(suppress:28285)) __pragma(warning(suppress:6504))
 #define __WI_SUPPRESS_NONINIT_ANALYSIS __pragma(warning(suppress:26495))

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -201,16 +201,19 @@ namespace wil
             winrt_to_hresult_handler = winrt_to_hresult;
         }
     }
-
+    
     /// @cond
     namespace details
     {
 #ifndef CPPWINRT_SUPPRESS_STATIC_INITIALIZERS
+        WI_ODR_PRAGMA("CPPWINRT_SUPPRESS_STATIC_INITIALIZERS", "0")
         WI_HEADER_INITITALIZATION_FUNCTION(WilInitialize_CppWinRT, []
         {
             ::wil::WilInitialize_CppWinRT();
             return 1;
         });
+#else
+        WI_ODR_PRAGMA("CPPWINRT_SUPPRESS_STATIC_INITIALIZERS", "1")
 #endif
     }
     /// @endcond

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -8,7 +8,6 @@
 //    PARTICULAR PURPOSE AND NONINFRINGEMENT.
 //
 //*********************************************************
-#include <stdint.h> // SIZE_MAX
 
 #include "result_macros.h"
 #include "wistd_functional.h"
@@ -20,6 +19,14 @@
 
 #ifndef __WIL_RESOURCE
 #define __WIL_RESOURCE
+
+// stdint.h and intsafe.h have conflicting definitions, so it's not safe to include either to pick up our dependencies,
+// so the definitions we need are copied below
+#ifdef _WIN64
+#define __WI_SIZE_MAX   0xffffffffffffffffui64 // UINT64_MAX
+#else /* _WIN64 */
+#define __WI_SIZE_MAX   0xffffffffui32 // UINT32_MAX
+#endif /* _WIN64 */
 
 // Forward declaration
 /// @cond
@@ -3808,7 +3815,7 @@ namespace wil
     {
         typedef typename wistd::remove_extent<T>::type E;
         static_assert(wistd::is_trivially_destructible<E>::value, "E has a destructor that won't be run when used with this function; use make_unique instead");
-        FAIL_FAST_IF((SIZE_MAX / sizeof(E)) < size);
+        FAIL_FAST_IF((__WI_SIZE_MAX / sizeof(E)) < size);
         size_t allocSize = sizeof(E) * size;
         unique_hlocal_ptr<T> sp(static_cast<E*>(::LocalAlloc(LMEM_FIXED, allocSize)));
         if (sp)
@@ -4899,7 +4906,7 @@ namespace wil
     {
         typedef typename wistd::remove_extent<T>::type E;
         static_assert(wistd::is_trivially_destructible<E>::value, "E has a destructor that won't be run when used with this function; use make_unique instead");
-        FAIL_FAST_IF((SIZE_MAX / sizeof(E)) < size);
+        FAIL_FAST_IF((__WI_SIZE_MAX / sizeof(E)) < size);
         size_t allocSize = sizeof(E) * size;
         unique_cotaskmem_ptr<T> sp(static_cast<E*>(::CoTaskMemAlloc(allocSize)));
         if (sp)


### PR DESCRIPTION
Corresponds to LKG commit a89288d4f659a6ef1736136d628bf47552f14a75

The fixes here:
* stdint.h conflicts with intsafe.h, so define the constants we need
* There are places in the OS source tree that use the `RETURN_*` macros with a non-`HRESULT` return type (e.g. `DWORD`). This _should_ always be a warning, but the compiler only seems to catch it when the value is a compile-time constant declared as `const` (e.g. `RETURN_HR(E_FAIL)`). This will suppress that warning