### PR TITLE
Holiday omnibus issue-addressing

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -1298,10 +1298,7 @@ namespace wil
     {
         template<typename T> void operator()(_Frees_ptr_opt_ T* toFree) const
         {
-            if (toFree)
-            {
-                TDeleter(toFree);
-            }
+            TDeleter(toFree);
         }
     };
 

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -3438,7 +3438,7 @@ namespace wil
     struct process_heap_deleter
     {
         template <typename T>
-        void operator()(_Pre_opt_valid_ _Frees_ptr_opt_ T* p) const
+        void operator()(_Pre_valid_ _Frees_ptr_ T* p) const
         {
             details::FreeProcessHeap(p);
         }
@@ -3447,7 +3447,7 @@ namespace wil
     struct virtualalloc_deleter
     {
         template<typename T>
-        void operator()(_Pre_opt_valid_ _Frees_ptr_opt_ T* p) const
+        void operator()(_Pre_valid_ _Frees_ptr_ T* p) const
         {
             ::VirtualFree(p, 0, MEM_RELEASE);
         }
@@ -3456,7 +3456,7 @@ namespace wil
     struct mapview_deleter
     {
         template<typename T>
-        void operator()(_Pre_opt_valid_ _Frees_ptr_opt_ T* p) const
+        void operator()(_Pre_valid_ _Frees_ptr_ T* p) const
         {
             ::UnmapViewOfFile(p);
         }
@@ -3489,7 +3489,7 @@ namespace wil
     /** Manages a typed pointer allocated with MapViewOfFile
     A specialization of wistd::unique_ptr<> that frees via UnmapViewOfFile(p).
     */
-    template<typename T>
+    template<typename T = void>
     using unique_mapview_ptr = wistd::unique_ptr<T, mapview_deleter>;
 
 #endif // __WIL_WINBASE_

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -1298,7 +1298,10 @@ namespace wil
     {
         template<typename T> void operator()(_Frees_ptr_opt_ T* toFree) const
         {
-            TDeleter(toFree);
+            if (toFree)
+            {
+                TDeleter(toFree);
+            }
         }
     };
 

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -406,10 +406,9 @@ namespace wil
 
                 if (shouldAllocate)
                 {
-                    Node *pNew = reinterpret_cast<Node *>(details::ProcessHeapAlloc(0, sizeof(Node)));
-                    if (pNew != nullptr)
+                    if (auto pNewRaw = details::ProcessHeapAlloc(0, sizeof(Node)))
                     {
-                        new(pNew)Node{ threadId };
+                        auto pNew = new (pNewRaw) Node{ threadId };
 
                         Node *pFirst;
                         do

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -15,7 +15,6 @@
 #include <sysinfoapi.h> // GetSystemTimeAsFileTime
 #include <libloaderapi.h> // GetProcAddress
 #include <Psapi.h> // GetModuleFileNameExW (macro), K32GetModuleFileNameExW
-#include <PathCch.h>
 #include <objbase.h>
 
 #include "result.h"

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -19,6 +19,7 @@
 #include "result.h"
 #include "com.h"
 #include "resource.h"
+#include <windows.foundation.h>
 #include <windows.foundation.collections.h>
 
 #ifdef __cplusplus_winrt
@@ -59,7 +60,6 @@ namespace std
 
 namespace wil
 {
-#ifdef _INC_TIME
     // time_t is the number of 1 - second intervals since January 1, 1970.
     long long const SecondsToStartOf1970 = 0x2b6109100;
     long long const HundredNanoSecondsInSecond = 10000000LL;
@@ -76,7 +76,6 @@ namespace wil
         dateTime.UniversalTime = (timeT + SecondsToStartOf1970) * HundredNanoSecondsInSecond;
         return dateTime;
     }
-#endif // _INC_TIME
 
 #pragma region HSTRING Helpers
     /// @cond

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -740,4 +740,5 @@ TEST_CASE("DefaultTemplateParamCompiles", "[resource]")
 
     wil::unique_midl_ptr<> g;
     wil::unique_cotaskmem_ptr<> h;
+    wil::unique_mapview_ptr<> i;
 }

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -1,5 +1,4 @@
 
-#include <ctime> // TODO: https://github.com/microsoft/wil/issues/44
 #include <wil/winrt.h>
 
 #ifdef WIL_ENABLE_EXCEPTIONS


### PR DESCRIPTION
The implementation of `wistd::unique_ptr` ensures that an invalid value (like `nullptr`) is never passed to the `_deleter` methods, here:

https://github.com/microsoft/wil/blob/adae42be8f45bdbf0fa50aca000fd8bf2063fff5/include/wil/wistd_memory.h#L568-L573

The `_opt_` annotations are irrelevant and can be removed, which fixes #154 

* Also adds a compilation test for `wil::unique_mapview_ptr<>` so untyped mapped views can be held.
* Removes a spurious inclusion of `pathcch.h` in `win32_helpers.h` which is no longer needed (fixes #38)
* Add an inclusion of `windows.foundation.h` to `winrt.h` to get `Windows::Foundation::DateTime` defined (fixes #44) 