### PR TITLE
Check for ERROR_ALREADY_EXISTS for the second CreateDirectoryW call.

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -113,7 +113,7 @@ namespace wil
     {
         if (::CreateDirectoryW(path, nullptr) == FALSE)
         {
-            DWORD const lastError = ::GetLastError();
+            DWORD lastError = ::GetLastError();
             if (lastError == ERROR_PATH_NOT_FOUND)
             {
                 size_t parentLength;
@@ -126,7 +126,11 @@ namespace wil
                 }
                 if (::CreateDirectoryW(path, nullptr) == FALSE)
                 {
-                    RETURN_WIN32(::GetLastError());
+                    lastError = ::GetLastError();
+                    if (lastError != ERROR_ALREADY_EXISTS)
+                    {
+                        RETURN_WIN32(lastError);
+                    }
                 }
             }
             else if (lastError != ERROR_ALREADY_EXISTS)

--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -113,7 +113,7 @@ namespace wil
     {
         if (::CreateDirectoryW(path, nullptr) == FALSE)
         {
-            DWORD lastError = ::GetLastError();
+            DWORD const lastError = ::GetLastError();
             if (lastError == ERROR_PATH_NOT_FOUND)
             {
                 size_t parentLength;
@@ -126,11 +126,10 @@ namespace wil
                 }
                 if (::CreateDirectoryW(path, nullptr) == FALSE)
                 {
-                    lastError = ::GetLastError();
+                    RETURN_WIN32(::GetLastError());
                 }
             }
-
-            if (lastError != ERROR_ALREADY_EXISTS)
+            else if (lastError != ERROR_ALREADY_EXISTS)
             {
                 RETURN_WIN32(lastError);
             }


### PR DESCRIPTION
Handle the case where multiple threads are trying to create the same directory and the second call to CreateDirectoryW can also return ERROR_ALREADY_EXISTS.