### PR TITLE
Enable access to the last error value in last_error_context

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -73,9 +73,9 @@ namespace wil
         }
 
         auto value() const
-		{
-			return m_error;
-		}
+        {
+            return m_error;
+        }
         
         last_error_context(last_error_context&& other) WI_NOEXCEPT
         {

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -72,6 +72,11 @@ namespace wil
         {
         }
 
+        DWORD get_last_error()
+		{
+			return m_error;
+		}
+        
         last_error_context(last_error_context&& other) WI_NOEXCEPT
         {
             operator=(wistd::move(other));

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -72,7 +72,7 @@ namespace wil
         {
         }
 
-        DWORD get_last_error()
+        auto value() const
 		{
 			return m_error;
 		}

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -59,6 +59,14 @@ TEST_CASE("ResourceTests::TestLastErrorContext", "[resource][last_error_context]
         SetLastError(1);
     }
     REQUIRE(GetLastError() == 1);
+
+    // The value in the context is unimpacted by other things changing the last error
+    {
+        SetLastError(42);
+        auto error42 = wil::last_error_context();
+        SetLastError(1);
+        REQUIRE(error42.value() == 42);
+    }
 }
 
 TEST_CASE("ResourceTests::TestScopeExit", "[resource][scope_exit]")


### PR DESCRIPTION
Add an option to get the last error kept in object. (In order to be displayed by log messages.)