### PR TITLE
Bring back "trivial" cleanup calls for most resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Some things that WIL includes to whet your appetite:
   API HANDLEs, HWNDs, and other resources and resource handles with
   [RAII](https://en.cppreference.com/w/cpp/language/raii) semantics.
 - [`include/wil/win32_helpers.h`](include/wil/win32_helpers.h)
-- ([documentation](https://github.com/microsoft/wil/wiki/Win32-helpers)): Wrappers for API functions
+  ([documentation](https://github.com/microsoft/wil/wiki/Win32-helpers)): Wrappers for API functions
   that save you the work of manually specifying buffer sizes, calling a function twice
   to get the needed buffer size and then allocate and pass the right-size buffer,
   casting or converting between types, and so on.

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -124,7 +124,7 @@ namespace wil
             inline static void close_reset(typename pointer_storage_t value) WI_NOEXCEPT
             {
                 auto preserveError = last_error_context();
-                wistd::invoke(value);
+                wistd::invoke(close_fn, value);
             }
         };
 
@@ -1543,7 +1543,7 @@ namespace wil
                 }
                 if (oldSource)
                 {
-                    wistd::invoke(close_fn, oldSource);
+                    details::close_invoker<close_fn_t, close_fn, interface_t*>::close(oldSource);
                     oldSource->Release();
                 }
             }
@@ -1655,7 +1655,7 @@ namespace wil
             m_call = false;
             if (call)
             {
-                wistd::invoke(close_fn);
+                close_fn();
             }
         }
 

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -120,8 +120,8 @@ namespace wil
 
         template<bool is_fn_ptr, typename close_fn_t, close_fn_t close_fn, typename pointer_storage_t> struct close_invoke_helper
         {
-            __forceinline static void close(typename pointer_storage_t value) WI_NOEXCEPT { wistd::invoke(close_fn, value); }
-            inline static void close_reset(typename pointer_storage_t value) WI_NOEXCEPT
+            __forceinline static void close(pointer_storage_t value) WI_NOEXCEPT { wistd::invoke(close_fn, value); }
+            inline static void close_reset(pointer_storage_t value) WI_NOEXCEPT
             {
                 auto preserveError = last_error_context();
                 wistd::invoke(close_fn, value);
@@ -130,8 +130,8 @@ namespace wil
 
         template<typename close_fn_t, close_fn_t close_fn, typename pointer_storage_t> struct close_invoke_helper<true, close_fn_t, close_fn, pointer_storage_t>
         {
-            __forceinline static void close(typename pointer_storage_t value) WI_NOEXCEPT { close_fn(value); }
-            inline static void close_reset(typename pointer_storage_t value) WI_NOEXCEPT
+            __forceinline static void close(pointer_storage_t value) WI_NOEXCEPT { close_fn(value); }
+            inline static void close_reset(pointer_storage_t value) WI_NOEXCEPT
             {
                 auto preserveError = last_error_context();
                 close_fn(value);

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -782,7 +782,7 @@ struct TokenTester : ITokenTester
     IFACEMETHOD_(ULONG, AddRef)() override { return 2; }
     IFACEMETHOD_(ULONG, Release)() override { return 1; }
     IFACEMETHOD(QueryInterface)(REFIID, void**) { return E_NOINTERFACE; }
-    void DirectClose(DWORD_PTR token) {
+    void DirectClose(DWORD_PTR token) override {
         m_closed = (token == m_closeToken);
     }
     bool m_closed = false;

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -771,3 +771,49 @@ TEST_CASE("UniqueInvokeCleanupMembers", "[resource]")
     }
     REQUIRE(structDestroyed);
 }
+
+struct ITokenTester : IUnknown
+{
+    virtual void DirectClose(DWORD_PTR token) = 0;
+};
+
+struct TokenTester : ITokenTester
+{
+    IFACEMETHOD_(ULONG, AddRef)() override { return 2; }
+    IFACEMETHOD_(ULONG, Release)() override { return 1; }
+    IFACEMETHOD(QueryInterface)(REFIID, void**) { return E_NOINTERFACE; }
+    void DirectClose(DWORD_PTR token) {
+        m_closed = (token == m_closeToken);
+    }
+    bool m_closed = false;
+    DWORD_PTR m_closeToken;
+};
+
+void MyTokenTesterCloser(ITokenTester* tt, DWORD_PTR token)
+{
+    tt->DirectClose(token);
+}
+
+TEST_CASE("ComTokenCloser", "[resource]")
+{
+    using token_tester_t = wil::unique_com_token<ITokenTester, DWORD_PTR, decltype(MyTokenTesterCloser), &MyTokenTesterCloser>;
+
+    TokenTester tt;
+    tt.m_closeToken = 4;
+    {
+        token_tester_t tmp{ &tt, 4 };
+    }
+    REQUIRE(tt.m_closed);
+}
+
+TEST_CASE("ComTokenDirectCloser", "[resource]")
+{
+    using token_tester_t = wil::unique_com_token<ITokenTester, DWORD_PTR, decltype(&ITokenTester::DirectClose), &ITokenTester::DirectClose>;
+
+    TokenTester tt;
+    tt.m_closeToken = 4;
+    {
+        token_tester_t tmp{ &tt, 4 };
+    }
+    REQUIRE(tt.m_closed);
+}


### PR DESCRIPTION
Some experimentation shows that use of `wistd::invoke` (see #43 ) results in a small but measurable size increase in certain DLLs for resources that have trivial C-style cleanup functions. Investigations showed that the inliner was unable to see through the `wistd::invoke(close_fn, value)` call and resolve it to just `close_fn(value)`, resulting in an indirect call.

This change supports both direct method calls and "invoke-ables", getting the best of both worlds. Direct methods are returned to their `close_fn(value)` and invoke-ables continue to use `wistd::invoke` to resolve the calls.

Also added some compilation & runtime tests to verify behavior.