### PR TITLE
Use appropriate SAL2 on GetFileInfo result

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -892,7 +892,7 @@ namespace wil
 
         // Type unsafe version used in the implementation to avoid template bloat.
         inline HRESULT GetFileInfo(HANDLE fileHandle, FILE_INFO_BY_HANDLE_CLASS infoClass, size_t allocationSize,
-            _Outptr_result_nullonfailure_ void **result)
+            _Outptr_result_maybenull_ void **result)
         {
             *result = nullptr;
 


### PR DESCRIPTION
According to the [SAL documentation](https://docs.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values?view=msvc-170), `_Outptr_result_nullonfailure_` means:
```
The returned pointer points to a valid buffer if the function succeeds, or null if the function fails. This annotation is for a non-optional parameter.
```
In the case of:
```
                    else if (lastError == ERROR_NO_MORE_FILES) // for folder enumeration cases
                    {
                        break;
                    }
```
`result` will be `nullptr` when the function succeeds.

Changing to the best one I could find as a replacement, `_Outptr_result_maybenull_`.