### PR TITLE
std::chrono wrappers for Windows times and timestamps

### DIFF
--- a/include/wil/chrono.h
+++ b/include/wil/chrono.h
@@ -1,0 +1,377 @@
+//*********************************************************
+//
+//    Copyright (c) Microsoft. All rights reserved.
+//    This code is licensed under the MIT License.
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+//    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+//    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//    PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//
+//*********************************************************
+#ifndef __WIL_CHRONO_INCLUDED
+#define __WIL_CHRONO_INCLUDED
+
+#include "common.h"
+#include "result.h"
+
+#ifdef WIL_KERNEL_MODE
+#error This header is not supported in kernel-mode.
+#endif
+
+#if __WI_CPLUSPLUS < 201103L
+#error This header requires C++11 or later
+#endif
+
+#include <chrono>
+
+#include <minwindef.h> // FILETIME, etc.
+#include <sysinfoapi.h> // GetTickCount[64], GetSystemTime[Precise]AsFileTime
+#include <realtimeapiset.h> // Query[Unbiased]InterruptTime[Precise]
+
+namespace wil
+{
+#pragma region std::chrono wrappers for GetTickCount[64]
+	namespace impl
+	{
+		template<class ResultT, ResultT(__stdcall *GetTickCount)(), class BaseClock>
+		struct tick_count_clock_impl
+		{
+			using rep = ResultT;
+			using period = std::milli;
+			using duration = std::chrono::duration<rep, period>;
+			using time_point = std::chrono::time_point<BaseClock, duration>;
+			static constexpr bool const is_steady = true;
+
+			WI_NODISCARD static time_point now() WI_NOEXCEPT
+			{
+				return time_point{duration{ GetTickCount() }};
+			}
+		};
+	}
+
+	struct tick_count_clock : impl::tick_count_clock_impl<DWORD, &::GetTickCount, tick_count_clock> {};
+#if _WIN32_WINNT >= 0x0600
+	struct tick_count64_clock : impl::tick_count_clock_impl<ULONGLONG, &::GetTickCount64, tick_count_clock> {};
+#endif // _WIN32_WINNT >= 0x0600
+#pragma endregion
+
+	namespace impl
+	{
+		constexpr DWORD64 filetime_to_int(const FILETIME& ft) WI_NOEXCEPT
+		{
+			return (static_cast<DWORD64>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+		}
+
+		constexpr FILETIME filetime_from_int(DWORD64 t) WI_NOEXCEPT
+		{
+			return {
+				static_cast<DWORD>(t >> 32),
+				static_cast<DWORD>(t)
+			};
+		}
+	}
+
+#pragma region std::chrono wrappers for GetSystemTime[Precise]AsFileTime
+	namespace impl
+	{
+		template<VOID(WINAPI *GetSystemTime)(_Out_ LPFILETIME), class BaseClock>
+		struct system_time_clock_impl
+		{
+		public:
+			using rep = LONGLONG;
+			using period = std::ratio_multiply<std::hecto, std::nano>;
+			using duration = std::chrono::duration<rep, period>;
+			using time_point = std::chrono::time_point<BaseClock, duration>;
+			static constexpr bool const is_steady = false;
+
+			WI_NODISCARD static time_point now() WI_NOEXCEPT
+			{
+				alignas(rep) FILETIME ft;
+				GetSystemTime(&ft);
+				return from_filetime(ft);
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 FILETIME to_filetime(const time_point& t) WI_NOEXCEPT
+			{
+				return filetime_from_int(static_cast<DWORD64>(t.time_since_epoch().count()));
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_filetime(const FILETIME& ft) WI_NOEXCEPT
+			{
+				return time_point{duration{ static_cast<rep>(filetime_to_int(ft)) }};
+			}
+
+#if __WI_LIBCPP_STD_VER > 11
+			static constexpr time_point unix_epoch{duration{116444736000000000LL}};
+#else
+			static time_point const unix_epoch;
+#endif
+
+		private:
+			template<class Duration>
+			static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 Duration to_unix_epoch(const time_point& t) WI_NOEXCEPT
+			{
+				return std::chrono::duration_cast<Duration>(t - unix_epoch);
+			}
+
+			template<class Duration>
+			static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_unix_epoch(const Duration& t) WI_NOEXCEPT
+			{
+				return std::chrono::time_point_cast<duration>(unix_epoch + t);
+			}
+
+			template<class Rep>
+			static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 Rep to_crt_time(const time_point& t) WI_NOEXCEPT
+			{
+				return to_unix_epoch<std::chrono::duration<Rep>>(t).count();
+			}
+
+			template<class Rep>
+			static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_crt_time(Rep t) WI_NOEXCEPT
+			{
+				return from_unix_epoch(std::chrono::duration<Rep>{t});
+			}
+
+		public:
+			template<class Duration = std::chrono::system_clock::duration>
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 std::chrono::time_point<std::chrono::system_clock, Duration> to_system_clock(const time_point& t) WI_NOEXCEPT
+			{
+				return std::chrono::time_point<std::chrono::system_clock, Duration>{to_unix_epoch<Duration>(t)};
+			}
+
+			template<class Duration>
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_system_clock(const std::chrono::time_point<std::chrono::system_clock, Duration>& t) WI_NOEXCEPT
+			{
+				return from_unix_epoch(t.time_since_epoch());
+			}
+
+#ifndef _CRT_NO_TIME_T
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 ::time_t to_time_t(const time_point& t) WI_NOEXCEPT
+			{
+				return to_crt_time<::time_t>(t);
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_time_t(::time_t t) WI_NOEXCEPT
+			{
+				return from_crt_time(t);
+			}
+#endif
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 ::__time32_t to_time32_t(const time_point& t) WI_NOEXCEPT
+			{
+				return to_crt_time<::__time32_t>(t);
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_time32_t(::__time32_t t) WI_NOEXCEPT
+			{
+				return from_crt_time(t);
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 ::__time64_t to_time64_t(const time_point& t) WI_NOEXCEPT
+			{
+				return to_crt_time<::__time64_t>(t);
+			}
+
+			WI_NODISCARD static __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 time_point from_time64_t(::__time64_t t) WI_NOEXCEPT
+			{
+				return from_crt_time(t);
+			}
+		};
+
+#if __WI_LIBCPP_STD_VER <= 11
+		template<VOID(WINAPI *GetSystemTime)(_Out_ LPFILETIME), class BaseClock>
+		typename system_time_clock_impl<GetSystemTime, BaseClock>::time_point const system_time_clock_impl<GetSystemTime, BaseClock>::unix_epoch{duration{116444736000000000LL}};
+#endif
+	}
+
+	struct system_time_clock : impl::system_time_clock_impl<&::GetSystemTimeAsFileTime, system_time_clock> {};
+
+#if _WIN32_WINNT >= _WIN32_WINNT_WIN8
+	struct precise_system_time_clock : impl::system_time_clock_impl<&::GetSystemTimePreciseAsFileTime, system_time_clock> {};
+	using high_precision_system_time_clock = precise_system_time_clock;
+#else // _WIN32_WINNT < _WIN32_WINNT_WIN8
+	using high_precision_system_time_clock = system_time_clock;
+#endif // _WIN32_WINNT < _WIN32_WINNT_WIN8
+#pragma endregion
+
+#pragma region std::chrono wrappers for Query[Unbiased]InterruptTime[Precise]
+	namespace impl
+	{
+		template<VOID(WINAPI *QueryInterruptTime)(_Out_ PULONGLONG), class BaseClock>
+		struct interrupt_time_clock_impl
+		{
+			using rep = LONGLONG;
+			using period = std::ratio_multiply<std::hecto, std::nano>;
+			using duration = std::chrono::duration<rep, period>;
+			using time_point = std::chrono::time_point<BaseClock, duration>;
+			static constexpr bool const is_steady = true;
+
+			WI_NODISCARD static time_point now() WI_NOEXCEPT
+			{
+				ULONGLONG t;
+				QueryInterruptTime(&t);
+				return time_point{duration{ static_cast<rep>(t) }};
+			}
+		};
+
+#if _WIN32_WINNT >= 0x0601
+		VOID WINAPI QueryUnbiasedInterruptTime(_Out_ PULONGLONG UnbiasedTime) WI_NOEXCEPT
+		{
+			::QueryUnbiasedInterruptTime(UnbiasedTime);
+		}
+#endif
+	}
+
+#if _WIN32_WINNT >= 0x0601
+	struct unbiased_interrupt_time_clock : impl::interrupt_time_clock_impl<&impl::QueryUnbiasedInterruptTime, unbiased_interrupt_time_clock> {};
+#if defined(NTDDI_WIN10)
+	struct interrupt_time_clock : impl::interrupt_time_clock_impl<&::QueryInterruptTime, interrupt_time_clock> {};
+	struct precise_interrupt_time_clock : impl::interrupt_time_clock_impl<&::QueryInterruptTimePrecise, interrupt_time_clock> {};
+	struct precise_unbiased_interrupt_time_clock : impl::interrupt_time_clock_impl<&::QueryUnbiasedInterruptTimePrecise, unbiased_interrupt_time_clock> {};
+#endif
+#endif
+#pragma endregion
+
+	using cpu_time_duration = std::chrono::duration<LONGLONG, std::ratio_multiply<std::hecto, std::nano>>;
+
+	enum class cpu_time
+	{
+		total,
+		kernel,
+		user,
+	};
+
+	struct execution_times
+	{
+		system_time_clock::time_point creation_time;
+		system_time_clock::time_point exit_time;
+		cpu_time_duration kernel_time;
+		cpu_time_duration user_time;
+	};
+
+	namespace impl
+	{
+		inline execution_times __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 execution_times_from_filetimes(FILETIME creation_time, FILETIME exit_time, FILETIME kernel_time, FILETIME user_time) WI_NOEXCEPT
+		{
+			return {
+				system_time_clock::from_filetime(creation_time),
+				system_time_clock::from_filetime(exit_time),
+				cpu_time_duration{ static_cast<cpu_time_duration::rep>(impl::filetime_to_int(kernel_time)) },
+				cpu_time_duration{ static_cast<cpu_time_duration::rep>(impl::filetime_to_int(user_time)) }
+			};
+		}
+
+		inline cpu_time_duration __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 get_cpu_time(const execution_times& times, cpu_time kind) WI_NOEXCEPT
+		{
+			switch (kind)
+			{
+				case cpu_time::total: return times.kernel_time + times.user_time;
+				case cpu_time::kernel: return times.kernel_time;
+				case cpu_time::user: return times.user_time;
+				DEFAULT_UNREACHABLE;
+			}
+		}
+	}
+
+	using thread_times = execution_times;
+
+	template<class ErrorPolicy>
+	WI_NODISCARD thread_times get_thread_times(HANDLE thread = ::GetCurrentThread())
+	{
+		FILETIME creation_time;
+		FILETIME exit_time;
+		FILETIME kernel_time;
+		FILETIME user_time;
+
+		ErrorPolicy::Win32BOOL(::GetThreadTimes(thread, &creation_time, &exit_time, &kernel_time, &user_time));
+
+		return impl::execution_times_from_filetimes(creation_time, exit_time, kernel_time, user_time);
+	}
+
+	WI_NODISCARD thread_times get_thread_times(HANDLE thread = ::GetCurrentThread())
+	{
+		return get_thread_times<err_exception_policy>(thread);
+	}
+
+	template<class ErrorPolicy>
+	WI_NODISCARD cpu_time_duration get_thread_cpu_time(HANDLE thread = ::GetCurrentThread(), cpu_time kind = cpu_time::total)
+	{
+		return impl::get_cpu_time(get_thread_times<ErrorPolicy>(thread), kind);
+	}
+
+	WI_NODISCARD cpu_time_duration get_thread_cpu_time(HANDLE thread = ::GetCurrentThread(), cpu_time kind = cpu_time::total)
+	{
+		return get_thread_cpu_time<err_exception_policy>(thread, kind);
+	}
+
+	using process_times = execution_times;
+
+	template<class ErrorPolicy>
+	WI_NODISCARD process_times get_process_times(HANDLE process = ::GetCurrentProcess())
+	{
+		FILETIME creation_time;
+		FILETIME exit_time;
+		FILETIME kernel_time;
+		FILETIME user_time;
+
+		ErrorPolicy::Win32BOOL(::GetProcessTimes(process, &creation_time, &exit_time, &kernel_time, &user_time));
+
+		return impl::execution_times_from_filetimes(creation_time, exit_time, kernel_time, user_time);
+	}
+
+	WI_NODISCARD process_times get_process_times(HANDLE process = ::GetCurrentProcess())
+	{
+		return get_process_times<err_exception_policy>(process);
+	}
+
+	template<class ErrorPolicy>
+	WI_NODISCARD cpu_time_duration get_process_cpu_time(HANDLE process = ::GetCurrentProcess(), cpu_time kind = cpu_time::total)
+	{
+		return impl::get_cpu_time(get_process_times<ErrorPolicy>(process), kind);
+	}
+
+	WI_NODISCARD cpu_time_duration get_process_cpu_time(HANDLE process = ::GetCurrentProcess(), cpu_time kind = cpu_time::total)
+	{
+		return get_process_cpu_time<err_exception_policy>(process, kind);
+	}
+
+	struct current_thread_cpu_time_clock
+	{
+		using rep = cpu_time_duration::rep;
+		using period = cpu_time_duration::period;
+		using duration = cpu_time_duration;
+		using time_point = std::chrono::time_point<current_thread_cpu_time_clock, duration>;
+
+		template<class ErrorPolicy>
+		WI_NODISCARD static time_point now()
+		{
+			return time_point{ get_thread_cpu_time<ErrorPolicy>() };
+		}
+
+		WI_NODISCARD static time_point now()
+		{
+			return time_point{ now<err_exception_policy>() };
+		}
+	};
+
+	struct current_process_cpu_time_clock
+	{
+		using rep = cpu_time_duration::rep;
+		using period = cpu_time_duration::period;
+		using duration = cpu_time_duration;
+		using time_point = std::chrono::time_point<current_process_cpu_time_clock, duration>;
+
+		template<class ErrorPolicy>
+		WI_NODISCARD static time_point now()
+		{
+			return time_point{ get_process_cpu_time<ErrorPolicy>() };
+		}
+
+		WI_NODISCARD static time_point now()
+		{
+			return time_point{ now<err_exception_policy>() };
+		}
+	};
+}
+
+#endif // __WIL_CHRONO_INCLUDED


### PR DESCRIPTION
New header `<wil/chrono.h>` defines `std::chrono` adapters for all fixed-frequency Windows timers and timestamps

## General considerations

User mode-only for now, because I don't know if `<chrono>` is kernel mode-safe. If we could get confirmation of the safety of `<chrono>` from the compiler people, we could add similar wrappers for functions like `KeQueryTickCount`, `KeQuerySystemTime`, etc. Alternatively, we could fork the LLVM `<chrono>` into a `wistd_chrono.h` header

Where possible, functions have been made `constexpr` through `__WI_LIBCPP_CONSTEXPR_AFTER_CXX11`, so that it depends on the underlying `constexpr`-ness of `<chrono>` functions

I haven't implemented DOS/FAT timestamps because, frankly, I think they aren't worth the effort

The following timers have a variable frequency and can't have zero-overhead `std::chrono` adapters, so they aren't included for now:

* `QueryPerformanceCounter`

* The auxiliary counter... if there was a function to query it (what *is* the deal with it?)

* The CPU timestamp register, as returned by intrinsics like `__rdtsc` or `__rdtscp`. This timer comes with additional considerations, such as:
  
  * Detecting availability: whether the architecture implements it, whether the sandbox/hypervisor/VM allows access to it, whether it has a stable frequency (e.g. constant or invariant TSC on Intel/AMD processors) etc.
  
  * Querying the frequency: hard (I tried! and I still don't have a good answer)
  
  * Instruction ordering: for example, `__rdtsc` is unordered, and needs a fence (`_mm_mfence` or `_mm_lfence`) for meaningful measurements, or alternatively `__rdtscp` can be used; but all solutions require an additional feature test... and even the feature test itself (`__cpuid`/`__cpuidex`) may, in turn, require a feature test

Processor cycle counters (e.g. `QueryThreadCycleTime`) are out of scope, since they aren't time-based at all

### Testing

I don't know how to write test cases, but I could learn. All clock classes support a form of compile-time dependency injection, so writing tests for corner cases shouldn't be hard

## Overview

### Tick counter clocks

The following *Clock*s are defined:

* `tick_count_clock` :
  
  * `rep`: `DWORD`
  
  * `period`: `std::milli` (1ms)
  
  * `is_steady`: `true`
  
  * `now`: wraps `GetTickCount`

* (`#if _WIN32_WINNT >= 0x0600`) `tick_count64_clock`:
  
  * `rep`: `ULONGLONG`
  
  * `period`, `is_steady`, `time_point`: same as `tick_count_clock`
  
  * `now`: wraps `GetTickCount64`

#### Caveats

Unlike standard C++ clocks, these clocks have an unsigned `rep`. This is intentional: the value returned by `GetTickCount` has a limited range, and we don't want to incur in undefined behavior dealing with signed under/overflow

### System time clocks

The following *Clock*s are defined:

* `system_time_clock`:
  
  * `rep`: `LONGLONG`
  
  * `period`: `std::ratio_multiply<std::hecto, std::nano>` (100ns)
  
  * `is_steady`: `false`
  
  * `now`: wraps `GetSystemTimeAsFileTime`
  
  * `to_filetime` and `from_filetime`: conversion between `time_point` and raw `FILETIME`s
  
  * `to_system_clock` and `from_system_clock`: conversion between `time_point` and `std::chrono::system_clock::time_point`
  
  * `to_time_t`, `from_time_t`, `to_time32_t`, `from_time32_t`, `to_time64_t`, `from_time64_t`: conversion between `time_point` (100ns, Windows epoch) and `std::time_t`/`__time32_t`/`__time64_t` (1s, UNIX epoch)

* (`#if _WIN32_WINNT >= _WIN32_WINNT_WIN8`) `precise_system_time_clock`:
  
  * `rep`, `period`, `time_point`, `is_steady`: same as `system_time_clock`
  
  * `to_filetime`, `from_filetime`, `to_system_clock`, `from_system_clock`, `to_time_t`, `from_time_t`, `to_time32_t`, `from_time32_t`, `to_time64_t`, `from_time64_t`: same as `system_time_clock`

  * `now`: wraps `GetSystemTimePreciseAsFileTime`

* `high_precision_system_time_clock`:
  
  * (`#if _WIN32_WINNT >= _WIN32_WINNT_WIN8`) alias for `precise_system_time_clock`
  
  * (`#else`) alias for `system_time_clock`

#### Caveats

`to_filetime` and `from_filetime` are implemented in-line, because including `win32_helpers.h` to use `wil::filetime` routines didn't seem worth it compared to the downsides:

* `win32_helpers.h` pulls in extra dependencies and pollutes the namespace

* `wil::filetime` routines aren't `constexpr` (nor `constexpr`-compatible)

In `to_system_clock` and `from_system_clock`, we non-portably assume `std::chrono::system_clock::time_point` starts from the UNIX epoch. However, this is true in all C++ runtime library implementations I know of *and* it will be a requirement starting from C++20

### Interrupt time clocks

When targeting Windows 7 or later (`#if _WIN32_WINNT >= 0x0601`), the following *Clock* is defined:

* `unbiased_interrupt_time_clock`:
  
  * `rep`: `LONGLONG`

  * `period`: `std::ratio_multiply<std::hecto, std::nano>` (100ns)
  
  * `is_steady`: `true`
  
  * `now`: wraps `QueryUnbiasedInterruptTime`

When targeting Windows 7 or later *and* using a Windows 10 or later SDK (`#ifdef NTDDI_WIN10`), the following *Clock*s are also defined:

* `interrupt_time_clock`:
  
  * `rep`: `LONGLONG`

  * `period`: `std::ratio_multiply<std::hecto, std::nano>` (100ns)
  
  * `is_steady`: `true`
  
  * `now`: wraps `QueryInterruptTime`

* `precise_interrupt_time_clock`:
  
  * `rep`, `period`, `time_point`, `is_steady`: same as `interrupt_time_clock`
  
  * `now`: wraps `QueryInterruptTimePrecise`

* `precise_unbiased_interrupt_time_clock`:
  
  * `rep`, `period`, `time_point`, `is_steady`: same as `unbiased_interrupt_time_clock`

  * `now`: wraps `QueryUnbiasedInterruptTimePrecise`

### Process and thread times

#### Types

The following types are defined:

* `cpu_time_duration`: `std::chrono::duration<LONGLONG, std::ratio_multiply<std::hecto, std::nano>>`

* `cpu_time`:
  
  ```cpp
  enum class cpu_time
  {
      total,
      kernel,
      user,
  };
  ```

* `execution_times`:
  
  ```cpp
  struct execution_times
  {
      system_time_clock::time_point creation_time;
      system_time_clock::time_point exit_time;
      cpu_time_duration kernel_time;
      cpu_time_duration user_time;
  };
  ```

* `thread_times` and `process_times`: aliases for `execution_times`

#### Functions

The following functions are defined:

* ```cpp
  template<class ErrorPolicy>
  thread_times get_thread_times(HANDLE thread = ::GetCurrentThread());
  
  thread_times get_thread_times(HANDLE thread = ::GetCurrentThread());
  ```
  
  Returns the `thread_times` for the thread identified by the `thread` handle. Defaults to the current thread.
  
  Wraps `GetThreadTimes`, handling errors according to `ErrorPolicy`. `ErrorPolicy` defaults to `err_exception_policy` when calling the non-template overload

* ```cpp
  template<class ErrorPolicy>
  cpu_time_duration get_thread_cpu_time(HANDLE thread = ::GetCurrentThread(), cpu_time kind = cpu_time::total);

  cpu_time_duration get_thread_cpu_time(HANDLE thread = ::GetCurrentThread(), cpu_time kind = cpu_time::total);
  ```
  
  Returns the CPU time usage specified by the `kind` argument for the thread identified by the `thread` handle. Defaults to the total (kernel + user) CPU time of the current thread.
  
  Wraps `GetThreadTimes`, handling errors according to `ErrorPolicy`. `ErrorPolicy` defaults to `err_exception_policy` when calling the non-template overload

* ```cpp
  template<class ErrorPolicy>
  process_times get_process_times(HANDLE process = ::GetCurrentProcess());

  process_times get_process_times(HANDLE process = ::GetCurrentProcess());
  ```
  
  Returns the `process_times` for the process identified by the `process` handle. Defaults to the current process.
  
  Wraps `GetProcessTimes`, handling errors according to `ErrorPolicy`. `ErrorPolicy` defaults to `err_exception_policy` when calling the non-template overload

* ```cpp
  template<class ErrorPolicy>
  cpu_time_duration get_process_cpu_time(HANDLE process = ::GetCurrentProcess(), cpu_time kind = cpu_time::total);

  cpu_time_duration get_process_cpu_time(HANDLE process = ::GetCurrentProcess(), cpu_time kind = cpu_time::total);
  ```
  
  Returns the CPU time usage specified by the `kind` argument for the process identified by the `process` handle. Defaults to the total (kernel + user) CPU time of the current process.
  
  Wraps `GetProcessTimes`, handling errors according to `ErrorPolicy`. `ErrorPolicy` defaults to `err_exception_policy` when calling the non-template overload

#### Clocks

The following *Clock*s are defined:

* `current_thread_cpu_time_clock`:
  
  * `rep`, `period`: same as `cpu_time_duration`
  
  * `duration`: `cpu_time_duration`
  
  * `now<ErrorPolicy>`: wraps `get_thread_cpu_time` with default arguments and the specified `ErrorPolicy`, returning the total CPU time used by the current thread
  
  * `now`: wraps `now`, passing `err_exception_policy` as its `ErrorPolicy`

* `current_process_cpu_time_clock`:
  
  * `rep`, `period`: same as `cpu_time_duration`

  * `duration`: `cpu_time_duration`
  
  * `now<ErrorPolicy>`: wraps `get_process_cpu_time` with default arguments and the specified `ErrorPolicy`, returning the total CPU time used by the current process
  
  * `now`: wraps `now`, passing `err_exception_policy` as its `ErrorPolicy`

#### Caveats

Only error policies that interrupt execution (e.g. `err_failfast_policy`, `err_exception_policy`) are meaningfully supported. Policies that return error codes will be effectively ignored, and errors will cause undefined values to be returned

CPU time clocks were only defined for the current process and current thread, so that they could be stateless classes. The *Clock* concept doesn't mandate statelessness, but it's unclear to me how statefulness conceptually interacts with `time_point`

CPU time clocks were only defined for total time, because I couldn't think of a good, unambiguous API for passing a `cpu_time` argument