### PR TITLE
[installation] Fix install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,4 +48,4 @@ install(EXPORT ${PROJECT_NAME}_targets
 )
 
 # Install the headers at a standard cmake location.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/wil" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")


### PR DESCRIPTION
Since case is sensitive in linux, and `PROJECT_NAME` is uppercase `WIL`:
https://github.com/microsoft/wil/blob/3b559727eceb622320a5a3540b8280fa2e1cb4ee/CMakeLists.txt#L2
And the header file directory name is lowercase `wil`:
_https://github.com/microsoft/wil/tree/master/include/wil_

This will cause a folder not found error when installing the header file directory in linux:
https://github.com/microsoft/wil/blob/3b559727eceb622320a5a3540b8280fa2e1cb4ee/CMakeLists.txt#L51

Fixes this.

Related: https://github.com/microsoft/vcpkg/pull/15438