### PR TITLE
Replace old C headers with the C++ ones

### DIFF
--- a/include/wil/wistd_config.h
+++ b/include/wil/wistd_config.h
@@ -39,7 +39,7 @@
 #define _WISTD_CONFIG_H_
 
 // DO NOT add *any* additional includes to this file -- there should be no dependencies from its usage
-#include <stddef.h> // For size_t and other necessary types
+#include <cstddef> // For size_t and other necessary types
 
 /// @cond
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -1,5 +1,5 @@
 
-#include <time.h> // TODO: https://github.com/microsoft/wil/issues/44
+#include <ctime> // TODO: https://github.com/microsoft/wil/issues/44
 #include <wil/winrt.h>
 
 #ifdef WIL_ENABLE_EXCEPTIONS


### PR DESCRIPTION
This PR changes the deprecated .h headers and replaces them with the equivalent c++ library

How changes were validated:
- Followed the instructions of the ISO draft 2005
- Unit testing