### PR TITLE
Variable-length path-based string cleanup

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -5539,7 +5539,7 @@ namespace wil
     ~~~
     unique_process_information process;
     CreateProcessW(..., CREATE_SUSPENDED, ..., &process);
-    THROW_IF_WIN32_BOOL_FALSE(ResumeThread(process.hThread));
+    THROW_LAST_ERROR_IF(ResumeThread(process.hThread) == -1);
     THROW_LAST_ERROR_IF(WaitForSingleObject(process.hProcess, INFINITE) != WAIT_OBJECT_0);
     ~~~
     */

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -567,4 +567,18 @@ TEST_CASE("FileSystemTests::VerifyGetModuleFileNameExW", "[filesystem]")
 #endif
 }
 
+TEST_CASE("FileSystemTests::QueryFullProcessImageNameW", "[filesystem]")
+{
+    WCHAR fullName[MAX_PATH * 4];
+    DWORD fullNameSize = ARRAYSIZE(fullName);
+    REQUIRE(::QueryFullProcessImageNameW(::GetCurrentProcess(), 0, fullName, &fullNameSize));
+
+    wil::unique_cotaskmem_string path;
+    REQUIRE_SUCCEEDED(wil::QueryFullProcessImageNameW(::GetCurrentProcess(), 0, path));
+    REQUIRE(wcscmp(fullName, path.get()) == 0);
+
+    wil::unique_cotaskmem nativePath;
+    REQUIRE_SUCCEEDED((wil::QueryFullProcessImageNameW<wil::unique_cotaskmem_string, 15>(::GetCurrentProcess(), 0, path)));
+}
+
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -540,6 +540,11 @@ TEST_CASE("FileSystemTests::VerifyGetModuleFileNameW", "[filesystem]")
     REQUIRE(wcscmp(path.get(), path2.get()) == 0);
 
     REQUIRE_FAILED(wil::GetModuleFileNameW((HMODULE)INVALID_HANDLE_VALUE, path));
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    auto wstringPath = wil::GetModuleFileNameW<std::wstring, 15>(nullptr);
+    REQUIRE(wstringPath.length() == ::wcslen(wstringPath.c_str()));
+#endif
 }
 
 TEST_CASE("FileSystemTests::VerifyGetModuleFileNameExW", "[filesystem]")
@@ -555,6 +560,11 @@ TEST_CASE("FileSystemTests::VerifyGetModuleFileNameExW", "[filesystem]")
     REQUIRE(wcscmp(path.get(), path2.get()) == 0);
 
     REQUIRE_FAILED(wil::GetModuleFileNameExW(nullptr, (HMODULE)INVALID_HANDLE_VALUE, path));
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    auto wstringPath = wil::GetModuleFileNameExW<std::wstring, 15>(nullptr, nullptr);
+    REQUIRE(wstringPath.length() == ::wcslen(wstringPath.c_str()));
+#endif
 }
 
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)


### PR DESCRIPTION
`wil::GetModuleFileName[Ex]W` now uses the "adapt fixed buffer to variable length" helper method,
which automatically does the retry-in-a-loop and does the "trim to the first null character" work so
that `result.length()` matches `wcslen(result.c_str())`.  Fixes #163 .

Also fixes `wil::QueryFullProcessImageNameW` to default to doubling the buffer rather than increment-by-one
which prevents spinning when paths are > default-stack-buffer-size. Fixes #3 .

And fixes the incorrectly used macro in documentation. Fixes #151 

Verified by adding new tests and seeing them work.