### PR TITLE
Initialize `wil::com_ptr_t::m_ptr` before passing it to `IUnknown::QueryInterface` (`wil::try_com_query` and `wil::try_com_copy`)

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -870,13 +870,13 @@ namespace wil
         }
 
         template <class U>
-        inline com_ptr_t(_In_ U* ptr, details::tag_try_com_query) WI_NOEXCEPT
+        inline com_ptr_t(_In_ U* ptr, details::tag_try_com_query) WI_NOEXCEPT : m_ptr(nullptr)
         {
             details::query_policy_t<U>::query(ptr, &m_ptr);
         }
 
         template <class U>
-        inline com_ptr_t(_In_ U* ptr, details::tag_com_copy)
+        inline com_ptr_t(_In_opt_ U* ptr, details::tag_com_copy)
         {
             if (ptr)
             {
@@ -887,14 +887,12 @@ namespace wil
         }
 
         template <class U>
-        inline com_ptr_t(_In_ U* ptr, details::tag_try_com_copy) WI_NOEXCEPT
+        inline com_ptr_t(_In_opt_ U* ptr, details::tag_try_com_copy) WI_NOEXCEPT : m_ptr(nullptr)
         {
             if (ptr)
             {
                 details::query_policy_t<U>::query(ptr, &m_ptr);
-                return;
             }
-            m_ptr = nullptr;
         }
         /// @endcond
 


### PR DESCRIPTION
`wil::try_com_query` relies on a dedicated `wil::com_ptr_t` constructor that:
1. Eats any error codes returned by `IUnknown::QueryInterface`.
2. Passes an `address-of` to an **uninitialized** pointer (indeterminate value) to return an interface-supporting object through (`wil::com_ptr_t::m_ptr`).

For well-behaving implementations of `IUnknown::QueryInterface`, (2) should not be a problem as:
1. If the object supports an interface, the indeterminate value should be replaced by an address to the interface-supporting object.
2. If the object does **not** support an interface (or if a different failure has been encountered), the value of the pointer should be changed to `nullptr`.

However, if `IUnknown::QueryInterface` does not incorporate the second expectation, passing an `address-of` to an indeterminate pointer value _may_ mean getting the same indeterminate pointer value back (if the implementation of `QueryInterface` does not touch the value on failure).

While the above situation should be perceived as a (soft) failure, in the eyes of `wil::try_com_query` it is seen as a success (since what determines success is getting a non-`nullptr` object address and in this case it is indeterminate) -- leading to various failures of reading from/writing to random memory addresses.

----

This change makes `wil::try_com_query` and `wil::try_com_copy` more resilient to the described situation by initializing `wil::com_ptr_t::m_ptr` with `nullptr` before passing `m_ptr` to `IUnknown::QueryInterface` (as an `address-of` to the member field).

The change is made only to the two constructors of `wil::com_ptr_t` that build the `wil::try_com_*` helpers.

Other constructors are not affected by the change as they are supposed to fail fast or throw an exception if `IUnknown::QueryInterface` fails (and failures on construction should prevent making the indeterminate value of `m_ptr` usable).