### PR TITLE
Allow unique/shared_any_t constructor to be noexcept

### DIFF
--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -276,6 +276,36 @@ void UniqueProcessInfo()
 }
 #endif
 
+// Compilation only test...
+#ifdef WIL_ENABLE_EXCEPTIONS
+void NoexceptConstructibleTest()
+{
+    using BaseStorage = wil::details::unique_storage<wil::details::handle_resource_policy>;
+
+    struct ThrowingConstructor : BaseStorage
+    {
+        explicit ThrowingConstructor(HANDLE) __WI_NOEXCEPT_(false) {}
+    };
+
+    struct ProtectedConstructor : BaseStorage
+    {
+    protected:
+        explicit ProtectedConstructor(HANDLE) WI_NOEXCEPT {}
+    };
+
+    // wil::unique_handle is one of the many types which are expected to be noexcept
+    // constructible since they don't perform any "advanced" initialization.
+    static_assert(wistd::is_nothrow_constructible_v<wil::unique_handle, HANDLE>, "wil::unique_any_t should be noexcept if the storage is");
+
+    // The inverse: A throwing storage constructor.
+    static_assert(!wistd::is_nothrow_constructible_v<wil::unique_any_t<ThrowingConstructor>, HANDLE>, "wil::unique_any_t shouldn't be noexcept if the storage isn't");
+
+    // With a protected constructor wil::unique_any_t will be unable to correctly
+    // "forward" the noexcept attribute, but the code should still compile.
+    wil::unique_any_t<ProtectedConstructor> p{ INVALID_HANDLE_VALUE };
+}
+#endif
+
 struct FakeComInterface
 {
     void AddRef()
@@ -821,7 +851,7 @@ TEST_CASE("ComTokenDirectCloser", "[resource]")
 
 TEST_CASE("UniqueCloseClipboardCall", "[resource]")
 {
-#if defined(__WIL__WINUSER_) && !defined(NOCLIPBOARD)    
+#if defined(__WIL__WINUSER_) && !defined(NOCLIPBOARD)
     if (auto clip = wil::open_clipboard(nullptr))
     {
         REQUIRE(::EmptyClipboard());

--- a/tests/ResourceTests.cpp
+++ b/tests/ResourceTests.cpp
@@ -284,20 +284,24 @@ void NoexceptConstructibleTest()
 
     struct ThrowingConstructor : BaseStorage
     {
+        ThrowingConstructor() = default;
         explicit ThrowingConstructor(HANDLE) __WI_NOEXCEPT_(false) {}
     };
 
     struct ProtectedConstructor : BaseStorage
     {
     protected:
+        ProtectedConstructor() = default;
         explicit ProtectedConstructor(HANDLE) WI_NOEXCEPT {}
     };
 
     // wil::unique_handle is one of the many types which are expected to be noexcept
     // constructible since they don't perform any "advanced" initialization.
+    static_assert(wistd::is_nothrow_default_constructible_v<wil::unique_handle>, "wil::unique_any_t should always be nothrow default constructible");
     static_assert(wistd::is_nothrow_constructible_v<wil::unique_handle, HANDLE>, "wil::unique_any_t should be noexcept if the storage is");
 
     // The inverse: A throwing storage constructor.
+    static_assert(wistd::is_nothrow_default_constructible_v<wil::unique_any_t<ThrowingConstructor>>, "wil::unique_any_t should always be nothrow default constructible");
     static_assert(!wistd::is_nothrow_constructible_v<wil::unique_any_t<ThrowingConstructor>, HANDLE>, "wil::unique_any_t shouldn't be noexcept if the storage isn't");
 
     // With a protected constructor wil::unique_any_t will be unable to correctly


### PR DESCRIPTION
This commit allows the use of most `wil::unique_*` types in `noexcept` contexts.
Unfortunately the use of inheritance made the modification slightly more
difficult and required the `unique_storage` constructor to be made public.
But thanks to inheritance those constructors are hidden from public use
as the explicit `unique_any_t` constructors "override" the base class ones.

The `shared_any_t` (and `shared_storage`) classes can't be `noexcept`
at the time of writing as they use a `std::shared_ptr` internally
which can throw during construction. But the classes were modified anyways
just in case other kinds of (non-throwing) sharing are added in the future.

Closes #191