### PR TITLE
wil::resume_foreground addresses many issues with winrt::resume_foreground

### DIFF
--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -146,7 +146,7 @@ TEST_CASE("CppWinRTTests::CppWinRTConsistencyTest", "[cppwinrt]")
 
 #if (defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 
-// Define our own custom dispatcher that we can force to be have in certain ways.
+// Define our own custom dispatcher that we can force it to behave in certain ways.
 // wil::resume_foreground supports any dispatcher that has a dispatcher_traits.
 
 namespace test
@@ -209,7 +209,7 @@ namespace wil::details
     {
         using Priority = test::TestDispatcherPriority;
         using Handler = test::TestDispatcherHandler;
-        using Queuer = dispatcher_TryEnqueue;
+        using Scheduler = dispatcher_TryEnqueue;
     };
 }
 
@@ -223,11 +223,11 @@ TEST_CASE("CppWinRTTests::ResumeForegroundTests", "[cppwinrt]")
         dispatcher.mode = test::TestDispatcherMode::Dispatch;
         co_await wil::resume_foreground(dispatcher);
 
-        // Race case: Resumes on new thread, race condition (handler runs before TryEnqueue returns)
+        // Race case: Resumes before TryEnqueue returns.
         dispatcher.mode = test::TestDispatcherMode::RaceDispatch;
         co_await wil::resume_foreground(dispatcher);
 
-        // Orphan case: Never resumes, detected when handler is destructed.
+        // Orphan case: Never resumes, detected when handler is destructed without ever being invoked.
         dispatcher.mode = test::TestDispatcherMode::Orphan;
         bool seen = false;
         try
@@ -240,7 +240,7 @@ TEST_CASE("CppWinRTTests::ResumeForegroundTests", "[cppwinrt]")
         }
         REQUIRE(seen);
 
-        // Fail case: Can't even queue the handler.
+        // Fail case: Can't even schedule the resumption.
         dispatcher.mode = test::TestDispatcherMode::Fail;
         seen = false;
         try


### PR DESCRIPTION
The C++/WinRT built-in `resume_foreground()` support is problematic.

`co_await resume_foreground(CoreDispatcher)` has no return value. If the resumption of the coroutine could not be enqueued, the coroutine simply hangs, resulting in a memory leak (from accumulated suspended coroutines that never complete), while giving the developer no indication that the work they wanted to do will never be done.

`co_await resume_foreground(DispatcherQueue)` returns `false` if the resumption of the coroutine could not be enqueued and the thread switch therefore failed. In practice, nobody checks the return value, meaning that the code after the `co_await` is running on the wrong thread. (This flaw was copy/paste'd into `Microsoft.UI.Dispatching.co_await.h`.)

Furthermore, just because the coroutine continuation was enqueued doesn't mean that it will actually run. The work item may end up simply abandoned, for example if the dispatcher thread exits abruptly.

To fix all this, we provide alternate versions `wil::resume_foreground()` which have these properties:

* If the thread-switch is successful, the `co_await` completes normally.
* If the thread-switch is unsuccessful, the `co_await` completes with an exception on an unspecified thread.

Another problem with C++/WinRT's `winrt::resume_foreground()` is simply that it's in C++/WinRT. It really belongs in an outside library, since C++/WinRT should be focused on the projection. Putting them in C++/WinRT forces dispatcher implementors to have to modify C++/WinRT whenever they want to change something.

Implementation details
======================

The implementation is tricky because `wil/cppwinrt.h` is included before any other C++/WinRT headers, yet it wants to access types from headers that may be included after it. It cannot `#include` those headers directly, because they may not exist.

The solution is to forward-declare the types, and then use them as dependent types in template expansions, so that the members aren't resolved until the second phase of template name lookup, at which point the full definitions should have been provided by the calling app.

We declare a traits type `dispatcher_traits` and specialize it for each of the dispatchers we support. This also serves as a convenient hook for the unit test: We can just invent our own custom dispatcher, and as long as it has a `dispatcher_traits`, we can use it with `wil::resume_foreground`.

In order to be able to call `RunAsync` or `TryEnqueue` before the methods have been declared, we make them dependent names in `dispatcher_RunAsync` and `dispatcher_TryEnqueue`, so that the name lookup happens at invoke time rather than definition time.

To detect abandoned work, we use a custom delegate which detects that it has been destructed without ever having been invoked, in which case it resumes the coroutine so it can raise an exception with error code `ERROR_NO_TASK_QUEUE`. (We ignore the return value from `Scheduler::Schedule` because a successful return value does not guarantee that the work item will run.)

The abandonment could take place on any thread, because it might occur after the work was successfully queued, and then before it can run, the destination thread exits. The work item is now stuck in limbo: The destination thread no longer exists, and the source thread may not exist either. It has no choice but to resume on some other thread.

The state of the suspended coroutine is kept in a `dispatched_handler_state`. Our `m_state` pointer is non-null if we are the "active" `dispatcher_handler`. The pointer is moved when the move-only `dispatcher_handler` is moved, so only the instance that lives inside the delegate has a non-null pointer, and even that instance nulls out its pointer before resuming the coroutine, so that we never have a pointer to a destructed state.

The `handle` is non-null if the coroutine is still suspended. `orphaned` is set to `true` if the handler discovers that it was never invoked. Upon resumption, we raise an exception if we realize we were orphaned.

There is a subtlety in the `await_suspend`: We need to keep an explicit reference to the work item, so that it doesn't destruct prematurely. In the case where the Queue function throws an exception, we null out the coroutine handle in the state so that the handler's destructor won't try to report the failure: The exception in the Queue function puts the the coroutine into an error state, making it no longer resumable.

A bonus side effect of the replacement `wil::resume_foreground` is that its `await_suspend` returns `void` rather than `bool`, thereby avoiding a heap corruption coroutine code generation bug in older versions of Visual Studio.

One of the problematic pieces is figuring out whether coroutine handles live in the `std` or `std::experimental` namespace (or neither, if coroutines aren't supported at all). This is particularly tricky because different versions of C++/WinRT leave different traces behind. Ultimately, I opted not to rely on C++/WinRT at all and instead use the compiler symbols.

* `_RESUMABLE_FUNCTIONS_SUPPORTED`: `/await` mode (pre-standard)
* `__cpp_lib_coroutine`: C++20 standard mode
