### PR TITLE
Allow basic_zstring_view to be constructed from noncopyable custom string types

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 #if _HAS_CXX17
 #include <string_view>
 #endif
@@ -151,8 +152,8 @@ namespace wil
         // we disable this constructor if the value is an array (including string literal).
         template<typename TPtr, std::enable_if_t<
             std::is_convertible<TPtr, const TChar*>::value && !std::is_array<TPtr>::value>* = nullptr>
-        constexpr basic_zstring_view(const TPtr pStr) noexcept
-            : std::basic_string_view<TChar>(pStr) {}
+        constexpr basic_zstring_view(TPtr&& pStr) noexcept
+            : std::basic_string_view<TChar>(std::forward<TPtr>(pStr)) {}
 
         constexpr basic_zstring_view(const std::basic_string<TChar>& str) noexcept
             : std::basic_string_view<TChar>(&str[0], str.size()) {}

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -47,6 +47,17 @@ TEST_CASE("StlTests::TestSecureAllocator", "[stl][secure_allocator]")
 }
 
 #if __WI_LIBCPP_STD_VER >= 17
+
+struct CustomNoncopyableString
+{
+    CustomNoncopyableString() = default;
+    CustomNoncopyableString(const CustomNoncopyableString&) = delete;
+    void operator=(const CustomNoncopyableString&) = delete;
+
+    constexpr operator PCSTR() const { return "hello"; }
+    constexpr operator PCWSTR() const { return L"w-hello"; }
+};
+
 TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 {
     // Test empty cases
@@ -95,6 +106,11 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
     static constexpr char badCharArray[2][3] = {{'a', 'b', 'c' }, {'a', 'b', 'c' }};
     REQUIRE_CRASH((wil::zstring_view{ &badCharArray[0][0], _countof(badCharArray[0]) }));
     REQUIRE_CRASH((wil::zstring_view{ badCharArray[0] }));
+
+    // Test constructing from custom string type
+    CustomNoncopyableString customString;
+    wil::zstring_view fromCustomString(customString);
+    REQUIRE(fromCustomString == (PCSTR)customString);
 }
 
 TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
@@ -145,5 +161,10 @@ TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
     static constexpr wchar_t badCharArray[2][3] = {{ L'a', L'b', L'c' }, { L'a', L'b', L'c' } };
     REQUIRE_CRASH((wil::zwstring_view{ &badCharArray[0][0], _countof(badCharArray[0]) }));
     REQUIRE_CRASH((wil::zwstring_view{ badCharArray[0] }));
+
+    // Test constructing from custom string type
+    CustomNoncopyableString customString;
+    wil::zwstring_view fromCustomString(customString);
+    REQUIRE(fromCustomString == (PCWSTR)customString);
 }
 #endif


### PR DESCRIPTION
basic_zstring_view's constructor should use perfect forwarding, otherwise it copies its argument. This fails on non-copyable string types. Ask me how I know.