### PR TITLE
Free-and-exit should be transferable

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -531,6 +531,105 @@ namespace wil
             FreeLibraryAndExitThread(thisModule, 0);
         });
     }
+
+    struct module_reference_for_new_thread
+    {
+        bool free_on_exit = false;
+        HMODULE module_ref = nullptr;
+
+        module_reference_for_new_thread()
+        {
+            FAIL_FAST_IF(!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, L"", &module_ref));
+        }
+
+        ~module_reference_for_new_thread()
+        {
+            reset();
+        }
+
+        module_reference_for_new_thread(module_reference_for_new_thread&& other)
+        {
+            wistd::exchange(free_on_exit, other.free_on_exit);
+            wistd::exchange(module_ref, other.module_ref);
+        }
+
+        module_reference_for_new_thread& operator=(module_reference_for_new_thread&& other)
+        {
+            if (this != wistd::addressof(other))
+            {
+                reset();
+                wistd::exchange(free_on_exit, other.free_on_exit);
+                wistd::exchange(module_ref, other.module_ref);
+            }
+            return *this;
+        }
+
+        module_reference_for_new_thread(module_reference_for_new_thread const&) = delete;
+        void operator=(module_reference_for_new_thread const&) = delete;
+
+        void arm()
+        {
+            free_on_exit = true;
+        }
+
+        void disarm()
+        {
+            free_on_exit = false;
+        }
+
+        void reset()
+        {
+            if (module_ref)
+            {
+                if (free_on_exit)
+                {
+                    ::FreeLibraryAndExitThread(module_ref, 0);
+                }
+                else
+                {
+                    ::FreeLibrary(module_ref);
+                }
+            }
+
+            free_on_exit = false;
+            module_ref = nullptr;
+        }
+
+        unique_hmodule release()
+        {
+            free_on_exit = false;
+            return unique_hmodule(wistd::exchange(module_ref, nullptr));
+        }
+    };
+
+    [[nodiscard]] inline unique_handle create_thread(wistd::function<void()>&& func, DWORD* threadId = nullptr)
+    {
+        struct thread_ctx
+        {
+            wistd::function<void()> func;
+            module_reference_for_new_thread host_module;
+
+            static DWORD WINAPI ThreadProc(void* param)
+            {
+                wistd::unique_ptr<thread_ctx> self{ reinterpret_cast<thread_ctx*>(param) };
+                self->host_module.arm();
+                self->func();
+                return 0;
+            }
+        };
+
+        wistd::unique_ptr<thread_ctx> context{ new thread_ctx };
+        context->func = wistd::move(func);
+        DWORD newThreadId;
+        wil::unique_handle thread{ ::CreateThread(nullptr, 0, &thread_ctx::ThreadProc, context.get(), 0, &newThreadId) };
+        if (thread)
+        {
+            context.release(); // created thread owns it now.
+            assign_to_opt_param(threadId, newThreadId);
+        }
+
+        return thread;
+    }
 #endif
 
     /// @cond

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -3564,6 +3564,32 @@ TEST_CASE("WindowsInternalTests::VerifyModuleReferencesForThread", "[win32_helpe
     }).join();
     REQUIRE(success);
 }
+
+TEST_CASE("WindowsInternalTests::TransferableThreadExiter", "[win32_helpers]")
+{
+    // Create & destroy should not release the reference yet
+    {
+        wil::module_reference_for_new_thread ref;
+    }
+
+    // Stuff a thread reference into the lambda for the new thread, it should only clear
+    // when the thread executes
+    std::thread([self = wil::module_reference_for_new_thread()]() mutable
+    {
+        self.arm();
+    }).join();
+}
+
+TEST_CASE("WindowsInternalTests::CreateThread", "[win32_helpers]")
+{
+    bool success = false;
+    auto thread = wil::create_thread([&success] {
+        auto thread_init = wil::CoInitializeEx();
+        success = true;
+    });
+    ::WaitForSingleObject(thread.get(), INFINITE);
+    REQUIRE(success);
+}
 #endif
 
 #pragma warning(pop)


### PR DESCRIPTION
See #232 for context. Adds a type that takes a module ref from the current thread and holds it while starting up another win32 thread. While `get_module_reference_for_thread` is great if you're already on the new thread, there is a potential for a race between `CreateThread` returning and the new thread being scheduled to execute its first instructions in which the DLL backing the instructions could be unloaded.