### PR TITLE
Guard GetModuleHandleW to avoid problem in app partition

### DIFF
--- a/include/wil/wrl.h
+++ b/include/wil/wrl.h
@@ -102,10 +102,12 @@ namespace wil
             }
             else
             {
+#ifdef GET_MODULE_HANDLE_EX_FLAG_PIN
                 // If this assertion fails, then you are using wrl_module_reference
                 // from a DLL that does not host WRL objects, and the module reference
                 // has no effect.
                 WI_ASSERT(reinterpret_cast<HMODULE>(&__ImageBase) == GetModuleHandleW(nullptr));
+#endif
             }
         }
 


### PR DESCRIPTION
In older SDKs, GetModuleHandleW was not allowed in app partition. Sniff the `GET_MODULE_HANDLE_EX_FLAG_PIN` symbol to figure out whether it is safe to call `GetModuleHandleW` in whatever SDK version the client is using.

This fixes a problem introduced in #205 