### PR TITLE
Merge with OS source

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -397,9 +397,9 @@ namespace wil
 
         //! Returns the address of the internal pointer casted to IUnknown** (releases ownership of the pointer BEFORE returning the address).
         //! @see put
-        IUnknown** put_unknown() WI_NOEXCEPT
+        ::IUnknown** put_unknown() WI_NOEXCEPT
         {
-            return reinterpret_cast<IUnknown**>(put());
+            return reinterpret_cast<::IUnknown**>(put());
         }
 
         //! Returns the address of the internal pointer (releases ownership of the pointer BEFORE returning the address).
@@ -2264,8 +2264,8 @@ namespace wil
     @param value Set to point to the allocated result of reading a string from `source`
     */
     inline HRESULT stream_read_string_nothrow(
-        _In_ ISequentialStream* source, 
-        _When_(options == empty_string_options::returns_empty, _Outptr_result_z_) _When_(options == empty_string_options::returns_null, _Outptr_result_maybenull_z_) wchar_t** value, 
+        _In_ ISequentialStream* source,
+        _When_(options == empty_string_options::returns_empty, _Outptr_result_z_) _When_(options == empty_string_options::returns_null, _Outptr_result_maybenull_z_) wchar_t** value,
         empty_string_options options = empty_string_options::returns_empty)
     {
         unsigned short cch;

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -75,27 +75,7 @@
 #define __WI_SUPPRESS_NOEXCEPT_ANALYSIS
 #endif
 
-#if !defined(__cplusplus) || defined(__WIL_MIN_KERNEL)
-
-#define WI_ODR_PRAGMA(NAME, TOKEN)
-#define WI_NOEXCEPT
-
-#else
-#pragma warning(push)
-#pragma warning(disable:4714)    // __forceinline not honored
-
-// DO NOT add *any* further includes to this file -- there should be no dependencies from its usage
 #include <sal.h>
-#include "wistd_type_traits.h"
-
-//! This macro inserts ODR violation protection; the macro allows it to be compatible with straight "C" code
-#define WI_ODR_PRAGMA(NAME, TOKEN)  __pragma(detect_mismatch("ODR_violation_" NAME "_mismatch", TOKEN))
-
-#ifdef WIL_KERNEL_MODE
-WI_ODR_PRAGMA("WIL_KERNEL_MODE", "1")
-#else
-WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
-#endif
 
 // Some SAL remapping / decoration to better support Doxygen.  Macros that look like function calls can
 // confuse Doxygen when they are used to decorate a function or variable.  We simplify some of these to
@@ -106,73 +86,6 @@ WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
 #define __declspec_noinline_ __declspec(noinline)
 #define __declspec_selectany_ __declspec(selectany)
 /// @endcond
-
-#if defined(_CPPUNWIND) && !defined(WIL_SUPPRESS_EXCEPTIONS)
-/** This define is automatically set when exceptions are enabled within wil.
-It is automatically defined when your code is compiled with exceptions enabled (via checking for the built-in
-_CPPUNWIND flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil
-header.  All exception-based WIL methods and classes are included behind:
-~~~~
-#ifdef WIL_ENABLE_EXCEPTIONS
-// code
-#endif
-~~~~
-This enables exception-free code to directly include WIL headers without worrying about exception-based
-routines suddenly becoming available. */
-#define WIL_ENABLE_EXCEPTIONS
-#endif
-/// @endcond
-
-/// @cond
-#if defined(WIL_EXCEPTION_MODE)
-static_assert(WIL_EXCEPTION_MODE <= 2, "Invalid exception mode");
-#elif !defined(WIL_LOCK_EXCEPTION_MODE)
-#define WIL_EXCEPTION_MODE 0            // default, can link exception-based and non-exception based libraries together
-#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "0")
-#elif defined(WIL_ENABLE_EXCEPTIONS)
-#define WIL_EXCEPTION_MODE 1            // new code optimization:  ONLY support linking libraries together that have exceptions enabled
-#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "1")
-#else
-#define WIL_EXCEPTION_MODE 2            // old code optimization:  ONLY support linking libraries that are NOT using exceptions
-#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "2")
-#endif
-
-#if WIL_EXCEPTION_MODE == 1 && !defined(WIL_ENABLE_EXCEPTIONS)
-#error Must enable exceptions when WIL_EXCEPTION_MODE == 1
-#endif
-
-// block for documentation only
-#if defined(WIL_DOXYGEN)
-/** This define can be explicitly set to disable exception usage within wil.
-Normally this define is never needed as the WIL_ENABLE_EXCEPTIONS macro is enabled automatically by looking
-at _CPPUNWIND.  If your code compiles with exceptions enabled, but does not want to enable the exception-based
-classes and methods from WIL, define this macro ahead of including the first WIL header. */
-#define WIL_SUPPRESS_EXCEPTIONS
-
-/** This define can be explicitly set to lock the process exception mode to WIL_ENABLE_EXCEPTIONS.
-Locking the exception mode provides optimizations to exception barriers, staging hooks and DLL load costs as it eliminates the need to
-do copy-on-write initialization of various function pointers and the necessary indirection that's done within WIL to avoid ODR violations
-when linking libraries together with different exception handling semantics. */
-#define WIL_LOCK_EXCEPTION_MODE
-
-/** This define explicit sets the exception mode for the process to control optimizations.
-Three exception modes are available:
-0)  This is the default.  This enables a binary to link both exception-based and non-exception based libraries together that
-    use WIL.  This adds overhead to exception barriers, DLL copy on write pages and indirection through function pointers to avoid ODR
-    violations when linking libraries together with different exception handling semantics.
-1)  Prefer this setting when it can be used.  This locks the binary to only supporting libraries which were built with exceptions enabled.
-2)  This locks the binary to libraries built without exceptions. */
-#define WIL_EXCEPTION_MODE
-#endif
-
-#if (__cplusplus >= 201703) || (_MSVC_LANG >= 201703)
-#define WIL_HAS_CXX_17 1
-#else
-#define WIL_HAS_CXX_17 0
-#endif
-
-// Until we'll have C++17 enabled in our code base, we're falling back to SAL
-#define WI_NODISCARD __WI_LIBCPP_NODISCARD_ATTRIBUTE
 
 //! @defgroup macrobuilding Macro Composition
 //! The following macros are building blocks primarily intended for authoring other macros.
@@ -326,6 +239,94 @@ Three exception modes are available:
 #define WI_MACRO_DISPATCH(name, ...) WI_PASTE(WI_PASTE(name, WI_ARGS_COUNT(__VA_ARGS__)), (__VA_ARGS__))
 
 //! @} // Macro composition helpers
+
+#if !defined(__cplusplus) || defined(__WIL_MIN_KERNEL)
+
+#define WI_ODR_PRAGMA(NAME, TOKEN)
+#define WI_NOEXCEPT
+
+#else
+#pragma warning(push)
+#pragma warning(disable:4714)    // __forceinline not honored
+
+// DO NOT add *any* further includes to this file -- there should be no dependencies from its usage
+#include "wistd_type_traits.h"
+
+//! This macro inserts ODR violation protection; the macro allows it to be compatible with straight "C" code
+#define WI_ODR_PRAGMA(NAME, TOKEN)  __pragma(detect_mismatch("ODR_violation_" NAME "_mismatch", TOKEN))
+
+#ifdef WIL_KERNEL_MODE
+WI_ODR_PRAGMA("WIL_KERNEL_MODE", "1")
+#else
+WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
+#endif
+
+#if defined(_CPPUNWIND) && !defined(WIL_SUPPRESS_EXCEPTIONS)
+/** This define is automatically set when exceptions are enabled within wil.
+It is automatically defined when your code is compiled with exceptions enabled (via checking for the built-in
+_CPPUNWIND flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil
+header.  All exception-based WIL methods and classes are included behind:
+~~~~
+#ifdef WIL_ENABLE_EXCEPTIONS
+// code
+#endif
+~~~~
+This enables exception-free code to directly include WIL headers without worrying about exception-based
+routines suddenly becoming available. */
+#define WIL_ENABLE_EXCEPTIONS
+#endif
+/// @endcond
+
+/// @cond
+#if defined(WIL_EXCEPTION_MODE)
+static_assert(WIL_EXCEPTION_MODE <= 2, "Invalid exception mode");
+#elif !defined(WIL_LOCK_EXCEPTION_MODE)
+#define WIL_EXCEPTION_MODE 0            // default, can link exception-based and non-exception based libraries together
+#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "0")
+#elif defined(WIL_ENABLE_EXCEPTIONS)
+#define WIL_EXCEPTION_MODE 1            // new code optimization:  ONLY support linking libraries together that have exceptions enabled
+#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "1")
+#else
+#define WIL_EXCEPTION_MODE 2            // old code optimization:  ONLY support linking libraries that are NOT using exceptions
+#pragma detect_mismatch("ODR_violation_WIL_EXCEPTION_MODE_mismatch", "2")
+#endif
+
+#if WIL_EXCEPTION_MODE == 1 && !defined(WIL_ENABLE_EXCEPTIONS)
+#error Must enable exceptions when WIL_EXCEPTION_MODE == 1
+#endif
+
+// block for documentation only
+#if defined(WIL_DOXYGEN)
+/** This define can be explicitly set to disable exception usage within wil.
+Normally this define is never needed as the WIL_ENABLE_EXCEPTIONS macro is enabled automatically by looking
+at _CPPUNWIND.  If your code compiles with exceptions enabled, but does not want to enable the exception-based
+classes and methods from WIL, define this macro ahead of including the first WIL header. */
+#define WIL_SUPPRESS_EXCEPTIONS
+
+/** This define can be explicitly set to lock the process exception mode to WIL_ENABLE_EXCEPTIONS.
+Locking the exception mode provides optimizations to exception barriers, staging hooks and DLL load costs as it eliminates the need to
+do copy-on-write initialization of various function pointers and the necessary indirection that's done within WIL to avoid ODR violations
+when linking libraries together with different exception handling semantics. */
+#define WIL_LOCK_EXCEPTION_MODE
+
+/** This define explicit sets the exception mode for the process to control optimizations.
+Three exception modes are available:
+0)  This is the default.  This enables a binary to link both exception-based and non-exception based libraries together that
+    use WIL.  This adds overhead to exception barriers, DLL copy on write pages and indirection through function pointers to avoid ODR
+    violations when linking libraries together with different exception handling semantics.
+1)  Prefer this setting when it can be used.  This locks the binary to only supporting libraries which were built with exceptions enabled.
+2)  This locks the binary to libraries built without exceptions. */
+#define WIL_EXCEPTION_MODE
+#endif
+
+#if (__cplusplus >= 201703) || (_MSVC_LANG >= 201703)
+#define WIL_HAS_CXX_17 1
+#else
+#define WIL_HAS_CXX_17 0
+#endif
+
+// Until we'll have C++17 enabled in our code base, we're falling back to SAL
+#define WI_NODISCARD __WI_LIBCPP_NODISCARD_ATTRIBUTE
 
 #define __R_ENABLE_IF_IS_CLASS(ptrType)                     wistd::enable_if_t<wistd::is_class<ptrType>::value, void*> = (void*)0
 #define __R_ENABLE_IF_IS_NOT_CLASS(ptrType)                 wistd::enable_if_t<!wistd::is_class<ptrType>::value, void*> = (void*)0

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -62,7 +62,7 @@
 #endif
 
 #if defined(_MSVC_LANG)
-#define __WI_SUPPRESS_4127_S __pragma(warning(push)) __pragma(warning(disable:4127)) __pragma(warning(disable:26498))
+#define __WI_SUPPRESS_4127_S __pragma(warning(push)) __pragma(warning(disable:4127)) __pragma(warning(disable:26498)) __pragma(warning(disable:4245))
 #define __WI_SUPPRESS_4127_E __pragma(warning(pop))
 #define __WI_SUPPRESS_NULLPTR_ANALYSIS __pragma(warning(suppress:28285)) __pragma(warning(suppress:6504))
 #define __WI_SUPPRESS_NONINIT_ANALYSIS __pragma(warning(suppress:26495))

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -108,7 +108,7 @@ namespace wil::details
             catch (const winrt::hresult_error& exception)
             {
                 MaybeGetExceptionString(exception, debugString, debugStringChars);
-                return exception.code().value;
+                return exception.to_abi();
             }
             catch (const std::bad_alloc& exception)
             {
@@ -149,7 +149,7 @@ namespace wil::details
             catch (const winrt::hresult_error& exception)
             {
                 MaybeGetExceptionString(exception, debugString, debugStringChars);
-                return exception.code().value;
+                return exception.to_abi();
             }
             catch (const std::bad_alloc& exception)
             {
@@ -201,7 +201,7 @@ namespace wil
             winrt_to_hresult_handler = winrt_to_hresult;
         }
     }
-    
+
     /// @cond
     namespace details
     {

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -201,16 +201,19 @@ namespace wil
             winrt_to_hresult_handler = winrt_to_hresult;
         }
     }
-
+    
     /// @cond
     namespace details
     {
 #ifndef CPPWINRT_SUPPRESS_STATIC_INITIALIZERS
+        WI_ODR_PRAGMA("CPPWINRT_SUPPRESS_STATIC_INITIALIZERS", "0")
         WI_HEADER_INITITALIZATION_FUNCTION(WilInitialize_CppWinRT, []
         {
             ::wil::WilInitialize_CppWinRT();
             return 1;
         });
+#else
+        WI_ODR_PRAGMA("CPPWINRT_SUPPRESS_STATIC_INITIALIZERS", "1")
 #endif
     }
     /// @endcond

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -8,7 +8,6 @@
 //    PARTICULAR PURPOSE AND NONINFRINGEMENT.
 //
 //*********************************************************
-#include <stdint.h> // SIZE_MAX
 
 #include "result_macros.h"
 #include "wistd_functional.h"
@@ -20,6 +19,14 @@
 
 #ifndef __WIL_RESOURCE
 #define __WIL_RESOURCE
+
+// stdint.h and intsafe.h have conflicting definitions, so it's not safe to include either to pick up our dependencies,
+// so the definitions we need are copied below
+#ifdef _WIN64
+#define __WI_SIZE_MAX   0xffffffffffffffffui64 // UINT64_MAX
+#else /* _WIN64 */
+#define __WI_SIZE_MAX   0xffffffffui32 // UINT32_MAX
+#endif /* _WIN64 */
 
 // Forward declaration
 /// @cond
@@ -3808,7 +3815,7 @@ namespace wil
     {
         typedef typename wistd::remove_extent<T>::type E;
         static_assert(wistd::is_trivially_destructible<E>::value, "E has a destructor that won't be run when used with this function; use make_unique instead");
-        FAIL_FAST_IF((SIZE_MAX / sizeof(E)) < size);
+        FAIL_FAST_IF((__WI_SIZE_MAX / sizeof(E)) < size);
         size_t allocSize = sizeof(E) * size;
         unique_hlocal_ptr<T> sp(static_cast<E*>(::LocalAlloc(LMEM_FIXED, allocSize)));
         if (sp)
@@ -4899,7 +4906,7 @@ namespace wil
     {
         typedef typename wistd::remove_extent<T>::type E;
         static_assert(wistd::is_trivially_destructible<E>::value, "E has a destructor that won't be run when used with this function; use make_unique instead");
-        FAIL_FAST_IF((SIZE_MAX / sizeof(E)) < size);
+        FAIL_FAST_IF((__WI_SIZE_MAX / sizeof(E)) < size);
         size_t allocSize = sizeof(E) * size;
         unique_cotaskmem_ptr<T> sp(static_cast<E*>(::CoTaskMemAlloc(allocSize)));
         if (sp)

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -5283,10 +5283,6 @@ namespace wil
             }
         }
 
-        explicit unique_hglobal_locked(unique_hglobal& global) : unique_hglobal_locked(global.get())
-        {
-        }
-
         explicit unique_hglobal_locked(STGMEDIUM& medium) : unique_hglobal_locked(medium.hGlobal)
         {
         }

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -318,7 +318,7 @@ namespace wil
 
                 const DWORD size = static_cast<DWORD>(sizeof(ProcessLocalStorageData<T>));
 
-                unique_process_heap_ptr<ProcessLocalStorageData<T>> dataAlloc(static_cast<ProcessLocalStorageData<T>*>(::HeapAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, size)));
+                unique_process_heap_ptr<ProcessLocalStorageData<T>> dataAlloc(static_cast<ProcessLocalStorageData<T>*>(details::ProcessHeapAlloc(HEAP_ZERO_MEMORY, size)));
                 __WIL_PRIVATE_RETURN_IF_NULL_ALLOC(dataAlloc);
 
                 SemaphoreValue semaphoreValue;
@@ -406,7 +406,7 @@ namespace wil
 
                 if (shouldAllocate)
                 {
-                    Node *pNew = reinterpret_cast<Node *>(::HeapAlloc(::GetProcessHeap(), 0, sizeof(Node)));
+                    Node *pNew = reinterpret_cast<Node *>(details::ProcessHeapAlloc(0, sizeof(Node)));
                     if (pNew != nullptr)
                     {
                         new(pNew)Node{ threadId };
@@ -487,7 +487,7 @@ namespace wil
 
                 if (!stringBuffer || (stringBufferSize < neededSize))
                 {
-                    auto newBuffer = ::HeapAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, neededSize);
+                    auto newBuffer = details::ProcessHeapAlloc(HEAP_ZERO_MEMORY, neededSize);
                     if (newBuffer)
                     {
                         ::HeapFree(::GetProcessHeap(), 0, stringBuffer);
@@ -565,7 +565,7 @@ namespace wil
                 if (!errors && create)
                 {
                     const unsigned short errorCount = 5;
-                    errors = reinterpret_cast<ThreadLocalFailureInfo *>(::HeapAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, errorCount * sizeof(ThreadLocalFailureInfo)));
+                    errors = reinterpret_cast<ThreadLocalFailureInfo *>(details::ProcessHeapAlloc(HEAP_ZERO_MEMORY, errorCount * sizeof(ThreadLocalFailureInfo)));
                     if (errors)
                     {
                         errorAllocCount = errorCount;

--- a/include/wil/result_originate.h
+++ b/include/wil/result_originate.h
@@ -82,6 +82,36 @@ namespace wil
                 }
             }
         }
+
+        // This method will check for the presence of stowed exception data on the current thread.  If such data exists, and the HRESULT
+        // matches the current failure, then we will call RoFailFastWithErrorContext.  RoFailFastWithErrorContext in this situation will
+        // result in -VASTLY- improved crash bucketing.  It is hard to express just how much better.  In other cases we just return and
+        // the calling method fails fast the same way it always has.
+        inline void __stdcall FailfastWithContextCallback(wil::FailureInfo const& failure) WI_NOEXCEPT
+        {
+            wil::com_ptr_nothrow<IRestrictedErrorInfo> restrictedErrorInformation;
+            if (GetRestrictedErrorInfo(&restrictedErrorInformation) == S_OK)
+            {
+                wil::unique_bstr descriptionUnused;
+                HRESULT existingHr = failure.hr;
+                wil::unique_bstr restrictedDescriptionUnused;
+                wil::unique_bstr capabilitySidUnused;
+                if (SUCCEEDED(restrictedErrorInformation->GetErrorDetails(&descriptionUnused, &existingHr, &restrictedDescriptionUnused, &capabilitySidUnused)) &&
+                    (existingHr == failure.hr))
+                {
+                    // GetRestrictedErrorInfo returns ownership of the error information.  We want it to be available for RoFailFastWithErrorContext
+                    // so we must restore it via SetRestrictedErrorInfo first.
+                    SetRestrictedErrorInfo(restrictedErrorInformation.get());
+                    RoFailFastWithErrorContext(existingHr);
+                }
+                else
+                {
+                    // The error didn't match the current failure.  Put it back in thread-local storage even though we aren't failing fast
+                    // in this method, so it is available in the debugger just-in-case.
+                    SetRestrictedErrorInfo(restrictedErrorInformation.get());
+                }
+            }
+        }
     } // namespace details
 } // namespace wil
 
@@ -89,6 +119,7 @@ namespace wil
 WI_HEADER_INITITALIZATION_FUNCTION(ResultStowedExceptionInitialize, []
 {
     ::wil::SetOriginateErrorCallback(::wil::details::RaiseRoOriginateOnWilExceptions);
+    ::wil::SetFailfastWithContextCallback(::wil::details::FailfastWithContextCallback);
     return 1;
 });
 #endif // __cplusplus_winrt

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -15,19 +15,9 @@
 #include "resource.h"
 #include <memory>
 #include <string>
+#include <vector>
 
 #if defined(WIL_ENABLE_EXCEPTIONS)
-namespace std
-{
-    template<class _Ty, class _Alloc>
-    class vector;
-
-    template<class _Elem>
-    struct char_traits;
-
-    template<class _Elem, class _Traits, class _Alloc>
-    class basic_string;
-} // namespace std
 
 namespace wil
 {

--- a/include/wil/wistd_functional.h
+++ b/include/wil/wistd_functional.h
@@ -46,6 +46,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 4324)
+#pragma warning(disable: 4800)
 
 /// @cond
 namespace wistd     // ("Windows Implementation" std)

--- a/tests/common.h
+++ b/tests/common.h
@@ -204,6 +204,15 @@ namespace witest
 #endif
     }
 
+    [[noreturn]]
+    inline void __stdcall FakeFailfastWithContext(const wil::FailureInfo&) noexcept
+    {
+        ::RaiseException(STATUS_STACK_BUFFER_OVERRUN, 0, 0, nullptr);
+#ifdef __clang__
+        __builtin_unreachable();
+#endif
+    }
+
     constexpr DWORD msvc_exception_code = 0xE06D7363;
 
     // This is a MAJOR hack. Catch2 registers a vectored exception handler - which gets run before our handler below -
@@ -241,6 +250,7 @@ namespace witest
     {
         // See above; we don't want to actually fail fast, so make sure we raise a different exception instead
         auto restoreHandler = AssignTemporaryValue(&wil::details::g_pfnRaiseFailFastException, TranslateFailFastException);
+        auto restoreHandler2 = AssignTemporaryValue(&wil::details::g_pfnFailfastWithContextCallback, FakeFailfastWithContext);
 
         auto handler = AddVectoredExceptionHandler(1, TranslateExceptionCodeHandler);
         auto removeVectoredHandler = wil::scope_exit([&] { RemoveVectoredExceptionHandler(handler); });


### PR DESCRIPTION
The most notable change is the removal of the `unique_hglobal&` constructor in `unique_hglobal_locked` (needed for a build break; the definition guards don't match up for the two - it's easy enough to work around by just calling `.get()`)

Fixes #91 