### PR TITLE
Add enum_iterator type

### DIFF
--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -119,7 +119,7 @@ namespace wistd {
     }
     template<typename TEnum>
     constexpr auto end(TEnum*) {
-        return wil::enum_iterator<TEnum>::template end();
+        return wil::enum_iterator<TEnum>::end();
     }
 }
 

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -38,7 +38,10 @@ namespace wil {
         template<typename F> struct FunctionTraits;
 
         template<typename T, typename Arg>
-        struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*)>
+        using Next_t = HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*);
+
+        template<typename T, typename Arg>
+        struct FunctionTraits<Next_t<T, Arg>>
             : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
         {};
 

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -43,7 +43,7 @@ namespace wil {
         {};
 
         template<typename TEnum>
-        using NextArgType = typename Details::FunctionTraits<decltype(&TEnum::template Next)>::template NthArg<1>;
+        using NextArgType = typename Details::FunctionTraits<decltype(&TEnum::Next)>::template NthArg<1>;
     }
 
     template<typename TEnum>

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -36,12 +36,9 @@ namespace wil {
         };
 
         template<typename F> struct FunctionTraits;
-
+        
         template<typename T, typename Arg>
-        using Next_t = HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*);
-
-        template<typename T, typename Arg>
-        struct FunctionTraits<Next_t<T, Arg>>
+        struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*) noexcept>
             : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
         {};
 

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -1,0 +1,128 @@
+//*********************************************************
+//
+//    Copyright (c) Microsoft. All rights reserved.
+//    This code is licensed under the MIT License.
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+//    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+//    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//    PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//
+//*********************************************************
+#ifndef __WIL_ENUM_ITERATOR
+#define __WIL_ENUM_ITERATOR
+
+#include "com.h"
+#include "result_macros.h"
+#include <type_traits>
+#include <tuple>
+
+
+#include <type_traits>
+#include <tuple>
+#include <cstdio>
+
+namespace wil {
+
+    namespace Details {
+        template<typename R, typename T, typename... Args>
+        struct FunctionTraitsBase
+        {
+            using RetType = R;
+            using Type = T;
+            using ArgTypes = std::tuple<Args...>;
+            static constexpr std::size_t ArgCount = sizeof...(Args);
+            template<std::size_t N>
+            using NthArg = std::tuple_element_t<N, ArgTypes>;
+        };
+
+        template<typename F> struct FunctionTraits;
+
+        template<typename T, typename Arg>
+        struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*)>
+            : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
+        {};
+
+        template<typename TEnum>
+        using NextArgType = typename Details::FunctionTraits<decltype(&TEnum::template Next)>::template NthArg<1>;
+
+        
+    }
+
+    template<typename TEnum>
+    /// <summary>
+    /// Iterator class for iterating through types that implement the IEnum* COM pattern.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumerator type, e.g. IEnumIDList, IDiaEnumSymbols.</typeparam>
+    struct enum_iterator{
+        enum_iterator(const enum_iterator& other) = default;
+        enum_iterator(TEnum* pEnum) : m_pEnum(pEnum) {
+            (*this)++;
+        }
+        /// <summary>
+        /// The type of the out parameter in Next(...) that corresponds to the element type being enumerated.
+        /// e.g. PITEMID_CHILD, IDiaSymbol, etc.
+        /// </summary>
+        using TElem = Details::NextArgType<TEnum>;
+        ~enum_iterator() = default;
+
+        auto& operator++(int) { return this->operator++(); }
+        auto& operator++() {
+            TElem* pChild{ nullptr };
+            ULONG celt = 0;
+            auto hr = m_pEnum->Next(1, &pChild, &celt);
+            if (hr == S_OK && celt == 1) {
+                m_current = pChild;
+            }
+            else if (hr == S_FALSE) {
+                m_end = true;
+            }
+            else {
+                THROW_HR(hr);
+            }
+            return *this;
+        }
+
+        TElem* const& operator*() const noexcept { return m_current; }
+        TElem* operator->() const noexcept { return m_current; }
+
+        auto operator+(int v) {
+            auto other = *this;
+            for (int i = 0; i < v; i++) {
+                other++;
+            }
+            return other;
+        }
+
+        bool operator==(const enum_iterator& o) const noexcept {
+            if (m_end ^ o.m_end) return false;
+            if (m_end == o.m_end && m_end == true) return true;
+            return o.m_current == this->m_current && o.m_pEnum == m_pEnum && m_end == o.m_end;
+        }
+
+        bool operator!=(const enum_iterator& o) const noexcept { return !(*this == o); }
+
+        static constexpr auto end() noexcept {
+            return enum_iterator{ end_tag{} };
+        }
+    protected:
+        struct end_tag {};
+        enum_iterator(end_tag) : m_end(true) {}
+        enum_iterator() {};
+        wil::com_ptr<TEnum> m_pEnum{ nullptr };
+        TElem* m_current{ nullptr };
+        bool m_end{ false };
+    };
+}
+
+namespace wistd {
+    template<typename TEnum>
+    auto begin(TEnum* pEnum) {
+        return wil::enum_iterator<TEnum>(pEnum);
+    }
+    template<typename TEnum>
+    constexpr auto end(TEnum*) {
+        return wil::enum_iterator<TEnum>::template end();
+    }
+}
+
+#endif

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -38,9 +38,16 @@ namespace wil {
         template<typename F> struct FunctionTraits;
         
         template<typename T, typename Arg>
+        struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*)>
+            : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
+        {};
+
+#ifdef __cpp_noexcept_function_type
+        template<typename T, typename Arg>
         struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*) noexcept>
             : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
         {};
+#endif
 
         template<typename TEnum>
         using NextArgType = typename Details::FunctionTraits<decltype(&TEnum::Next)>::template NthArg<1>;

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -16,14 +16,14 @@
 #include <type_traits>
 #include <tuple>
 
-
 #include <type_traits>
 #include <tuple>
 #include <cstdio>
 
-namespace wil {
-
-    namespace Details {
+namespace wil
+{
+    namespace Details
+    {
         template<typename R, typename T, typename... Args>
         struct FunctionTraitsBase
         {
@@ -36,7 +36,7 @@ namespace wil {
         };
 
         template<typename F> struct FunctionTraits;
-        
+
         template<typename T, typename Arg>
         struct FunctionTraits<HRESULT(__stdcall T::*)(ULONG, Arg**, ULONG*)>
             : FunctionTraitsBase<HRESULT, T, ULONG, Arg, ULONG*>
@@ -58,9 +58,11 @@ namespace wil {
     /// Iterator class for iterating through types that implement the IEnum* COM pattern.
     /// </summary>
     /// <typeparam name="TEnum">The enumerator type, e.g. IEnumIDList, IDiaEnumSymbols.</typeparam>
-    struct enum_iterator{
+    struct enum_iterator
+    {
         enum_iterator(const enum_iterator& other) = default;
-        enum_iterator(TEnum* pEnum) : m_pEnum(pEnum) {
+        enum_iterator(TEnum* pEnum) : m_pEnum(pEnum)
+        {
             (*this)++;
         }
         /// <summary>
@@ -71,17 +73,21 @@ namespace wil {
         ~enum_iterator() = default;
 
         auto& operator++(int) { return this->operator++(); }
-        auto& operator++() {
+        auto& operator++()
+        {
             TElem* pChild{ nullptr };
             ULONG celt = 0;
             auto hr = m_pEnum->Next(1, &pChild, &celt);
-            if (hr == S_OK && celt == 1) {
+            if ((hr == S_OK) && (celt == 1))
+            {
                 m_current = pChild;
             }
-            else if (hr == S_FALSE) {
+            else if (hr == S_FALSE)
+            {
                 m_end = true;
             }
-            else {
+            else
+            {
                 THROW_HR(hr);
             }
             return *this;
@@ -90,23 +96,27 @@ namespace wil {
         TElem* const& operator*() const noexcept { return m_current; }
         TElem* operator->() const noexcept { return m_current; }
 
-        auto operator+(int v) {
+        auto operator+(int v)
+        {
             auto other = *this;
-            for (int i = 0; i < v; i++) {
+            for (int i = 0; i < v; i++)
+            {
                 other++;
             }
             return other;
         }
 
-        bool operator==(const enum_iterator& o) const noexcept {
+        bool operator==(const enum_iterator& o) const noexcept
+        {
             if (m_end ^ o.m_end) return false;
-            if (m_end == o.m_end && m_end == true) return true;
-            return o.m_current == this->m_current && o.m_pEnum == m_pEnum && m_end == o.m_end;
+            if ((m_end == o.m_end) && m_end) return true;
+            return (o.m_current == this->m_current) && (o.m_pEnum == m_pEnum) && (m_end == o.m_end);
         }
 
         bool operator!=(const enum_iterator& o) const noexcept { return !(*this == o); }
 
-        static constexpr auto end() noexcept {
+        static constexpr auto end() noexcept
+        {
             return enum_iterator{ end_tag{} };
         }
     protected:
@@ -119,13 +129,16 @@ namespace wil {
     };
 }
 
-namespace wistd {
+namespace wistd
+{
     template<typename TEnum>
-    auto begin(TEnum* pEnum) {
+    auto begin(TEnum* pEnum)
+    {
         return wil::enum_iterator<TEnum>(pEnum);
     }
     template<typename TEnum>
-    constexpr auto end(TEnum*) {
+    constexpr auto end(TEnum*)
+    {
         return wil::enum_iterator<TEnum>::end();
     }
 }

--- a/include/wil/enum_iterator.h
+++ b/include/wil/enum_iterator.h
@@ -44,8 +44,6 @@ namespace wil {
 
         template<typename TEnum>
         using NextArgType = typename Details::FunctionTraits<decltype(&TEnum::template Next)>::template NthArg<1>;
-
-        
     }
 
     template<typename TEnum>

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -46,7 +46,7 @@ namespace wil
     //! to that value when it is destroyed.
     //!
     //! This is useful in library code that runs during a value's destructor. If the library code could
-    //! inadvertantly change the value of GetLastError (by calling a Win32 API or similar), it should
+    //! inadvertently change the value of GetLastError (by calling a Win32 API or similar), it should
     //! instantiate a value of this type before calling the library function in order to preserve the
     //! GetLastError value the user would expect.
     //!
@@ -624,14 +624,14 @@ namespace wil
     namespace details
     {
         // The first two attach_to_smart_pointer() overloads are ambiguous when passed a com_ptr_t.
-        // To solve that use this functions return type to elminate the reset form for com_ptr_t.
+        // To solve that use this functions return type to eliminate the reset form for com_ptr_t.
         template <typename T, typename err> wistd::false_type use_reset(wil::com_ptr_t<T, err>*) { return wistd::false_type(); }
         template <typename T> wistd::true_type use_reset(T*) { return wistd::true_type(); }
     }
     /// @endcond
 
     /** Generically attach a raw pointer to a compatible smart pointer.
-    Calls the correct reset(), attach(), or Attach() method based on samrt pointer type. */
+    Calls the correct reset(), attach(), or Attach() method based on smart pointer type. */
     template <typename TSmartPointer, typename EnableResetForm = wistd::enable_if_t<decltype(details::use_reset(static_cast<TSmartPointer*>(nullptr)))::value>>
     void attach_to_smart_pointer(TSmartPointer& smartPtr, typename TSmartPointer::pointer rawPtr)
     {
@@ -762,7 +762,7 @@ namespace wil
     }
 
     /** Use to retrieve raw out parameter pointers (with a required cast) into smart pointers that do not support the '&' operator.
-    Use only when the smart pointer's &handle is not equal to the output type a function requries, necessitating a cast.
+    Use only when the smart pointer's &handle is not equal to the output type a function requires, necessitating a cast.
     Example: `wil::out_param_ptr<PSECURITY_DESCRIPTOR*>(securityDescriptor)` */
     template <typename Tcast, typename T>
     details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p)
@@ -916,7 +916,7 @@ namespace wil
     };
 
     /** unique_any_array_ptr is a RAII type for managing conformant arrays that need to be freed and have elements that may need to be freed.
-    The intented use for this RAII type would be to capture out params from API like IPropertyValue::GetStringArray.
+    The intended use for this RAII type would be to capture out params from API like IPropertyValue::GetStringArray.
     This class also maintains the size of the array, so it can iterate over the members and deallocate them before it deallocates the base array pointer.
 
     If the type you're wrapping is a system type, you can share the code by declaring it in this file (Resource.h). Send requests to wildisc.
@@ -2441,7 +2441,7 @@ namespace wil
         };
 
         // SetThreadpoolTimer(timer, nullptr, 0, 0) will cancel any pending callbacks,
-        // then CloseThreadpoolTimer will asynchronusly close the timer if a callback is running.
+        // then CloseThreadpoolTimer will asynchronously close the timer if a callback is running.
         template <typename threadpool_t, PendingCallbackCancellationBehavior cancellationBehavior>
         struct DestroyThreadPoolTimer
         {

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -2908,6 +2908,18 @@ private:
 };
 
 
+TEST_CASE("COM type traits", "[com][IsCOM]")
+{
+    static_assert(wil::Details::has_AddRef_v<IUnknown>);
+    static_assert(!wil::Details::has_AddRef_v<IUnknown*>);
+    static_assert(!wil::Details::has_AddRef_v<int>);
+    static_assert(wil::Details::has_AddRef_v<IFakeEnum_COM<1>>);
+    static_assert(wil::Details::has_AddRef_v<IFakeEnum_NonCOM<1>>);
+
+    static_assert(std::is_same_v<wil::enum_iterator<IFakeEnum_COM<1>>::TElem, wil::com_ptr<IFakeItem>>);
+    static_assert(std::is_same_v<wil::enum_iterator<IFakeEnum_NonCOM<1>>::TElem, int*>);
+}
+
 TEST_CASE("EnumForLoop", "[com][IEnumXyz]")
 {
     SECTION("IEnum* that iterates over COM objects; for loop")
@@ -2986,21 +2998,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
         }
     }
 
-    SECTION("IEnum* that iterates over non-smart pointer COM objects; for_each")
-    {
-        IFakeItem::s_id = 0;
-        {
-            IFakeEnum_COM<3> fakeEnum;
-
-            auto i = 0;
-            std::for_each(wistd::begin(&fakeEnum), wistd::end(&fakeEnum), [&i](IFakeItem* element) {
-                REQUIRE(element->m_id == i);
-                i++;
-                });
-            REQUIRE(i == fakeEnum.NumberOfItems());
-        }
-    }
-
     SECTION("IEnum* that iterates over smart pointer COM objects; for_each")
     {
         IFakeItem::s_id = 0;
@@ -3029,5 +3026,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
         REQUIRE(i == fakeEnum.NumberOfItems());
     }
 }
+
 
 #endif

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3042,5 +3042,4 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
     }
 }
 
-
 #endif

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -2915,8 +2915,6 @@ TEST_CASE("EnumForLoop", "[com][IEnumXyz]")
         IFakeEnum_COM<3> fakeEnum;
 
         auto i = 0;
-        using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
         for (auto it = wistd::begin(&fakeEnum); it != wistd::end(&fakeEnum); it++) {
             if (i < fakeEnum.NumberOfItems() - 1) {
                 const auto& c = fakeEnum.Current(); // already advanced past the iterator
@@ -2935,8 +2933,6 @@ TEST_CASE("EnumForLoop", "[com][IEnumXyz]")
             IFakeEnum_NonCOM<3> fakeEnum;
 
             auto i = 0;
-            using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
             for (auto it = wistd::begin(&fakeEnum); it != wistd::end(&fakeEnum); it++) {
                 REQUIRE(**it == i); // the iterator captured the enumerator's previous value
                 i++;
@@ -2982,8 +2978,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
             IFakeEnum_COM<3> fakeEnum;
 
             auto i = 0;
-            using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
             std::for_each(wistd::begin(&fakeEnum), wistd::end(&fakeEnum), [&i](wil::com_ptr<IFakeItem> element) {
                 REQUIRE(element->m_id == i);
                 i++;
@@ -2999,8 +2993,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
             IFakeEnum_COM<3> fakeEnum;
 
             auto i = 0;
-            using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
             std::for_each(wistd::begin(&fakeEnum), wistd::end(&fakeEnum), [&i](IFakeItem* element) {
                 REQUIRE(element->m_id == i);
                 i++;
@@ -3016,8 +3008,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
             IFakeEnum_COM<3> fakeEnum;
 
             auto i = 0;
-            using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
             std::for_each(wistd::begin(&fakeEnum), wistd::end(&fakeEnum), [&i](wil::com_ptr<IFakeItem> element) {
                 REQUIRE(element->m_id == i);
                 i++;
@@ -3031,8 +3021,6 @@ TEST_CASE("EnumForEach", "[com][IEnumXyz]")
         IFakeEnum_NonCOM<3> fakeEnum;
 
         auto i = 0;
-        using iterator_type = wil::enum_iterator<decltype(fakeEnum)>;
-
         std::for_each(fakeEnum.begin(), fakeEnum.end(), [&i](const int* element) {
             REQUIRE(*element == i);
             i++;


### PR DESCRIPTION
This change adds an `enum_iterator` type which allows iterating in a natural way over `IEnum`-like COM interfaces, like `IEnumIDList`, `IDiaEnumSymbols`, etc.

bonus track: also fixes a few unrelated typos