### PR TITLE
Add "already exists" output to try_create methods for named objects (events, mutex, etc.)

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -3032,7 +3032,7 @@ namespace wil
             storage_t::reset(handle);
             return true;
         }
-        
+
         // Returns HRESULT for unique_semaphore_nothrow, void with exceptions for shared_event and unique_event
         result create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name = nullptr, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
         {

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2927,21 +2927,23 @@ namespace wil
         }
 
         // Tries to create a named mutex -- returns false if unable to do so (gle may still be inspected with return=false)
-        bool try_create(_In_opt_ PCWSTR name, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr)
+        bool try_create(_In_opt_ PCWSTR name, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
         {
             auto handle = ::CreateMutexExW(pMutexAttributes, name, dwFlags, desiredAccess);
             if (handle == nullptr)
             {
+                assign_to_opt_param(pAlreadyExists, false);
                 return false;
             }
+            assign_to_opt_param(pAlreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
             storage_t::reset(handle);
             return true;
         }
 
         // Returns HRESULT for unique_mutex_nothrow, void with exceptions for shared_mutex and unique_mutex
-        result create(_In_opt_ PCWSTR name = nullptr, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr)
+        result create(_In_opt_ PCWSTR name = nullptr, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
         {
-            return err_policy::LastErrorIfFalse(try_create(name, dwFlags, desiredAccess, pMutexAttributes));
+            return err_policy::LastErrorIfFalse(try_create(name, dwFlags, desiredAccess, pMutexAttributes, pAlreadyExists));
         }
 
         // Tries to open a named mutex -- returns false if unable to do so (gle may still be inspected with return=false)
@@ -3018,21 +3020,23 @@ namespace wil
         }
 
         // Tries to create a named event -- returns false if unable to do so (gle may still be inspected with return=false)
-        bool try_create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr)
+        bool try_create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
         {
             auto handle = ::CreateSemaphoreExW(pSemaphoreAttributes, lInitialCount, lMaximumCount, name, 0, desiredAccess);
             if (handle == nullptr)
             {
+                assign_to_opt_param(pAlreadyExists, false);
                 return false;
             }
+            assign_to_opt_param(pAlreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
             storage_t::reset(handle);
             return true;
         }
-
+        
         // Returns HRESULT for unique_semaphore_nothrow, void with exceptions for shared_event and unique_event
-        result create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name = nullptr, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr)
+        result create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name = nullptr, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
         {
-            return err_policy::LastErrorIfFalse(try_create(lInitialCount, lMaximumCount, name, desiredAccess, pSemaphoreAttributes));
+            return err_policy::LastErrorIfFalse(try_create(lInitialCount, lMaximumCount, name, desiredAccess, pSemaphoreAttributes, pAlreadyExists));
         }
 
         // Tries to open the named semaphore -- returns false if unable to do so (gle may still be inspected with return=false)

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2927,23 +2927,25 @@ namespace wil
         }
 
         // Tries to create a named mutex -- returns false if unable to do so (gle may still be inspected with return=false)
-        bool try_create(_In_opt_ PCWSTR name, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        bool try_create(_In_opt_ PCWSTR name, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS,
+                        _In_opt_ PSECURITY_ATTRIBUTES mutexAttributes = nullptr, _Out_opt_ bool* alreadyExists = nullptr)
         {
-            auto handle = ::CreateMutexExW(pMutexAttributes, name, dwFlags, desiredAccess);
+            auto handle = ::CreateMutexExW(mutexAttributes, name, dwFlags, desiredAccess);
             if (handle == nullptr)
             {
-                assign_to_opt_param(pAlreadyExists, false);
+                assign_to_opt_param(alreadyExists, false);
                 return false;
             }
-            assign_to_opt_param(pAlreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
+            assign_to_opt_param(alreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
             storage_t::reset(handle);
             return true;
         }
 
         // Returns HRESULT for unique_mutex_nothrow, void with exceptions for shared_mutex and unique_mutex
-        result create(_In_opt_ PCWSTR name = nullptr, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pMutexAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        result create(_In_opt_ PCWSTR name = nullptr, DWORD dwFlags = 0, DWORD desiredAccess = MUTEX_ALL_ACCESS,
+                      _In_opt_ PSECURITY_ATTRIBUTES mutexAttributes = nullptr, _Out_opt_ bool* alreadyExists = nullptr)
         {
-            return err_policy::LastErrorIfFalse(try_create(name, dwFlags, desiredAccess, pMutexAttributes, pAlreadyExists));
+            return err_policy::LastErrorIfFalse(try_create(name, dwFlags, desiredAccess, mutexAttributes, alreadyExists));
         }
 
         // Tries to open a named mutex -- returns false if unable to do so (gle may still be inspected with return=false)

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2667,23 +2667,23 @@ namespace wil
         }
 
         // Tries to create a named event -- returns false if unable to do so (gle may still be inspected with return=false)
-        bool try_create(EventOptions options, PCWSTR name, _In_opt_ LPSECURITY_ATTRIBUTES pSecurity = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        bool try_create(EventOptions options, PCWSTR name, _In_opt_ LPSECURITY_ATTRIBUTES securityAttributes = nullptr, _Out_opt_ bool *alreadyExists = nullptr)
         {
-            auto handle = ::CreateEventExW(pSecurity, name, (WI_IsFlagSet(options, EventOptions::ManualReset) ? CREATE_EVENT_MANUAL_RESET : 0) | (WI_IsFlagSet(options, EventOptions::Signaled) ? CREATE_EVENT_INITIAL_SET : 0), EVENT_ALL_ACCESS);
+            auto handle = ::CreateEventExW(securityAttributes, name, (WI_IsFlagSet(options, EventOptions::ManualReset) ? CREATE_EVENT_MANUAL_RESET : 0) | (WI_IsFlagSet(options, EventOptions::Signaled) ? CREATE_EVENT_INITIAL_SET : 0), EVENT_ALL_ACCESS);
             if (!handle)
             {
-                assign_to_opt_param(pAlreadyExists, false);
+                assign_to_opt_param(alreadyExists, false);
                 return false;
             }
-            assign_to_opt_param(pAlreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
+            assign_to_opt_param(alreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
             storage_t::reset(handle);
             return true;
         }
 
         // Returns HRESULT for unique_event_nothrow, void with exceptions for shared_event and unique_event
-        result create(EventOptions options = EventOptions::None, PCWSTR name = nullptr, _In_opt_ LPSECURITY_ATTRIBUTES pSecurity = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        result create(EventOptions options = EventOptions::None, PCWSTR name = nullptr, _In_opt_ LPSECURITY_ATTRIBUTES securityAttributes = nullptr, _Out_opt_ bool *alreadyExists = nullptr)
         {
-            return err_policy::LastErrorIfFalse(try_create(options, name, pSecurity, pAlreadyExists));
+            return err_policy::LastErrorIfFalse(try_create(options, name, securityAttributes, alreadyExists));
         }
 
         // Tries to open the named event -- returns false if unable to do so (gle may still be inspected with return=false)
@@ -3022,23 +3022,23 @@ namespace wil
         }
 
         // Tries to create a named event -- returns false if unable to do so (gle may still be inspected with return=false)
-        bool try_create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        bool try_create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *alreadyExists = nullptr)
         {
             auto handle = ::CreateSemaphoreExW(pSemaphoreAttributes, lInitialCount, lMaximumCount, name, 0, desiredAccess);
             if (handle == nullptr)
             {
-                assign_to_opt_param(pAlreadyExists, false);
+                assign_to_opt_param(alreadyExists, false);
                 return false;
             }
-            assign_to_opt_param(pAlreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
+            assign_to_opt_param(alreadyExists, (::GetLastError() == ERROR_ALREADY_EXISTS));
             storage_t::reset(handle);
             return true;
         }
 
         // Returns HRESULT for unique_semaphore_nothrow, void with exceptions for shared_event and unique_event
-        result create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name = nullptr, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *pAlreadyExists = nullptr)
+        result create(LONG lInitialCount, LONG lMaximumCount, _In_opt_ PCWSTR name = nullptr, DWORD desiredAccess = SEMAPHORE_ALL_ACCESS, _In_opt_ PSECURITY_ATTRIBUTES pSemaphoreAttributes = nullptr, _Out_opt_ bool *alreadyExists = nullptr)
         {
-            return err_policy::LastErrorIfFalse(try_create(lInitialCount, lMaximumCount, name, desiredAccess, pSemaphoreAttributes, pAlreadyExists));
+            return err_policy::LastErrorIfFalse(try_create(lInitialCount, lMaximumCount, name, desiredAccess, pSemaphoreAttributes, alreadyExists));
         }
 
         // Tries to open the named semaphore -- returns false if unable to do so (gle may still be inspected with return=false)

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -228,7 +228,7 @@ namespace test
                 return;
             }
 
-            auto background = [](auto mode, auto handler) ->winrt::fire_and_forget
+            std::ignore = [](auto mode, auto handler) ->winrt::fire_and_forget
             {
                 co_await winrt::resume_background();
                 if (mode == TestDispatcherMode::Dispatch)
@@ -255,6 +255,7 @@ TEST_CASE("CppWinRTTests::ResumeForegroundTests", "[cppwinrt]")
 {
     // Verify that the DispatcherQueue version has been unlocked.
     using Verify = decltype(wil::resume_foreground(winrt::Windows::System::DispatcherQueue{ nullptr }));
+    static_assert(wistd::is_trivial_v<Verify> || !wistd::is_trivial_v<Verify>);
 
     []() -> winrt::Windows::Foundation::IAsyncAction
     {

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1478,15 +1478,17 @@ TEST_CASE("WindowsInternalTests::HandleWrappers", "[resource][unique_any]")
     wil::unique_event_nothrow testEventNoExcept;
     REQUIRE(SUCCEEDED(testEventNoExcept.create(wil::EventOptions::ManualReset)));
 
-
     MutexTestCommon<wil::unique_mutex_nothrow>();
     MutexTestCommon<wil::unique_mutex_failfast>();
+    MutexRaiiTest<wil::unique_mutex_nothrow>();
+    MutexRaiiTest<wil::unique_mutex_failfast>();
 
     // intentionally disabled in the non-exception version...
     // wil::unique_mutex_nothrow testMutex2(L"FOO-TEST-2");
     wil::unique_mutex_failfast testMutex3(L"FOO-TEST-3");
 #ifdef WIL_ENABLE_EXCEPTIONS
     MutexTestCommon<wil::unique_mutex>();
+    MutexRaiiTest<wil::unique_mutex>();
 
     wil::unique_mutex testMutex(L"FOO-TEST");
     WaitForSingleObjectEx(testMutex.get(), INFINITE, TRUE);
@@ -1505,12 +1507,15 @@ TEST_CASE("WindowsInternalTests::HandleWrappers", "[resource][unique_any]")
 
     SemaphoreTestCommon<wil::unique_semaphore_nothrow>();
     SemaphoreTestCommon<wil::unique_semaphore_failfast>();
+    SemaphoreRaiiTest<wil::unique_semaphore_nothrow>();
+    SemaphoreRaiiTest<wil::unique_semaphore_failfast>();
 
     // intentionally disabled in the non-exception version...
     // wil::unique_semaphore_nothrow testSemaphore2(1, 1);
     wil::unique_semaphore_failfast testSemaphore3(1, 1);
 #ifdef WIL_ENABLE_EXCEPTIONS
     SemaphoreTestCommon<wil::unique_semaphore>();
+    SemaphoreRaiiTest<wil::unique_semaphore>();
 
     wil::unique_semaphore testSemaphore(1, 1);
     WaitForSingleObjectEx(testSemaphore.get(), INFINITE, true);
@@ -2239,6 +2244,62 @@ void EventRaiiTests()
     REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
     REQUIRE(::GetLastError() != ERROR_SUCCESS);
     REQUIRE(var4.try_open(L"wiltestevent"));
+}
+
+template <typename test_t>
+void MutexRaiiTests()
+{
+    test_t var1;
+    var1.create();
+
+    {
+        REQUIRE(var1.acquire());
+    }
+
+    // try_create
+    bool exists = false;
+    REQUIRE(var1.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE_FALSE(exists);
+    test_t var2;
+    REQUIRE(var2.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(exists);
+    test_t var3;
+    REQUIRE_FALSE(var3.try_create(L"\\illegal\\chars\\too\\\\many\\\\namespaces", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+
+    // try_open
+    test_t var4;
+    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+    REQUIRE(var4.try_open(L"wiltestmutex"));
+}
+
+template <typename test_t>
+void SemaphoreRaiiTests()
+{
+    test_t var1;
+    var1.create(1, 1);
+
+    {
+        REQUIRE(var1.acquire());
+    }
+
+    // try_create
+    bool exists = false;
+    REQUIRE(var1.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE_FALSE(exists);
+    test_t var2;
+    REQUIRE(var2.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(exists);
+    test_t var3;
+    REQUIRE_FALSE(var3.try_create(1, 1, L"\\illegal\\chars\\too\\\\many\\\\namespaces", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+
+    // try_open
+    test_t var4;
+    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+    REQUIRE(var4.try_open(L"wiltestsemaphore"));
 }
 
 void EventTests()

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1480,15 +1480,15 @@ TEST_CASE("WindowsInternalTests::HandleWrappers", "[resource][unique_any]")
 
     MutexTestCommon<wil::unique_mutex_nothrow>();
     MutexTestCommon<wil::unique_mutex_failfast>();
-    MutexRaiiTest<wil::unique_mutex_nothrow>();
-    MutexRaiiTest<wil::unique_mutex_failfast>();
+    MutexRaiiTests<wil::unique_mutex_nothrow>();
+    MutexRaiiTests<wil::unique_mutex_failfast>();
 
     // intentionally disabled in the non-exception version...
     // wil::unique_mutex_nothrow testMutex2(L"FOO-TEST-2");
     wil::unique_mutex_failfast testMutex3(L"FOO-TEST-3");
 #ifdef WIL_ENABLE_EXCEPTIONS
     MutexTestCommon<wil::unique_mutex>();
-    MutexRaiiTest<wil::unique_mutex>();
+    MutexRaiiTests<wil::unique_mutex>();
 
     wil::unique_mutex testMutex(L"FOO-TEST");
     WaitForSingleObjectEx(testMutex.get(), INFINITE, TRUE);
@@ -1507,15 +1507,15 @@ TEST_CASE("WindowsInternalTests::HandleWrappers", "[resource][unique_any]")
 
     SemaphoreTestCommon<wil::unique_semaphore_nothrow>();
     SemaphoreTestCommon<wil::unique_semaphore_failfast>();
-    SemaphoreRaiiTest<wil::unique_semaphore_nothrow>();
-    SemaphoreRaiiTest<wil::unique_semaphore_failfast>();
+    SemaphoreRaiiTests<wil::unique_semaphore_nothrow>();
+    SemaphoreRaiiTests<wil::unique_semaphore_failfast>();
 
     // intentionally disabled in the non-exception version...
     // wil::unique_semaphore_nothrow testSemaphore2(1, 1);
     wil::unique_semaphore_failfast testSemaphore3(1, 1);
 #ifdef WIL_ENABLE_EXCEPTIONS
     SemaphoreTestCommon<wil::unique_semaphore>();
-    SemaphoreRaiiTest<wil::unique_semaphore>();
+    SemaphoreRaiiTests<wil::unique_semaphore>();
 
     wil::unique_semaphore testSemaphore(1, 1);
     WaitForSingleObjectEx(testSemaphore.get(), INFINITE, true);

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1445,6 +1445,62 @@ void SemaphoreTestCommon()
     REQUIRE(eManual.try_open(L"BAR-TEST"));
 }
 
+template <typename test_t>
+void MutexRaiiTests()
+{
+    test_t var1;
+    var1.create();
+
+    {
+        REQUIRE(var1.acquire());
+    }
+
+    // try_create
+    bool exists = false;
+    REQUIRE(var1.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE_FALSE(exists);
+    test_t var2;
+    REQUIRE(var2.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(exists);
+    test_t var3;
+    REQUIRE_FALSE(var3.try_create(L"\\illegal\\chars\\too\\\\many\\\\namespaces", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+
+    // try_open
+    test_t var4;
+    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+    REQUIRE(var4.try_open(L"wiltestmutex"));
+}
+
+template <typename test_t>
+void SemaphoreRaiiTests()
+{
+    test_t var1;
+    var1.create(1, 1);
+
+    {
+        REQUIRE(var1.acquire());
+    }
+
+    // try_create
+    bool exists = false;
+    REQUIRE(var1.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE_FALSE(exists);
+    test_t var2;
+    REQUIRE(var2.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(exists);
+    test_t var3;
+    REQUIRE_FALSE(var3.try_create(1, 1, L"\\illegal\\chars\\too\\\\many\\\\namespaces", MUTEX_ALL_ACCESS, nullptr, &exists));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+
+    // try_open
+    test_t var4;
+    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
+    REQUIRE(::GetLastError() != ERROR_SUCCESS);
+    REQUIRE(var4.try_open(L"wiltestsemaphore"));
+}
+
 TEST_CASE("WindowsInternalTests::HandleWrappers", "[resource][unique_any]")
 {
     EventTestCommon<wil::unique_event_nothrow>();
@@ -2244,62 +2300,6 @@ void EventRaiiTests()
     REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
     REQUIRE(::GetLastError() != ERROR_SUCCESS);
     REQUIRE(var4.try_open(L"wiltestevent"));
-}
-
-template <typename test_t>
-void MutexRaiiTests()
-{
-    test_t var1;
-    var1.create();
-
-    {
-        REQUIRE(var1.acquire());
-    }
-
-    // try_create
-    bool exists = false;
-    REQUIRE(var1.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE_FALSE(exists);
-    test_t var2;
-    REQUIRE(var2.try_create(L"wiltestmutex", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE(exists);
-    test_t var3;
-    REQUIRE_FALSE(var3.try_create(L"\\illegal\\chars\\too\\\\many\\\\namespaces", 0, MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE(::GetLastError() != ERROR_SUCCESS);
-
-    // try_open
-    test_t var4;
-    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
-    REQUIRE(::GetLastError() != ERROR_SUCCESS);
-    REQUIRE(var4.try_open(L"wiltestmutex"));
-}
-
-template <typename test_t>
-void SemaphoreRaiiTests()
-{
-    test_t var1;
-    var1.create(1, 1);
-
-    {
-        REQUIRE(var1.acquire());
-    }
-
-    // try_create
-    bool exists = false;
-    REQUIRE(var1.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE_FALSE(exists);
-    test_t var2;
-    REQUIRE(var2.try_create(1, 1, L"wiltestsemaphore", MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE(exists);
-    test_t var3;
-    REQUIRE_FALSE(var3.try_create(1, 1, L"\\illegal\\chars\\too\\\\many\\\\namespaces", MUTEX_ALL_ACCESS, nullptr, &exists));
-    REQUIRE(::GetLastError() != ERROR_SUCCESS);
-
-    // try_open
-    test_t var4;
-    REQUIRE_FALSE(var4.try_open(L"\\illegal\\chars\\too\\\\many\\\\namespaces"));
-    REQUIRE(::GetLastError() != ERROR_SUCCESS);
-    REQUIRE(var4.try_open(L"wiltestsemaphore"));
 }
 
 void EventTests()


### PR DESCRIPTION
Fixes #229