### PR TITLE
Update ifdefs to skip features unsupported by Vista

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -31,6 +31,7 @@ namespace wil
         return wcsncmp(path, L"\\\\?\\", 4) == 0;
     }
 
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
     //! Find the last segment of a path. Matches the behavior of shlwapi!PathFindFileNameW()
     //! note, does not support streams being specified like PathFindFileNameW(), is that a bug or a feature?
     inline PCWSTR find_last_path_segment(_In_ PCWSTR path)
@@ -51,6 +52,7 @@ namespace wil
         }
         return result;
     }
+#endif
 
     //! Determine if the file name is one of the special "." or ".." names.
     inline bool path_is_dot_or_dotdot(_In_ PCWSTR fileName)
@@ -83,7 +85,7 @@ namespace wil
         return false;
     }
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 
     // PathCch.h APIs are only in desktop API for now.
 
@@ -957,7 +959,7 @@ namespace wil
         return result;
     }
 #endif // _CPPUNWIND
-#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 }
 
 #endif // __WIL_FILESYSTEM_INCLUDED

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2676,7 +2676,7 @@ namespace wil
     typedef unique_any_t<event_t<details::unique_storage<details::handle_resource_policy>, err_exception_policy>>      unique_event;
 #endif
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
     enum class SlimEventType
     {
         AutoReset,
@@ -2843,7 +2843,7 @@ namespace wil
     /** An alias for `wil::slim_event_auto_reset`. */
     using slim_event = slim_event_auto_reset;
 
-#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 
     typedef unique_any<HANDLE, decltype(&details::ReleaseMutex), details::ReleaseMutex, details::pointer_access_none> mutex_release_scope_exit;
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -345,7 +345,7 @@ namespace witest
         return S_OK;
     }
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 
     struct TestFolder
     {

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -3267,7 +3267,7 @@ TEST_CASE("WindowsInternalTests::ThreadPoolTimerTest", "[resource][unique_thread
     ThreadPoolTimerWorkHelper<wil::unique_threadpool_timer_nocancel, FILETIME>(SetThreadpoolTimer, true);
 }
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 static void __stdcall SlimEventTrollCallback(
     _Inout_ PTP_CALLBACK_INSTANCE /*instance*/,
     _Inout_opt_ void* context,
@@ -3339,7 +3339,7 @@ TEST_CASE("WindowsInternalTests::SlimEventTests", "[resource][slim_event]")
     }
 
 }
-#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
 
 struct ConditionVariableCSCallbackContext
 {


### PR DESCRIPTION
Please check #134 for the rationale behind this PR.

Even though targetting anything older than Windows 7 is technically unsupported by Visual Studio nowadays, WIL itself claims to require the target version to be Vista or newer. This turned out to be untrue in the following cases:

1. `QueryUnbiasedInterruptTime` used in `slim_event_t` in `resource.h` - it was introduced in Windows 7, which makes slim events technically unsupported in Vista.
2. `FindStringOrdinal` in `filesystem.h` - `find_last_path_segment` seems to rely on it, and since it's a heavily used internal function in the entire WIL filesystem functionality, I figured it's best to make it unsupported on Vista. The alternative was to use `StrRChrIW` from `Shlwapi.h`, but that creates a dependency on `Shlwapi.lib` and it would most certainly not be welcome.

As of now, this PR **does** fix existing tests for Vista but **does not** add a new Vista test. I have those prepared locally, so in case they are needed (they should be, really - but I have noticed some concerns regarding inflated compilation times should tests get too extensive) I will commit them as well - my Vista tests are a copypaste of Windows 7 tests, but with `FileSystemTests` and `WatcherTests` removed, due to unsupported filesystem functionality.

Fixes #134 