### PR TITLE
Make assignment of details::g_pfnGetContextAndNotifyFailure in wil::WilInitialize_Result for users who suppress static initializers

### DIFF
--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -1130,7 +1130,11 @@ namespace wil
 
         details::InitGlobalWithStorage(state, s_processLocalData, details_abi::g_pProcessLocalData, "WilError_03");
         details::InitGlobalWithStorage(state, s_threadFailureCallbacks, details::g_pThreadFailureCallbacks);
-        details::g_pfnGetContextAndNotifyFailure = details::GetContextAndNotifyFailure;
+
+        if (state == WilInitializeCommand::Create)
+        {
+            details::g_pfnGetContextAndNotifyFailure = details::GetContextAndNotifyFailure;
+        }
     }
 
     /// @cond

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -1130,6 +1130,7 @@ namespace wil
 
         details::InitGlobalWithStorage(state, s_processLocalData, details_abi::g_pProcessLocalData, "WilError_03");
         details::InitGlobalWithStorage(state, s_threadFailureCallbacks, details::g_pThreadFailureCallbacks);
+        details::g_pfnGetContextAndNotifyFailure = details::GetContextAndNotifyFailure;
     }
 
     /// @cond


### PR DESCRIPTION
Users who suppress static initializers will not have g_pfnGetContextAndNotifyFailure defined.
They are unable to use thread based callbacks and telemetry callbacks with error macros.

Users can workaround this by making the assignment of g_pfnGetContextAndNotifyFailure themselves.  This change removes the need for the workaround.

Verified by testing the change in my app where my team uses WIL.

#76 