### PR TITLE
Make is_valid() on unique_any and shared_any public

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -185,12 +185,12 @@ namespace wil
                 other.m_ptr = policy::invalid_value();
             }
 
+        public:
             bool is_valid() const WI_NOEXCEPT
             {
                 return policy::is_valid(m_ptr);
             }
 
-        public:
             void reset(pointer_storage ptr = policy::invalid_value()) WI_NOEXCEPT
             {
                 if (policy::is_valid(m_ptr))
@@ -1911,12 +1911,12 @@ namespace wil {
                 m_ptr = wistd::move(other.m_ptr);
             }
 
+        public:
             bool is_valid() const WI_NOEXCEPT
             {
                 return (m_ptr && static_cast<bool>(*m_ptr));
             }
 
-        public:
             void reset(pointer_storage ptr = policy::invalid_value())
             {
                 if (policy::is_valid(ptr))


### PR DESCRIPTION
Currently, if you want to return a bool depending on the validity, a cast or functional style cast is needed (because the bool operator is explicit):
```cpp
class my_sink
{
    wil::unique_hfile m_Handle;

public:
    // ...

    bool opened() const noexcept { return bool(m_Handle); }
    // or
    bool opened() const noexcept { return static_cast<bool>(m_Handle); }
};
```

It doesn't makes sense, doesn't explains what it does, and doesn't shows up in autocomplete.

This PR makes the `is_valid()` member function of unique_storage and shared_storage public, so that the call to the function is more explicative of the code (plus it shows up in IntelliSense)
The code above can then be made better like this:
```cpp
class my_sink
{
    wil::unique_hfile m_Handle;

public:
    // ...
    bool opened() const noexcept { return m_Handle.is_valid(); }
};
```

