### PR TITLE
Use wistd::nullptr_t instead of global nullptr_t for default intsafe_conversion

### DIFF
--- a/include/wil/safecast.h
+++ b/include/wil/safecast.h
@@ -13,6 +13,7 @@
 
 #include "result_macros.h"
 #include <intsafe.h>
+#include "wistd_config.h"
 #include "wistd_type_traits.h"
 
 namespace wil
@@ -20,7 +21,7 @@ namespace wil
     namespace details
     {
         // Default error case for undefined conversions in intsafe.h
-        template<typename OldT, typename NewT> constexpr nullptr_t intsafe_conversion = nullptr;
+        template<typename OldT, typename NewT> constexpr wistd::nullptr_t intsafe_conversion = nullptr;
 
         // is_known_safe_static_cast_v determines if a conversion is known to be safe or not. Known
         // safe conversions can be handled by static_cast, this includes conversions between the same


### PR DESCRIPTION
I wasn't able to have a minimal repro for the issue the change fixed, but I updated the code to use the "correct" `nullptr_t`