### PR TITLE
Simplify tests to build faster

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -1,39 +1,41 @@
 # Windows Implementation Library Pipeline
 
-trigger:
-- master
+jobs:
+- job: Build and Test
+  timeoutInMinutes: 360
 
-pool:
-  vmImage: 'windows-2019'
+  trigger:
+  - master
 
-timeoutInMinutes: 360
+  pool:
+    vmImage: 'windows-2019'
 
-steps:
-- script: |
-    choco install llvm
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
-  displayName: 'Install Clang'
+  steps:
+  - script: |
+      choco install llvm
+      if %ERRORLEVEL% NEQ 0 goto :eof
+      echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
+    displayName: 'Install Clang'
 
-- script: |
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    
-    call scripts\init_all.cmd --fast
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    
-    call scripts\build_all.cmd
-  displayName: 'Build x86'
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+      if %ERRORLEVEL% NEQ 0 goto :eof
+      
+      call scripts\init_all.cmd --fast
+      if %ERRORLEVEL% NEQ 0 goto :eof
+      
+      call scripts\build_all.cmd
+    displayName: 'Build x86'
 
-- script: |
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    
-    call scripts\init_all.cmd --fast
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    
-    call scripts\build_all.cmd
-  displayName: 'Build x64'
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      if %ERRORLEVEL% NEQ 0 goto :eof
+      
+      call scripts\init_all.cmd --fast
+      if %ERRORLEVEL% NEQ 0 goto :eof
+      
+      call scripts\build_all.cmd
+    displayName: 'Build x64'
 
-- script: call scripts\runtests.cmd
-  displayName: 'Run Tests'
+  - script: call scripts\runtests.cmd
+    displayName: 'Run Tests'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
 - master
 
 jobs:
-- job: Build and Test
+- job: BuildAndTest
   timeoutInMinutes: 360
 
   pool:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -17,21 +17,17 @@ steps:
     call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
     if %ERRORLEVEL% NEQ 0 goto :eof
     
-    call scripts\init.cmd -c clang -g ninja -b debug --fast
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    call scripts\init.cmd -c msvc -g ninja -b debug --fast
+    call scripts\init_all.cmd --fast
     if %ERRORLEVEL% NEQ 0 goto :eof
     
     call scripts\build_all.cmd
   displayName: 'Build x86'
 
 - script: |
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsx86_amd64.bat"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
     if %ERRORLEVEL% NEQ 0 goto :eof
     
-    call scripts\init.cmd -c clang -g ninja -b debug --fast
-    if %ERRORLEVEL% NEQ 0 goto :eof
-    call scripts\init.cmd -c msvc -g ninja -b debug --fast
+    call scripts\init_all.cmd --fast
     if %ERRORLEVEL% NEQ 0 goto :eof
     
     call scripts\build_all.cmd

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -1,11 +1,11 @@
 # Windows Implementation Library Pipeline
 
+trigger:
+- master
+
 jobs:
 - job: Build and Test
   timeoutInMinutes: 360
-
-  trigger:
-  - master
 
   pool:
     vmImage: 'windows-2019'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -6,6 +6,8 @@ trigger:
 pool:
   vmImage: 'windows-2019'
 
+timeoutInMinutes: 360
+
 steps:
 - script: |
     choco install llvm

--- a/scripts/init.cmd
+++ b/scripts/init.cmd
@@ -9,8 +9,9 @@ goto :init
 
 :usage
     echo USAGE:
-    echo     init.cmd [--help] [-c^|--compiler ^<clang^|msvc^>] [-g^|--generator ^<ninja^|msbuild^>] [--fast]
-    echo         [-b^|--build-type ^<debug^|release^|relwithdebinfo^|minsizerel^>] [-v^|--version X.Y.Z]
+    echo     init.cmd [--help] [-c^|--compiler ^<clang^|msvc^>] [-g^|--generator ^<ninja^|msbuild^>]
+    echo         [-b^|--build-type ^<debug^|release^|relwithdebinfo^|minsizerel^>] [-l^|--linker link^|lld-link]
+    echo         [--fast] [-v^|--version X.Y.Z]
     echo.
     echo ARGUMENTS
     echo     -c^|--compiler       Controls the compiler used, either 'clang' (the default) or 'msvc'
@@ -29,6 +30,7 @@ goto :init
     set COMPILER=
     set GENERATOR=
     set BUILD_TYPE=
+    set LINKER=
     set CMAKE_ARGS=
     set BITNESS=
     set VERSION=
@@ -86,6 +88,21 @@ goto :init
         goto :parse
     )
 
+    set LINKER_SET=0
+    if /I "%~1"=="-l" set LINKER_SET=1
+    if /I "%~1"=="--linker" set LINKER_SET=1
+    if %LINKER_SET%==1 (
+        if "%LINKER%" NEQ "" echo ERROR: Linker already specified & call :usage & exit /B 1
+
+        if /I "%~2"=="link" set LINKER=link
+        if /I "%~2"=="lld-link" set LINKER=lld-link
+        if "!LINKER!"=="" echo ERROR: Unrecognized/missing linker %~2 & call :usage & exit /B 1
+
+        shift
+        shift
+        goto :parse
+    )
+
     set VERSION_SET=0
     if /I "%~1"=="-v" set VERSION_SET=1
     if /I "%~1"=="--version" set VERSION_SET=1
@@ -113,8 +130,11 @@ goto :init
 
 :execute
     :: Check for conflicting arguments
-    if "%COMPILER%"=="clang" (
-        if "%GENERATOR%"=="msbuild" echo ERROR: Cannot use Clang with MSBuild & exit /B 1
+    if "%GENERATOR%"=="msbuild" (
+        if "%COMPILER%"=="clang" echo ERROR: Cannot use Clang with MSBuild & exit /B 1
+
+        :: While CMake won't give an error, specifying the linker won't actually have any effect with the VS generator
+        if "%LINKER%"=="lld-link" echo ERROR: Cannot use lld-link with MSBuild & exit /B 1
     )
 
     :: Select defaults
@@ -124,6 +144,8 @@ goto :init
     if "%COMPILER%"=="" set COMPILER=clang
 
     if "%BUILD_TYPE%"=="" set BUILD_TYPE=debug
+
+    if "%LINKER%"=="" set LINKER=link
 
     :: Formulate CMake arguments
     if %GENERATOR%==ninja set CMAKE_ARGS=%CMAKE_ARGS% -G Ninja
@@ -143,6 +165,10 @@ goto :init
         :: '/permissive-' etc. and older versions of the SDK are typically not as clean as the most recent versions.
         :: This flag will force the generator to select the most recent SDK version independent of host OS version.
         set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_SYSTEM_VERSION=10.0
+    )
+
+    if %LINKER%==lld-link (
+        set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_LINKER=lld-link
     )
 
     if "%VERSION%" NEQ "" set CMAKE_ARGS=%CMAKE_ARGS% -DWIL_BUILD_VERSION=%VERSION%
@@ -165,6 +191,7 @@ goto :init
     :: Run CMake
     pushd %BUILD_DIR%
     echo Using compiler....... %COMPILER%
+    echo Using linker......... %LINKER%
     echo Using architecture... %Platform%
     echo Using build type..... %BUILD_TYPE%
     echo Using build root..... %CD%

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -944,25 +944,23 @@ static void TestSmartPointerConversion(const Ptr1& ptr1, const Ptr2& ptr2)
 template <typename IFace1, typename IFace2>
 static void TestPointerConversionCombination(IFace1* p1, IFace2* p2)
 {
+#ifdef WIL_ENABLE_EXCEPTIONS
+    TestSmartPointerConversion(wil::com_ptr<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
+#endif
+    TestSmartPointerConversion(wil::com_ptr_failfast<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
+    TestSmartPointerConversion(wil::com_ptr_nothrow<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
+
 #ifdef WIL_EXHAUSTIVE_TEST
 #ifdef WIL_ENABLE_EXCEPTIONS
     TestSmartPointerConversion(wil::com_ptr<IFace1>(p1), wil::com_ptr<IFace2>(p2));
-    TestSmartPointerConversion(wil::com_ptr<IFace1>(p1), wil::com_ptr_failfast<IFace2>(p2));
-    TestSmartPointerConversion(wil::com_ptr<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
-#endif
-
-#ifdef WIL_ENABLE_EXCEPTIONS
     TestSmartPointerConversion(wil::com_ptr_failfast<IFace1>(p1), wil::com_ptr<IFace2>(p2));
+    TestSmartPointerConversion(wil::com_ptr_nothrow<IFace1>(p1), wil::com_ptr<IFace2>(p2));
+
+    TestSmartPointerConversion(wil::com_ptr<IFace1>(p1), wil::com_ptr_failfast<IFace2>(p2));
 #endif
     TestSmartPointerConversion(wil::com_ptr_failfast<IFace1>(p1), wil::com_ptr_failfast<IFace2>(p2));
-    TestSmartPointerConversion(wil::com_ptr_failfast<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
-#endif // WIL_EXHAUSTIVE_TEST
-
-#ifdef WIL_ENABLE_EXCEPTIONS
-    TestSmartPointerConversion(wil::com_ptr_nothrow<IFace1>(p1), wil::com_ptr<IFace2>(p2));
-#endif
     TestSmartPointerConversion(wil::com_ptr_nothrow<IFace1>(p1), wil::com_ptr_failfast<IFace2>(p2));
-    TestSmartPointerConversion(wil::com_ptr_nothrow<IFace1>(p1), wil::com_ptr_nothrow<IFace2>(p2));
+#endif
 }
 
 template <typename IFace1, typename IFace2, typename Object>
@@ -991,16 +989,17 @@ TEST_CASE("ComTests::Test_PointerConversion", "[com][com_ptr]")
     TestPointerConversion<NoCom, NoCom, NoCom>();
 
     TestPointerConversion<ComObject, ComObject, ComObject>();
-    TestPointerConversion<IUnknown, IUnknown, ComObject>();
     TestPointerConversion<IUnknown, ITest, ComObject>();
     TestPointerConversion<IUnknown, IDerivedTest, ComObject>();
-    TestPointerConversion<IUnknown, IAlways, ComObject>();
-    TestPointerConversion<ITest, ITest, ComObject>();
     TestPointerConversion<ITest, IDerivedTest, ComObject>();
-    TestPointerConversion<IDerivedTest, IDerivedTest, ComObject>();
-    TestPointerConversion<IAlways, IAlways, ComObject>();
 
 #ifdef WIL_EXHAUSTIVE_TEST
+    TestPointerConversion<IUnknown, IUnknown, ComObject>();
+    TestPointerConversion<ITest, ITest, ComObject>();
+    TestPointerConversion<IDerivedTest, IDerivedTest, ComObject>();
+    TestPointerConversion<IAlways, IAlways, ComObject>();
+    TestPointerConversion<IUnknown, IAlways, ComObject>();
+
     TestPointerConversion<WinRtObject, WinRtObject, WinRtObject>();
     TestPointerConversion<IUnknown, IUnknown, WinRtObject>();
     TestPointerConversion<IUnknown, ITest, WinRtObject>();


### PR DESCRIPTION
Predominantly modifies tests to move more stuff under the `WIL_EXHAUSTIVE_TEST` condition. Most of the things moved are mostly redundant (e.g. no need to test calling `QueryInterface` more than once). Other changes were to avoid doing things that were unnecessary (e.g. no need to test `com_ptr_t::operator&` or `com_raw_ptr` for all specializations). There's still room for improvement, but this is a good start.

Also changes Azure pipelines file to include relwithdebinfo now that we should be able to build everything within the allotted time limit.

Also adds the option to the init script to use `lld-link` in place of `link.exe`, though speed impact isn't that huge since template instantiation/Catch2 accounts for the vast majority of build time.

fixes #9 