### PR TITLE
Apply PR feedback for duck-typing of to_vector

### DIFF
--- a/cmake/common_build_flags.cmake
+++ b/cmake/common_build_flags.cmake
@@ -49,6 +49,9 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     # results through the following flags.
     append_cxx_flag("-fno-delayed-template-parsing")
 
+    # clang-cl needs this to enable _InterlockedCompareExchange128
+    append_cxx_flag("-mcx16")
+
     # NOTE: Windows headers not clean enough for us to realistically attempt to start fixing these errors yet. That
     # said, errors that originate from WIL headers may benefit
     # append_cxx_flag("-fno-ms-compatibility")

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -46,11 +46,16 @@ struct vector_like
 {
     uint32_t Size() const { return 100; }
     int GetAt(uint32_t) const { return 15; }
+
     uint32_t GetMany(uint32_t start, winrt::array_view<int> items) const
     { 
-        if (start > 0) throw winrt::hresult_out_of_bounds(); 
-        std::fill_n(items.begin(), (std::min)(items.size(), Size()), GetAt(0));
-        return Size();
+        if (start > 0)
+        {
+            throw winrt::hresult_out_of_bounds(); 
+        }
+        uint32_t const to_fill = (std::min)(items.size(), Size());
+        std::fill_n(items.begin(), to_fill, GetAt(0));
+        return to_fill;
     }
 };
 
@@ -59,6 +64,7 @@ struct iterator_like
     static const uint32_t total = 20;
     mutable uint32_t remaining = total;
     int Current() const { return 3; }
+
     uint32_t GetMany(winrt::array_view<int> items) const
     {
         auto to_copy = (std::min)(items.size(), remaining);
@@ -78,10 +84,13 @@ struct unstable_vector : winrt::implements<unstable_vector, winrt::Windows::Foun
 {
     auto Size() { return 4; }
     int GetAt(uint32_t) { return 7; }
-    uint32_t GetMany(uint32_t, winrt::array_view<int> items) { 
-        std::fill(items.begin(), items.end(), 7);
+
+    uint32_t GetMany(uint32_t, winrt::array_view<int> items) 
+    { 
+        std::fill(items.begin(), items.end(), GetAt(0));
         return items.size();
     }
+
     bool IndexOf(int, uint32_t) { throw winrt::hresult_not_implemented(); }
 };
 

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -152,6 +152,9 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
     auto vlike = wil::to_vector(vector_like{});
     REQUIRE(vlike.size() == vector_like{}.Size());
     for (auto&& i : vlike) REQUIRE(i == vector_like{}.GetAt(0));    
+
+    winrt::clear_factory_cache();
+    winrt::uninit_apartment();
 }
 
 TEST_CASE("CppWinRTTests::WilToCppWinRTExceptionTranslationTest", "[cppwinrt]")

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1846,10 +1846,13 @@ TEST_CASE("WindowsInternalTests::Locking", "[resource]")
     {
         CRITICAL_SECTION cs;
         ::InitializeCriticalSectionEx(&cs, 0, 0);
-        auto lock = wil::EnterCriticalSection(&cs);
-        REQUIRE(lock);
-        auto tryLock = wil::TryEnterCriticalSection(&cs);
-        REQUIRE(tryLock);
+        {
+            auto lock = wil::EnterCriticalSection(&cs);
+            REQUIRE(lock);
+            auto tryLock = wil::TryEnterCriticalSection(&cs);
+            REQUIRE(tryLock);
+        }
+        ::DeleteCriticalSection(&cs);
     }
     {
         wil::critical_section cs;


### PR DESCRIPTION
@oldnewthing had a great suggestion to duck-type the to_vector helper from #240 but I was too hasty.

Along the way, discovered that the test crash was due to an interaction between the malloc spy and leaking an apartment init, so added explicit init/shutdown that uses it.

And suddenly, LLVM is complaining that cppwinrt's base.h uses `_InterlockedCompareExchange128` which needs their `-mcx16` option, but which wasn't included in our common build flags.