### PR TITLE
Fix self-assignment in various types

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -303,7 +303,6 @@ namespace wil
         //! Move assign from a like `com_ptr_t` (releases current pointer, avoids AddRef/Release by moving the parameter).
         com_ptr_t& operator=(com_ptr_t&& other) WI_NOEXCEPT
         {
-            WI_ASSERT_MSG(this != wistd::addressof(other), "R-Values should be unique: self assignment is a bug");
             attach(other.detach());
             return *this;
         }

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -79,10 +79,8 @@ namespace wil
 
         last_error_context & operator=(last_error_context&& other) WI_NOEXCEPT
         {
-            m_dismissed = other.m_dismissed;
+            m_dismissed = wistd::exchange(other.m_dismissed, true);
             m_error = other.m_error;
-
-            other.m_dismissed = true;
 
             return *this;
         }
@@ -4449,8 +4447,7 @@ namespace wil
             {
                 m_value = wistd::move(source.m_value);
                 m_bufferHandle = wistd::move(source.m_bufferHandle);
-                m_charBuffer = source.m_charBuffer;
-                source.m_charBuffer = nullptr;
+                m_charBuffer = wistd::exchange(source.m_charBuffer, nullptr);
                 return *this;
             }
 

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -1390,17 +1390,23 @@ namespace wil
 
             shared_buffer& operator=(shared_buffer const &other) WI_NOEXCEPT
             {
-                assign(other.m_pCopy, other.m_size);
+                if (this != wistd::addressof(other))
+                {
+                    assign(other.m_pCopy, other.m_size);
+                }
                 return *this;
             }
 
             shared_buffer& operator=(shared_buffer &&other) WI_NOEXCEPT
             {
-                reset();
-                m_pCopy = other.m_pCopy;
-                m_size = other.m_size;
-                other.m_pCopy = nullptr;
-                other.m_size = 0;
+                if (this != wistd::addressof(other))
+                {
+                    reset();
+                    m_pCopy = other.m_pCopy;
+                    m_size = other.m_size;
+                    other.m_pCopy = nullptr;
+                    other.m_size = 0;
+                }
                 return *this;
             }
 
@@ -1532,20 +1538,26 @@ namespace wil
 
             shared_object& operator=(shared_object const &other) WI_NOEXCEPT
             {
-                reset();
-                m_pCopy = other.m_pCopy;
-                if (m_pCopy != nullptr)
+                if (this != wistd::addressof(other))
                 {
-                    ::InterlockedIncrementNoFence(&m_pCopy->m_refCount);
+                    reset();
+                    m_pCopy = other.m_pCopy;
+                    if (m_pCopy != nullptr)
+                    {
+                        ::InterlockedIncrementNoFence(&m_pCopy->m_refCount);
+                    }
                 }
                 return *this;
             }
 
             shared_object& operator=(shared_object &&other) WI_NOEXCEPT
             {
-                reset();
-                m_pCopy = other.m_pCopy;
-                other.m_pCopy = nullptr;
+                if (this != wistd::addressof(other))
+                {
+                    reset();
+                    m_pCopy = other.m_pCopy;
+                    other.m_pCopy = nullptr;
+                }
                 return *this;
             }
 

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -587,9 +587,12 @@ namespace wil
 
             vector_iterator& operator=(const vector_iterator& other)
             {
-                m_v = other.m_v;
-                m_i = other.m_i;
-                err_policy::HResult(other.m_element.CopyTo(m_element.ReleaseAndGetAddressOf()));
+                if (this != wistd::addressof(other))
+                {
+                    m_v = other.m_v;
+                    m_i = other.m_i;
+                    err_policy::HResult(other.m_element.CopyTo(m_element.ReleaseAndGetAddressOf()));
+                }
                 return *this;
             }
 

--- a/include/wil/wistd_type_traits.h
+++ b/include/wil/wistd_type_traits.h
@@ -1939,6 +1939,15 @@ namespace wistd     // ("Windows Implementation" std)
         return static_cast<_Tp&&>(__t);
     }
 
+    template <class _T1, class _T2 = _T1>
+    inline __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX17
+    _T1 exchange(_T1& __obj, _T2 && __new_value)
+    {
+        _T1 __old_value = wistd::move(__obj);
+        __obj = wistd::forward<_T2>(__new_value);
+        return __old_value;
+    }
+
 #else  // __WI_LIBCPP_HAS_NO_RVALUE_REFERENCES
 
     template <class _Tp>
@@ -1965,6 +1974,14 @@ namespace wistd     // ("Windows Implementation" std)
         return __t;
     }
 
+    template <class _T1, class _T2 = _T1>
+    inline __WI_LIBCPP_INLINE_VISIBILITY
+    _T1 exchange(_T1& __obj, const _T2& __new_value)
+    {
+        _T1 __old_value = __obj;
+        __obj = __new_value;
+        return __old_value;
+    }
 
     template <class _Tp>
     class __rv

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -172,6 +172,9 @@ TEST_CASE("ComTests::Test_Assign", "[com][com_ptr]")
         // as this should be a rare/never operation...
         // REQUIRE(IUnknownFake::GetRelease() == 0);
         // REQUIRE(IUnknownFake::GetAddRef() == 0);
+
+        ptr = std::move(ptr);
+        REQUIRE(ptr.get() == &helper);
     }
 
     IUnknownFake2 helper3;

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -15,6 +15,52 @@
 
 #include "common.h"
 
+TEST_CASE("ResourceTests::TestLastErrorContext", "[resource][last_error_context]")
+{
+    // Destructing the last_error_context restores the error.
+    {
+        SetLastError(42);
+        auto error42 = wil::last_error_context();
+        SetLastError(0);
+    }
+    REQUIRE(GetLastError() == 42);
+
+    // The context can be moved.
+    {
+        SetLastError(42);
+        auto error42 = wil::last_error_context();
+        SetLastError(0);
+        {
+            auto another_error42 = wil::last_error_context(std::move(error42));
+            SetLastError(1);
+        }
+        REQUIRE(GetLastError() == 42);
+        SetLastError(0);
+        // error42 has been moved-from and should not do anything at destruction.
+    }
+    REQUIRE(GetLastError() == 0);
+
+    // The context can be self-assigned, which has no effect.
+    {
+        SetLastError(42);
+        auto error42 = wil::last_error_context();
+        SetLastError(0);
+        error42 = std::move(error42);
+        SetLastError(1);
+    }
+    REQUIRE(GetLastError() == 42);
+
+    // The context can be dismissed, which cause it to do nothing at destruction.
+    {
+        SetLastError(42);
+        auto error42 = wil::last_error_context();
+        SetLastError(0);
+        error42.release();
+        SetLastError(1);
+    }
+    REQUIRE(GetLastError() == 1);
+}
+
 TEST_CASE("ResourceTests::TestScopeExit", "[resource][scope_exit]")
 {
     int count = 0;

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -806,6 +806,31 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     {
         REQUIRE(index++ == itr->Get().X);
     }
+
+    // Iterator self-assignment is a nop.
+    {
+        auto inspRange2 = wil::get_range(inspectables.Get());
+        auto itr = inspRange2.begin();
+        REQUIRE(itr != inspRange2.end()); // should have something in it
+        auto& ref = *itr;
+        auto val = ref;
+        itr = itr;
+        REQUIRE(val == ref);
+        itr = std::move(itr);
+        REQUIRE(val == ref);
+    }
+
+    {
+        auto strRange2 = wil::get_range(strings.Get());
+        auto itr = strRange2.begin();
+        REQUIRE(itr != strRange2.end()); // should have something in it
+        auto& ref = *itr;
+        auto val = ref.Get();
+        itr = itr;
+        REQUIRE(val == ref);
+        itr = std::move(itr);
+        REQUIRE(val == ref.Get());
+    }
 #endif
 }
 


### PR DESCRIPTION
Updated corresponding tests, or wrote missing ones. Added `wistd::exchange` from LLVM since it comes in handy when writing move assignment operators.

| Type                                   | Move self-assignment | Copy self-assignment |
|----------------------------------------|----------------------|----------------------|
| `com_ptr_t`                            | Fixed (Note 1)       |                      |
| `last_error_context`                   | Fixed                |                      |
| `details::string_maker<unique_string>` | Fixed                |                      |
| `details::shared_object`               | Fixed                | Fixed                |
| `vector_range::vector_iterator`        |                      | Fixed                |
| `iterable_range::iterable_iterator`    | (Note 2)             |                      |

Notes:

1. `wil::com_ptr_t` move assignment contained spurious assertion for self-assignment, which triggers on operations like `std::vector v; v.erase(v.begin(), v.begin());`. Code is correct as-is. Remove assertion.

2. `wil::iterable_range::iterable_iterator` move assignment accidentally destroys `m_element`, but that's okay because the next `operator*` will re-create it.