### PR TITLE
Avoid possible compiler warning for duplicate SECURITY_WIN32 define

### DIFF
--- a/include/wil/token_helpers.h
+++ b/include/wil/token_helpers.h
@@ -21,7 +21,9 @@
 #include <processthreadsapi.h>
 
 // for GetUserNameEx()
+#ifndef SECURITY_WIN32
 #define SECURITY_WIN32
+#endif
 #include <Security.h>
 
 namespace wil


### PR DESCRIPTION
This commit avoids compiler warnings when using `token_helpers.h` in a source file that has already defined `SECURITY_WIN32`.