### PR TITLE
cmake : Add install target to support consuming WIL through cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.11)
 project(WIL)
 
+include(GNUInstallDirs)
+
 # Set by build server to speed up build/reduce file/object size
 option(FAST_BUILD "Sets options to speed up build/reduce obj/executable size" OFF)
-option(WIL_BUILD_PACKAGING "Sets options build the packaging, default on" On)
-option(WIL_BUILD_TESTS "Sets options build the unit tests, default on" On)
+option(WIL_BUILD_PACKAGING "Sets option to build the packaging, default on" On)
+option(WIL_BUILD_TESTS "Sets option to build the unit tests, default on" On)
 
 if (NOT DEFINED WIL_BUILD_VERSION)
     set(WIL_BUILD_VERSION "0.0.0")
@@ -20,11 +22,11 @@ else()
 endif()
 
 if (${WIL_BUILD_PACKAGING})
-	add_subdirectory(packaging)
+    add_subdirectory(packaging)
 endif()
 
 if (${WIL_BUILD_TESTS})
-	add_subdirectory(tests)
+    add_subdirectory(tests)
 endif()
 
 # Gather headers into an interface library.
@@ -33,16 +35,16 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 # The interface's include directory.
 target_include_directories(${PROJECT_NAME} INTERFACE
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 # Install Package Configuration
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_targets)
 install(EXPORT ${PROJECT_NAME}_targets
-	NAMESPACE ${PROJECT_NAME}::
-	FILE ${PROJECT_NAME}-config.cmake
-	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
 )
 
 # Install the headers at a standard cmake location.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,23 @@ endif()
 
 add_subdirectory(packaging)
 add_subdirectory(tests)
+
+
+file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h")
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+# Install Package Configuration
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_targets)
+
+install(EXPORT ${PROJECT_NAME}_targets
+	NAMESPACE ${PROJECT_NAME}::
+	FILE ${PROJECT_NAME}-config.cmake
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+)
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(WIL)
 
 # Set by build server to speed up build/reduce file/object size
 option(FAST_BUILD "Sets options to speed up build/reduce obj/executable size" OFF)
+option(WIL_BUILD_PACKAGING "Sets options build the packaging, default on" On)
+option(WIL_BUILD_TESTS "Sets options build the unit tests, default on" On)
 
 if (NOT DEFINED WIL_BUILD_VERSION)
     set(WIL_BUILD_VERSION "0.0.0")
@@ -17,13 +19,19 @@ else()
     string(REGEX REPLACE "\\\\$" "" WIL_WINDOWS_SDK_VERSION "$ENV{WindowsSDKVersion}")
 endif()
 
-add_subdirectory(packaging)
-add_subdirectory(tests)
+if (${WIL_BUILD_PACKAGING})
+	add_subdirectory(packaging)
+endif()
 
+if (${WIL_BUILD_TESTS})
+	add_subdirectory(tests)
+endif()
 
+# Gather headers into an interface library.
 file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h")
 add_library(${PROJECT_NAME} INTERFACE)
 
+# The interface's include directory.
 target_include_directories(${PROJECT_NAME} INTERFACE
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -31,11 +39,11 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 
 # Install Package Configuration
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_targets)
-
 install(EXPORT ${PROJECT_NAME}_targets
 	NAMESPACE ${PROJECT_NAME}::
 	FILE ${PROJECT_NAME}-config.cmake
 	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
 )
 
+# Install the headers at a standard cmake location.
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
-
-include(${CMAKE_SOURCE_DIR}/cmake/common_build_flags.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/common_build_flags.cmake)
+cmake_minimum_required(VERSION 3.11)
 
 # All projects need to reference the WIL headers
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
 # TODO: Might be worth trying to conditionally do this on SDK version, assuming there's a semi-easy way to detect that
 include_directories(BEFORE SYSTEM ./workarounds/wrl)


### PR DESCRIPTION
These changes allow a user to install WIL using cmake and consume it through available cmake mechanisms like `find_package`, `ExternalProject_Add` or `FetchContent`.

You can install it locally using the following command :
```bash
cmake .. -DCMAKE_INSTALL_PREFIX=install -DWIL_BUILD_TESTS=Off && cmake --build . && cmake --build . --target install
```

- Adds an `INTERFACE` target for the headers.
- Adds an install config to export the necessary target find info.
- Adds options to disable packaging and tests since you usually don't want to build those when consuming a lib (default on to prevent breaking existing builds).
- Fix the the path variable used in the tests cmake file to support consuming using FetchContent.

Unit tests were ran and passed.