### PR TITLE
Update root CMakeLists to include 'project()' to suppress CMake warning and remove '-Wno-invalid-noreturn' clang compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
+project(WIL)
 
 # Set by build server to speed up build/reduce file/object size
 option(FAST_BUILD "Sets options to speed up build/reduce obj/executable size" OFF)

--- a/cmake/common_build_flags.cmake
+++ b/cmake/common_build_flags.cmake
@@ -35,7 +35,6 @@ append_cxx_flag("/wd4324")
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     # Ignore a few Clang warnings. We may want to revisit in the future to see if any of these can/should be removed
     append_cxx_flag("-Wno-switch")
-    append_cxx_flag("-Wno-invalid-noreturn")
     append_cxx_flag("-Wno-c++17-compat-mangling")
     append_cxx_flag("-Wno-missing-field-initializers")
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -199,6 +199,9 @@ namespace witest
         // RaiseFailFastException cannot be continued or handled. By instead calling RaiseException, it allows us to
         // handle exceptions
         ::RaiseException(rec->ExceptionCode, rec->ExceptionFlags, rec->NumberParameters, rec->ExceptionInformation);
+#ifdef __clang__
+        __builtin_unreachable();
+#endif
     }
 
     constexpr DWORD msvc_exception_code = 0xE06D7363;


### PR DESCRIPTION
Recent versions of CMake are now issuing a warning when the top-level CMakeLists.txt has no `project()` command, so adding one to suppress the warning.

Also using this PR as a means to try and diagnose what's wrong with the CI build triggers, so if you see random commits with whitespace changes, that's why