### PR TITLE
make_com_ptr helpers to work around lack of alias template deduction guides pre-C++20

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -1180,6 +1180,43 @@ namespace wil
 #endif
     /// @endcond
 
+#ifdef WIL_ENABLE_EXCEPTIONS
+    //! Constructs a `com_ptr` from a raw pointer.
+    //! This avoids having to restate the interface in pre-C++20.
+    //! Starting in C++20, you can write `wil::com_ptr(p)` directly.
+    //! ~~~
+    //! void example(ILongNamedThing* thing)
+    //! {
+    //!    callback([thing = wil::make_com_ptr(thing)] { /* do something */ });
+    //! }
+    //! ~~~
+    template <typename T>
+    com_ptr<T> make_com_ptr(T* p) { return p; }
+#endif
+
+    //! Constructs a `com_ptr_nothrow` from a raw pointer.
+    //! This avoids having to restate the interface in pre-C++20.
+    //! Starting in C++20, you can write `wil::com_ptr_nothrow(p)` directly.
+    //! ~~~
+    //! void example(ILongNamedThing* thing)
+    //! {
+    //!    callback([thing = wil::make_com_ptr_nothrow(thing)] { /* do something */ });
+    //! }
+    //! ~~~
+    template <typename T>
+    com_ptr_nothrow<T> make_com_ptr_nothrow(T* p) { return p; }
+
+    //! Constructs a `com_ptr_failfast` from a raw pointer.
+    //! This avoids having to restate the interface in pre-C++20.
+    //! Starting in C++20, you can write `wil::com_ptr_failfast(p)` directly.
+    //! ~~~
+    //! void example(ILongNamedThing* thing)
+    //! {
+    //!    callback([thing = wil::make_com_ptr_failfast(thing)] { /* do something */ });
+    //! }
+    //! ~~~
+    template <typename T>
+    com_ptr_failfast<T> make_com_ptr_failfast(T* p) { return p; }
 
     //! @name Stand-alone query helpers
     //! * Source pointer can be raw interface pointer, any wil com_ptr, or WRL ComPtr

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -130,6 +130,25 @@ TEST_CASE("ComTests::Test_Constructors", "[com][com_ptr]")
         REQUIRE(ptrMove2.get() == &helper4);
         REQUIRE(ptr2.get() == nullptr);
     }
+
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201907L)
+    SECTION("CTAD pointer construction")
+    {
+        wil::com_ptr_nothrow ptr(&helper); // explicit
+        REQUIRE(IUnknownFake::GetAddRef() == 1);
+        REQUIRE(ptr.get() == &helper);
+    }
+#endif
+}
+
+TEST_CASE("ComTests::Test_Make", "[com][com_ptr]")
+{
+    IUnknownFake::Clear();
+    IUnknownFake helper;
+
+    auto ptr = wil::make_com_ptr_nothrow(&helper); // CTAD workaround for pre-C++20
+    REQUIRE(IUnknownFake::GetAddRef() == 1);
+    REQUIRE(ptr.get() == &helper);
 }
 
 TEST_CASE("ComTests::Test_Assign", "[com][com_ptr]")


### PR DESCRIPTION
C++20 adds support for deduction guides for alias templates. For older versions, we provide helper `make_com_ptr` functions.

* `make_com_ptr(p)`
* `make_com_ptr_nothrow(p)`
* `make_com_ptr_failfast(p)`

```cpp
// Pre-C++20 without helper
void OnThingCreated(ILongNamedThing* rawThing)
{
    auto thing = wil::com_ptr<ILongNamedThing>(rawThing);

    wil::com_ptr<ILongNamedThing> thing(rawThing);

    RunAsync([thing = wil::com_ptr<ILongNamedThing>(rawThing)]
      { ... });
}

// Pre-C++20 with helper
void OnThingCreated(ILongNamedThing* rawThing)
{
    auto thing = wil::make_com_ptr(rawThing);

    RunAsync([thing = wil::make_com_ptr(rawThing)]
      { ... });
}

// C++20 and onward
void OnThingCreated(ILongNamedThing* rawThing)
{
    auto thing = wil::com_ptr(rawThing);

    wil::com_ptr thing(rawThing);

    RunAsync([thing = wil::com_ptr(rawThing)]
      { ... });
}
```

Similarly `com_ptr_nothrow` and `com_ptr_failfast`.