### PR TITLE
Add alias target WIL::WIL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 # Gather headers into an interface library.
 file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h")
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 # The interface's include directory.
 target_include_directories(${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
To consume WIL, typically there are two methods:
- Install WIL (e.g. `vcpkg install wil`),  then `find_package(WIL)`, finally link to namespaced imported target `target_link_libraries(WIL::WIL)`. https://github.com/microsoft/wil/blob/c3c9e030240a21e21ea81bef38ce566191b42f13/CMakeLists.txt#L45
- Add WIL as submodule `add_subdirectory(wil)`, then link to target `target_link_libraries(WIL)`.
https://github.com/microsoft/wil/blob/c3c9e030240a21e21ea81bef38ce566191b42f13/CMakeLists.txt#L34

By adding the namespaced target, consumer can use same target name `WIL::WIL` for either method.
