### PR TITLE
wil/cppwinrt.h should consume winrt::winrt_throw_hresult_handler to log cppwinrt exceptions that are thrown

### DIFF
--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -28,7 +28,8 @@
 namespace wil::details
 {
     // Since the C++/WinRT version macro is a string...
-    inline constexpr int major_version_from_string(const char* versionString)
+    // For example: "2.0.210122.3"
+    inline constexpr int version_from_string(const char* versionString)
     {
         int result = 0;
         auto str = versionString;
@@ -39,6 +40,34 @@ namespace wil::details
         }
 
         return result;
+    }
+
+    // Since the C++/WinRT version macro is a string...
+    // For example: "2.0.210122.3"
+    inline constexpr int major_version_from_string(const char* versionString)
+    {
+        return version_from_string(versionString);
+    }
+
+    inline constexpr int minor_version_from_string(const char* versionString)
+    {
+        auto str = versionString;
+        int dotCount = 0;
+        while ((*str != '\0'))
+        {
+            if (*str == '.')
+            {
+                ++dotCount;
+            }
+
+            ++str;
+            if (dotCount == 2)
+            {
+                break;
+            }
+        }
+
+        return version_from_string(str);
     }
 }
 /// @endcond
@@ -74,6 +103,9 @@ static_assert(::wil::details::major_version_from_string(CPPWINRT_VERSION) >= 2,
 // linker errors than it is to SFINAE on variable existence, so we declare the variable here, but are careful not to
 // use it unless the version of C++/WinRT is high enough
 extern std::int32_t(__stdcall* winrt_to_hresult_handler)(void*) noexcept;
+
+// The same is true with this function pointer as well, except that the version must be 2.X or higher.
+extern void(__stdcall* winrt_throw_hresult_handler)(uint32_t, char const*, char const*, void*, winrt::hresult const) noexcept;
 
 /// @cond
 namespace wil::details
@@ -193,6 +225,12 @@ namespace wil
         return static_cast<std::int32_t>(details::ReportFailure_CaughtException<FailureType::Return>(__R_DIAGNOSTICS_RA(DiagnosticsInfo{}, returnAddress)));
     }
 
+    inline void __stdcall winrt_throw_hresult(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept
+    {
+        void* callerReturnAddress{nullptr}; PCSTR code{nullptr};
+        wil::details::ReportFailure_Hr<FailureType::Log>(__R_FN_CALL_FULL __R_COMMA result);
+    }
+
     inline void WilInitialize_CppWinRT()
     {
         details::g_pfnResultFromCaughtException_CppWinRt = details::ResultFromCaughtException_CppWinRt;
@@ -200,6 +238,12 @@ namespace wil
         {
             WI_ASSERT(winrt_to_hresult_handler == nullptr);
             winrt_to_hresult_handler = winrt_to_hresult;
+        }
+
+        if constexpr ((details::major_version_from_string(CPPWINRT_VERSION) >= 2) && (details::minor_version_from_string(CPPWINRT_VERSION) >= 210122))
+        {
+            WI_ASSERT(winrt_throw_hresult_handler == nullptr);
+            winrt_throw_hresult_handler = winrt_throw_hresult;
         }
     }
 

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -42,8 +42,6 @@ namespace wil::details
         return result;
     }
 
-    // Since the C++/WinRT version macro is a string...
-    // For example: "2.0.210122.3"
     inline constexpr int major_version_from_string(const char* versionString)
     {
         return version_from_string(versionString);
@@ -65,6 +63,11 @@ namespace wil::details
             {
                 break;
             }
+        }
+
+        if (*str == '\0')
+        {
+            return 0;
         }
 
         return version_from_string(str);


### PR DESCRIPTION
Fixes #172

## Why is this change being made?
This change is being made to improve the interop between cppwinrt and WIL (particularly WIL's logging abilities for errors). It consumes a new hook from the `winrt::throw_hresult` method via `<wil/cppwinrt.h>` by filling it in with a function pointer. That function pointer will allow WIL's logging abilities to gain knowledge of the exceptions that are originated within cppwinrt.  When both changes are combined WIL is able to observe and log cppwinrt exceptions that previously flew past invisibly.

## Briefly summarize what changed
The core of this change is the new `winrt_throw_hresult` method which will be called from `winrt::throw_hresult` when things are set up properly.  This method forwards along the error information in a way roughly equivalent to `LOG_HR`.  The contract allows for the usual set of information (file name, function name, line number, error code, return address).  At this time only the return address and error code are actually able to be provided by cppwinrt.  Hopefully that changes in the future with [C++20 source_location](https://en.cppreference.com/w/cpp/utility/source_location).

The other piece of this is hooking up the new extension point when the cppwinrt version is new enough.  This is done via an `if constexpr` check in `WilInitialize_CppWinRT`.  If the version is new enough then it is hooked up.  If the version is too old then it would be a linker error and it compiles away into nothingness.

The trickiest part was refactoring the `constexpr` version checking method to expose both the major and minor versions instead of just the major version.  The minor version is actually the 3rd number in the versioning scheme so this isn't the prettiest method.  Unfortunately all of the usual STL string helpers are unavailable from a `constexpr` method so this must be done manually.

## How was the change tested?
This change was tested in a cppwinrt blank project that calls `winrt::check_hresult` with a WIL logger active.  Previous to both of these changes it never saw the error.  I pulled the latest NuGet from cppwinrt with that portion of this change and rebuilt.  Same result.  I then made the <wil/cppwinrt.h> changes and got that into the blank project and confirmed that it is properly logging the error as expected.  I also ran a `ninja` build and `runtests.cmd`.  