### PR TITLE
fix SAL annotation

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2361,7 +2361,7 @@ namespace wil
         // Non-RTL implementation for threadpool_t parameter of DestroyThreadPoolTimer<>
         struct SystemThreadPoolMethods
         {
-            static void WINAPI SetThreadpoolTimer(_Inout_ PTP_TIMER Timer, _In_opt_ PFILETIME DueTime, _In_ DWORD Period, _In_opt_ DWORD WindowLength) WI_NOEXCEPT
+            static void WINAPI SetThreadpoolTimer(_Inout_ PTP_TIMER Timer, _In_opt_ PFILETIME DueTime, _In_ DWORD Period, _In_ DWORD WindowLength) WI_NOEXCEPT
             {
                 ::SetThreadpoolTimer(Timer, DueTime, Period, WindowLength);
             }


### PR DESCRIPTION
The static analysis engine in VS2022 is flagging the _In_opt_ annotation for a DWORD as being invalid.

private\external\wil\include\wil\resource.h | 2429 | 6553 |   | The annotation for function 'SetThreadpoolTimer' on _Param_(4) does not apply to a value type.

Switching this annotation to _In_ instead.