### PR TITLE
Hide QueryUnbiasedInterruptTimeAs100ns and QueryUnbiasedInterruptTimeAsMSec when not targetting Win7

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -120,7 +120,7 @@ namespace wil
             return timeMsec * filetime_duration::one_millisecond;
         }
 
-#if defined(_APISETREALTIME_)
+#if defined(_APISETREALTIME_) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
         /// Returns the current unbiased interrupt-time count, in units of 100 nanoseconds. The unbiased interrupt-time count does not include time the system spends in sleep or hibernation.
         ///
         /// This API avoids prematurely shortcircuiting timing loops due to system sleep/hibernation.


### PR DESCRIPTION
When targetting `_WIN32_WINNT = 0x0600`, an unconditional reliance on `QueryUnbiasedInterruptTime` prevented `wil/win32_helpers.h` from compiling. This change modifies the ifdef to mirror `realtimeapiset.h`.

Since pre-Win7 targets are technically unsupported, no tests or documentation have been updated.