### PR TITLE
wil::to_array for bulk fetching of vector and iterable types

### DIFF
--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -276,7 +276,7 @@ namespace wil
         {
             using T = decltype(src.Current());
             std::vector<T> result;
-            const uint32_t chunkSize = 5;
+            const uint32_t chunkSize = 64;
             while (true)
             {
                 auto const lastSize = result.size();

--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -240,8 +240,8 @@ namespace wil
     }
     /// @endcond
 
-    /** Converts C++ / WinRT vectors, iterators, and iterables to std::vector by requesting
-    the collection's data in chunks. This can be more efficient in terms of IPC cost than
+    /** Converts C++ / WinRT vectors, iterators, and iterables to std::vector by requesting the
+    collection's data a single request. This can be more efficient in terms of IPC cost than
     iteratively processing the collection.
     ~~~
     winrt::IVector<winrt::hstring> collection = GetCollection();
@@ -253,6 +253,8 @@ namespace wil
     ~~~
     Can be used for IVector<T>, IVectorView<T>, IIterable<T>, IIterator<T>, and any type or
     interface that C++/WinRT projects those interfaces for (PropertySet, IMap<T,K>, etc.)
+    Iterable-only types fetch content in units of 64. When used with an iterator, the returned
+    vector contains the iterator's current position and any others after it.
     */ 
     template<typename TSrc> auto to_vector(TSrc const& src)
     {

--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -223,10 +223,10 @@ namespace wil
         template<typename TData, typename TSrc> std::vector<TData> to_vector_impl(TSrc&& fetcher)
         {
             std::vector<TData> output;
-            uint32_t offset = 0;
             const uint32_t chunkSize = 64;
             while (true)
             {
+                uint32_t offset = output.size();
                 output.resize(output.size() + chunkSize, winrt::impl::empty_value<TData>());
                 auto fetched = fetcher(offset, winrt::array_view<TData>{ output.data() + offset, output.data() + output.size() });
                 if (fetched < chunkSize)
@@ -234,7 +234,6 @@ namespace wil
                     output.resize(offset + fetched);
                     break;
                 }
-                offset += fetched;
             }
             return output;
         }

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -1001,9 +1001,8 @@ namespace wil
 #pragma endregion
 
 #if defined(__WI_HAS_STD_VECTOR)
-    /** Converts WinRT vectors to std::vector by requesting the collection's
-    data in chunks. This can be more efficient in terms of IPC cost than
-    iteratively processing the collection.
+    /** Converts WinRT vectors to std::vector by requesting the collection's data in a single
+    operation. This can be more efficient in terms of IPC cost than iteratively processing it.
     ~~~
     ComPtr<IVector<IPropertyValue*>> values = GetValues();
     std::vector<ComPtr<IPropertyValue>> allData = wil::to_vector(values);

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -50,7 +50,7 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
         REQUIRE(wil::to_vector(sv) == src_vector);
         REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
         REQUIRE(wil::to_vector(sv.First()) == src_vector);
-        REQUIRE(wil::to_vector<winrt::hstring, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.First()) == src_vector);
         REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<winrt::hstring>>()) == src_vector);
     }
     {
@@ -59,7 +59,7 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
         REQUIRE(wil::to_vector(sv) == src_vector);
         REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
         REQUIRE(wil::to_vector(sv.First()) == src_vector);
-        REQUIRE(wil::to_vector<uint32_t, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.First()) == src_vector);
         REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<uint32_t>>()) == src_vector);
     }
     {
@@ -67,7 +67,7 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
         auto sv = winrt::single_threaded_vector(copy_thing(src_vector));
         REQUIRE(wil::to_vector(sv) == src_vector);
         REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
-        REQUIRE(wil::to_vector<float, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.First()) == src_vector);
         REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<float>>()) == src_vector);
     }
     {

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -59,7 +59,6 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
         REQUIRE(wil::to_vector(sv) == src_vector);
         REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
         REQUIRE(wil::to_vector(sv.First()) == src_vector);
-        REQUIRE(wil::to_vector(sv.First()) == src_vector);
         REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<uint32_t>>()) == src_vector);
     }
     {
@@ -75,7 +74,29 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
         auto sm = winrt::single_threaded_map(copy_thing(src_map));
         CheckMapVector(wil::to_vector(sm), src_map);
         CheckMapVector(wil::to_vector(sm.GetView()), src_map);
-        CheckMapVector(wil::to_vector(sm), src_map);
+        CheckMapVector(wil::to_vector(sm.First()), src_map);
+    }
+    {
+        winrt::Windows::Foundation::Collections::PropertySet props;
+        props.Insert(L"kitten", winrt::box_value(L"fluffy"));
+        props.Insert(L"puppy", winrt::box_value<uint32_t>(25));
+        auto converted = wil::to_vector(props);
+        REQUIRE(converted.size() == props.Size());
+        for (auto&& kv : converted)
+        {
+            if (kv.Key() == L"kitten")
+            {
+                REQUIRE(kv.Value().as<winrt::hstring>() == L"fluffy");
+            }
+            else if (kv.Key() == L"puppy")
+            {
+                REQUIRE(kv.Value().as<uint32_t>() == 25);
+            }
+            else
+            {
+                REQUIRE(false);
+            }
+        }
     }
 }
 

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -1,6 +1,7 @@
 
 #include <wil/cppwinrt.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <wil/cppwinrt_helpers.h>
 #include <winrt/Windows.System.h>
 #include <wil/cppwinrt_helpers.h> // Verify can include a second time to unlock more features
@@ -25,6 +26,58 @@ static const HRESULT cppwinrt_mapped_hresults[] =
     HRESULT_FROM_WIN32(ERROR_CANCELLED),
     E_OUTOFMEMORY,
 };
+
+template<typename T> auto copy_thing(T const& src)
+{
+    return std::decay_t<T>(src);
+}
+
+template<typename T, typename K> 
+void CheckMapVector(std::vector<winrt::Windows::Foundation::Collections::IKeyValuePair<T, K>> const& test, std::map<T, K> const& src)
+{
+    REQUIRE(test.size() == src.size());
+    for (auto&& i : test)
+    {
+        REQUIRE(i.Value() == src.at(i.Key()));
+    }
+}
+
+TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
+{
+    {
+        std::vector<winrt::hstring> src_vector = { L"foo", L"bar", L"bas" };
+        auto sv = winrt::single_threaded_vector(copy_thing(src_vector));
+        REQUIRE(wil::to_vector(sv) == src_vector);
+        REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
+        REQUIRE(wil::to_vector(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector<winrt::hstring, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<winrt::hstring>>()) == src_vector);
+    }
+    {
+        std::vector<uint32_t> src_vector = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+        auto sv = winrt::single_threaded_vector(copy_thing(src_vector));
+        REQUIRE(wil::to_vector(sv) == src_vector);
+        REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
+        REQUIRE(wil::to_vector(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector<uint32_t, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<uint32_t>>()) == src_vector);
+    }
+    {
+        std::vector<float> src_vector;
+        auto sv = winrt::single_threaded_vector(copy_thing(src_vector));
+        REQUIRE(wil::to_vector(sv) == src_vector);
+        REQUIRE(wil::to_vector(sv.GetView()) == src_vector);
+        REQUIRE(wil::to_vector<float, 2>(sv.First()) == src_vector);
+        REQUIRE(wil::to_vector(sv.as<winrt::Windows::Foundation::Collections::IIterable<float>>()) == src_vector);
+    }
+    {
+        std::map<winrt::hstring, winrt::hstring> src_map{{L"kittens", L"fluffy"}, {L"puppies", L"cute"}};
+        auto sm = winrt::single_threaded_map(copy_thing(src_map));
+        CheckMapVector(wil::to_vector(sm), src_map);
+        CheckMapVector(wil::to_vector(sm.GetView()), src_map);
+        CheckMapVector(wil::to_vector(sm), src_map);
+    }
+}
 
 TEST_CASE("CppWinRTTests::WilToCppWinRTExceptionTranslationTest", "[cppwinrt]")
 {

--- a/tests/FakeWinRTTypes.h
+++ b/tests/FakeWinRTTypes.h
@@ -207,7 +207,7 @@ private:
     WinRTStorage<Abi> m_storage;
 };
 
-template <typename Logical, typename Abi = Logical, size_t MaxSize = 42>
+template <typename Logical, typename Abi = Logical, size_t MaxSize = 250>
 struct FakeVector : Microsoft::WRL::RuntimeClass<
     ABI::Windows::Foundation::Collections::IVector<Logical>,
     ABI::Windows::Foundation::Collections::IVectorView<Logical>>


### PR DESCRIPTION
Provides a "bulk convert collection to vector" to reduce calls when the caller intends to process the entire content of the collection, such as in a loop.  For example:

```c++
winrt::IVector<winrt::IPropertyValue> values = /* ... */
uint32_t total = 0;
for (auto&& i : values) {
    total += i.GetUInt32();
}
```

The range-for initialization uses `Size()` once.  Each step of the range-for calls `GetAt(idx)` to retrieve the next type. Even for small collections, the cost of cross-apartment calls can be significant.

The `wil::to_vector` method instead uses the `GetMany()` method available on `IVector[View]` and other collection types to retrieve the full content of the container.  When used with `IMap` or `IIterable`, it uses `IIterator::GetMany` in blocks of 64 elements to retrieve the full content.