### PR TITLE
quite bits C++ 20 warning

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -20,7 +20,7 @@
 
 // detect std::bit_cast
 #ifdef __has_include
-#  if __has_include(<bit>)
+#  if (__cplusplus > 202000) && __has_include(<bit>)
 #    include <bit>
 #  endif
 #endif

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -20,7 +20,7 @@
 
 // detect std::bit_cast
 #ifdef __has_include
-#  if (__cplusplus > 202000) && __has_include(<bit>)
+#  if (__cplusplus >= 202002L || _MSVC_LANG >= 202002L) && __has_include(<bit>)
 #    include <bit>
 #  endif
 #endif


### PR DESCRIPTION
I've got this in my apartment variable change but that is taking longer than I though, so bringing this warning quieting change in

```
Build started...
1>------ Build started: Project: MultiXamlAndWindowApp, Configuration: Debug x64 ------
1>pch.cpp
1>The contents of <bit> are available only with C++20 or later.
1>MultiXamlAndWindowApp.cpp
1>MultiXamlAndWindowApp.vcxproj -> C:\Users\chris\source\repos\ChrisGuzak\Win32XamlApp\x64\Debug\MultiXamlAndWindowApp.exe
```