### PR TITLE
Download/run cppwinrt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,15 @@ include(GNUInstallDirs)
 
 # Set by build server to speed up build/reduce file/object size
 option(FAST_BUILD "Sets options to speed up build/reduce obj/executable size" OFF)
-option(WIL_BUILD_PACKAGING "Sets option to build the packaging, default on" On)
-option(WIL_BUILD_TESTS "Sets option to build the unit tests, default on" On)
+option(WIL_BUILD_PACKAGING "Sets option to build the packaging, default on" ON)
+option(WIL_BUILD_TESTS "Sets option to build the unit tests, default on" ON)
 
 if (NOT DEFINED WIL_BUILD_VERSION)
     set(WIL_BUILD_VERSION "0.0.0")
+endif()
+
+if (NOT DEFINED CPPWINRT_VERSION)
+    set(CPPWINRT_VERSION "2.0.210806.1")
 endif()
 
 # Detect the Windows SDK version. If we're using the Visual Studio generator, this will be provided for us. Otherwise

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,31 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 # TODO: Might be worth trying to conditionally do this on SDK version, assuming there's a semi-easy way to detect that
 include_directories(BEFORE SYSTEM ./workarounds/wrl)
 
+# Because we don't always use msbuild, we need to run nuget manually
+find_program(NUGET nuget)
+if (NOT NUGET)
+    message(FATAL_ERROR "Unable to find the nuget CLI tool. Please install it from https://www.nuget.org/downloads and ensure it has been added to the PATH")
+endif()
+
+execute_process(COMMAND
+    ${NUGET} install Microsoft.Windows.CppWinRT -Version ${CPPWINRT_VERSION} -OutputDirectory packages
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    RESULT_VARIABLE ret)
+if (NOT ret EQUAL 0)
+    message(FATAL_ERROR "Failed to install nuget package Microsoft.Windows.CppWinRT.${CPPWINRT_VERSION}")
+endif()
+
+set(CPPWINRT ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT.${CPPWINRT_VERSION}/bin/cppwinrt.exe)
+execute_process(COMMAND
+    ${CPPWINRT} -input sdk -output include
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    RESULT_VARIABLE ret)
+if (NOT ret EQUAL 0)
+    message(FATAL_ERROR "Failed to run cppwinrt.exe")
+endif()
+
+include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
+
 # The build pipelines have limitations that local development environments do not, so turn a few knobs
 if (${FAST_BUILD})
     replace_cxx_flag("/GR" "/GR-") # Disables RTTI


### PR DESCRIPTION
This is so that we don't have to rely on the constantly outdated version used to generate SDK headers