### PR TITLE
Update tests to account for reduced dependencies of newer WinRT ABI headers

### DIFF
--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -7,6 +7,13 @@
 #include <string>
 #endif
 
+// Required for pinterface template specializations that we depend on in this test
+#include <Windows.ApplicationModel.Chat.h>
+#pragma push_macro("GetCurrentTime")
+#undef GetCurrentTime
+#include <Windows.UI.Xaml.Data.h>
+#pragma pop_macro("GetCurrentTime")
+
 #include "common.h"
 #include "FakeWinRTTypes.h"
 #include "test_objects.h"


### PR DESCRIPTION
The WinRT ABI headers were changed somewhat recently and a side effect of that change is reduced dependencies. The net result here is that some of the generic types are not specialized in the headers included by the tests. E.g. something like `IAsyncOperation<int>` is no longer present in `Windows.Foundation.h` because nothing in the `Windows::Foundation` namespace actually _uses_ that type. This is generally okay since such types should only ever be referenced in user code when interfacing with something that requires that type (i.e. something defined in a WinRT ABI header that uses that type and will therefore provide the necessary specialization). This does however, affect things such as our tests since we're testing helpers/implementations of these types and not necessarily any specific use.