### PR TITLE
wrl_module_reference and winrt_module_reference to prevent DLL from unloading

### DIFF
--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -333,6 +333,75 @@ namespace wil
     {
         return winrt::capture<WinRTResult>(o.as<Interface>(), method, std::forward<Args>(args)...);
     }
+
+    /** Holds a reference to the host C++/WinRT module to prevent it from being unloaded.
+    Normally, this is done by being in an IAsyncOperation coroutine or by holding a strong
+    reference to a C++/WinRT object hosted in the same module, but if you have neither,
+    you will need to hold a reference explicitly. For the WRL equivalent, see wrl_module_reference.
+
+    This can be used as a base, which permits EBO:
+    ~~~~
+    struct NonWinrtObject : wil::winrt_module_reference
+    {
+        int value;
+    };
+
+    // DLL will not be unloaded as long as NonWinrtObject is still alive.
+    auto p = std::make_unique<NonWinrtObject>();
+    ~~~~
+
+    Or it can be used as a member (with [[no_unique_address]] to avoid
+    occupying any memory):
+    ~~~~
+    struct NonWinrtObject
+    {
+        int value;
+
+        [[no_unique_address]] wil::winrt_module_reference module_ref;
+    };
+
+    // DLL will not be unloaded as long as NonWinrtObject is still alive.
+    auto p = std::make_unique<NonWinrtObject>();
+    ~~~~
+
+    If using it to prevent the host DLL from unloading while a thread
+    or threadpool work item is still running, create the object before
+    starting the thread, and pass it to the thread. This avoids a race
+    condition where the host DLL could get unloaded before the thread starts.
+    ~~~~
+    std::thread([module_ref = wil::winrt_module_reference()]() { do_background_work(); });
+
+    // Don't do this (race condition)
+    std::thread([]() { wil::winrt_module_reference module_ref; do_background_work(); }); // WRONG
+    ~~~~
+
+    Also useful in coroutines that neither capture DLL-hosted COM objects, nor are themselves
+    DLL-hosted COM objects. (If the coroutine returns IAsyncAction or captures a get_strong()
+    of its containing WinRT class, then the IAsyncAction or strong reference will itself keep
+    a strong reference to the host module.)
+    ~~~~
+    winrt::fire_and_forget ContinueBackgroundWork()
+    {
+        // prevent DLL from unloading while we are running on a background thread.
+        // Do this before switching to the background thread.
+        wil::winrt_module_reference module_ref;
+
+        co_await winrt::resume_background();
+        do_background_work();
+    };
+    ~~~~
+    */
+    struct [[nodiscard]] winrt_module_reference
+    {
+        winrt_module_reference()
+        {
+            ++winrt::get_module_lock();
+        }
+        ~winrt_module_reference()
+        {
+            --winrt::get_module_lock();
+        }
+    };
 }
 
 #if (defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -397,6 +397,9 @@ namespace wil
         {
             ++winrt::get_module_lock();
         }
+
+        winrt_module_reference(winrt_module_reference const&) : winrt_module_reference() {}
+
         ~winrt_module_reference()
         {
             --winrt::get_module_lock();

--- a/include/wil/wrl.h
+++ b/include/wil/wrl.h
@@ -79,6 +79,37 @@ namespace wil
         return result;
     }
 #endif // WIL_ENABLE_EXCEPTIONS
+
+    /** Holds a reference to the host WRL module to prevent it from being unloaded.
+    Normally, the reference is held implicitly because you are a member function
+    of a DLL-hosted COM object, or because you retain a strong reference
+    to some DLL-hosted COM object, but if those do not apply to you, then you
+    will need to hold a reference explicitly. For examples (and for the C++/WinRT
+    equivalent), see winrt_module_reference.
+
+    Warning: If wrl_module_reference is used from a module that does not
+    use WRL factories, it will have no effect. This is expected if used from
+    an executable module, but will be surprising if used from a DLL.
+    */
+    struct [[nodiscard]] wrl_module_reference
+    {
+        wrl_module_reference()
+        {
+            if (auto modulePtr = ::Microsoft::WRL::GetModuleBase())
+            {
+                modulePtr->IncrementObjectCount();
+            }
+        }
+
+        ~wrl_module_reference()
+        {
+            if (auto modulePtr = ::Microsoft::WRL::GetModuleBase())
+            {
+                modulePtr->DecrementObjectCount();
+            }
+        }
+    };
+
 } // namespace wil
 
 #endif // __WIL_WRL_INCLUDED

--- a/include/wil/wrl.h
+++ b/include/wil/wrl.h
@@ -101,6 +101,8 @@ namespace wil
             }
         }
 
+        wrl_module_reference(wrl_module_reference const&) : wrl_module_reference() {}
+
         ~wrl_module_reference()
         {
             if (auto modulePtr = ::Microsoft::WRL::GetModuleBase())

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -144,6 +144,22 @@ TEST_CASE("CppWinRTTests::CppWinRTConsistencyTest", "[cppwinrt]")
     // that such exceptions become HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION)
 }
 
+TEST_CASE("CppWinRTTests::ModuleReference", "[cppwinrt]")
+{
+    auto peek_module_ref_count = []()
+    {
+        ++winrt::get_module_lock();
+        return --winrt::get_module_lock();
+    };
+
+    auto initial = peek_module_ref_count();
+    {
+        auto module_ref = wil::winrt_module_reference();
+        REQUIRE(peek_module_ref_count() == initial + 1);
+    }
+    REQUIRE(peek_module_ref_count() == initial);
+}
+
 #if (defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 
 // Define our own custom dispatcher that we can force it to behave in certain ways.

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -153,9 +153,28 @@ TEST_CASE("CppWinRTTests::ModuleReference", "[cppwinrt]")
     };
 
     auto initial = peek_module_ref_count();
+
+    // Basic test: Construct and destruct.
     {
         auto module_ref = wil::winrt_module_reference();
         REQUIRE(peek_module_ref_count() == initial + 1);
+    }
+    REQUIRE(peek_module_ref_count() == initial);
+
+    // Fancy test: Copy object with embedded reference.
+    {
+        struct object_with_ref
+        {
+            wil::winrt_module_reference ref;
+        };
+        object_with_ref o1;
+        REQUIRE(peek_module_ref_count() == initial + 1);
+        auto o2 = o1;
+        REQUIRE(peek_module_ref_count() == initial + 2);
+        o1 = o2;
+        REQUIRE(peek_module_ref_count() == initial + 2);
+        o2 = std::move(o1);
+        REQUIRE(peek_module_ref_count() == initial + 2);
     }
     REQUIRE(peek_module_ref_count() == initial);
 }

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -3519,9 +3519,28 @@ TEST_CASE("WindowsInternalTests::ModuleReference", "[wrl]")
     };
 
     auto initial = peek_module_ref_count();
+
+    // Basic test: Construct and destruct.
     {
         auto module_ref = wil::wrl_module_reference();
         REQUIRE(peek_module_ref_count() == initial + 1);
+    }
+    REQUIRE(peek_module_ref_count() == initial);
+
+    // Fancy test: Copy object with embedded reference.
+    {
+        struct object_with_ref
+        {
+            wil::wrl_module_reference ref;
+        };
+        object_with_ref o1;
+        REQUIRE(peek_module_ref_count() == initial + 1);
+        auto o2 = o1;
+        REQUIRE(peek_module_ref_count() == initial + 2);
+        o1 = o2;
+        REQUIRE(peek_module_ref_count() == initial + 2);
+        o2 = std::move(o1);
+        REQUIRE(peek_module_ref_count() == initial + 2);
     }
     REQUIRE(peek_module_ref_count() == initial);
 }

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -3480,4 +3480,51 @@ TEST_CASE("WindowsInternalTests::ShutdownAwareObjectAlignmentTests", "[result_ma
     VerifyAlignment<wil::object_without_destructor_on_shutdown>();
 }
 
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+TEST_CASE("WindowsInternalTests::ModuleReference", "[wrl]")
+{
+    REQUIRE(::Microsoft::WRL::GetModuleBase() == nullptr);
+    // Executables don't have a ModuleBase, so we need to create one.
+    struct FakeModuleBase : Microsoft::WRL::Details::ModuleBase
+    {
+        unsigned long count = 42;
+        STDMETHOD_(unsigned long, IncrementObjectCount)()
+        {
+            return InterlockedIncrement(&count);
+        }
+        STDMETHOD_(unsigned long, DecrementObjectCount)()
+        {
+            return InterlockedDecrement(&count);
+        }
+        STDMETHOD_(unsigned long, GetObjectCount)() const
+        {
+            return count;
+        }
+        // Dummy implementations of everything else (never called).
+        STDMETHOD_(const Microsoft::WRL::Details::CreatorMap**, GetFirstEntryPointer)() const { return nullptr; }
+        STDMETHOD_(const Microsoft::WRL::Details::CreatorMap**, GetMidEntryPointer)() const { return nullptr; }
+        STDMETHOD_(const Microsoft::WRL::Details::CreatorMap**, GetLastEntryPointer)() const { return nullptr; }
+        STDMETHOD_(SRWLOCK*, GetLock)() const { return nullptr; }
+        STDMETHOD(RegisterWinRTObject)(const wchar_t*, const wchar_t**, _Inout_ RO_REGISTRATION_COOKIE*, unsigned int) { return E_NOTIMPL; }
+        STDMETHOD(UnregisterWinRTObject)(const wchar_t*, _In_ RO_REGISTRATION_COOKIE) { return E_NOTIMPL; }
+        STDMETHOD(RegisterCOMObject)(const wchar_t*, _In_ IID*, _In_ IClassFactory**, _Inout_ DWORD*, unsigned int) { return E_NOTIMPL; }
+        STDMETHOD(UnregisterCOMObject)(const wchar_t*, _Inout_ DWORD*, unsigned int) { return E_NOTIMPL; }
+
+    };
+    FakeModuleBase fake;
+
+    auto peek_module_ref_count = []()
+    {
+        return ::Microsoft::WRL::GetModuleBase()->GetObjectCount();
+    };
+
+    auto initial = peek_module_ref_count();
+    {
+        auto module_ref = wil::wrl_module_reference();
+        REQUIRE(peek_module_ref_count() == initial + 1);
+    }
+    REQUIRE(peek_module_ref_count() == initial);
+}
+#endif
+
 #pragma warning(pop)


### PR DESCRIPTION
 `wrl_module_reference` and `winrt_module_reference` hold a reference to the host WRL or C++/WinRT module to prevent it from being unloaded. Normally, the reference is held implicitly because you are a member function of a DLL-hosted COM object, or because you are a coroutine that returns IAsyncAction (or similar), or because you retain a strong reference to some DLL-hosted object. But if those do not apply to you then you will need to hold a reference explicitly.

Examples in comments.

WARNING: If `wrl_module_reference` is used from a module that does not use WRL factories, it will have no effect. This is expected if used from an executable module, but will be surprising if used from a DLL.