### PR TITLE
Add exception macro for gcc and clang

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -264,7 +264,7 @@ WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
 #if (defined(_CPPUNWIND) || defined(__EXCEPTIONS)) && !defined(WIL_SUPPRESS_EXCEPTIONS)
 /** This define is automatically set when exceptions are enabled within wil.
 It is automatically defined when your code is compiled with exceptions enabled (via checking for the built-in
-_CPPUNWIND flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil
+_CPPUNWIND or __EXCEPTIONS flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil
 header.  All exception-based WIL methods and classes are included behind:
 ~~~~
 #ifdef WIL_ENABLE_EXCEPTIONS

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -261,7 +261,7 @@ WI_ODR_PRAGMA("WIL_KERNEL_MODE", "1")
 WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
 #endif
 
-#if defined(_CPPUNWIND) || defined(__EXCEPTIONS) && !defined(WIL_SUPPRESS_EXCEPTIONS)
+#if (defined(_CPPUNWIND) || defined(__EXCEPTIONS)) && !defined(WIL_SUPPRESS_EXCEPTIONS)
 /** This define is automatically set when exceptions are enabled within wil.
 It is automatically defined when your code is compiled with exceptions enabled (via checking for the built-in
 _CPPUNWIND flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -261,7 +261,7 @@ WI_ODR_PRAGMA("WIL_KERNEL_MODE", "1")
 WI_ODR_PRAGMA("WIL_KERNEL_MODE", "0")
 #endif
 
-#if defined(_CPPUNWIND) && !defined(WIL_SUPPRESS_EXCEPTIONS)
+#if defined(_CPPUNWIND) || defined(__EXCEPTIONS) && !defined(WIL_SUPPRESS_EXCEPTIONS)
 /** This define is automatically set when exceptions are enabled within wil.
 It is automatically defined when your code is compiled with exceptions enabled (via checking for the built-in
 _CPPUNWIND flag) unless you explicitly define WIL_SUPPRESS_EXCEPTIONS ahead of including your first wil


### PR DESCRIPTION
`gcc` and `clang` don't define `_CPPUNWIND`, but they define `__EXCEPTIONS`, so I added a check for it.