### PR TITLE
WI_NODISCARD is not very useful because it does not create compiler warnings/errors

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -325,8 +325,12 @@ Three exception modes are available:
 #define WIL_HAS_CXX_17 0
 #endif
 
-// Until we'll have C++17 enabled in our code base, we're falling back to SAL
+#if __has_cpp_attribute(nodiscard)
+#define WI_NODISCARD [[nodiscard]]
+#else
+// If we don't have C++17 enabled in our code base then fall back to SAL
 #define WI_NODISCARD __WI_LIBCPP_NODISCARD_ATTRIBUTE
+#endif
 
 #define __R_ENABLE_IF_IS_CLASS(ptrType)                     wistd::enable_if_t<wistd::is_class<ptrType>::value, void*> = (void*)0
 #define __R_ENABLE_IF_IS_NOT_CLASS(ptrType)                 wistd::enable_if_t<!wistd::is_class<ptrType>::value, void*> = (void*)0


### PR DESCRIPTION
Closes #260

## Why is this change being made?
I am converting some custom lock wrappers to `wil::critical_section` and was trying to demonstrate that accidentally dropping the lifetime wrapper generates an error.  Whoops, it does not.  It happily compiles with no obvious warnings and hides a severe bug.

## Briefly summarize what changed
Use the C++ standard language feature to detect `[[nodiscard]]` support and if it is present define `WI_NODISCARD` to be `[[nodiscard]]`.  If the feature is not present then the existing (mostly unhelpful) annotation is used instead.

## How was this change tested?
init_all + build_all + runtests

```
Building from v:\T\wil\build\clang64debug
[85/85] Linking CXX executable tests\win7\witest.win7.exe
Building from v:\T\wil\build\clang64relwithdebinfo
[85/85] Linking CXX executable tests\win7\witest.win7.exe
Building from v:\T\wil\build\msvc64debug
[86/86] Linking CXX executable tests\win7\witest.win7.exe
Building from v:\T\wil\build\msvc64relwithdebinfo
[86/86] Linking CXX executable tests\win7\witest.win7.exe
All build completed successfully
```

There was one test failure that seems unrelated (case sensitivity error):
```
V:\T\wil\tests\FileSystemTests.cpp(613): FAILED:
  REQUIRE( procName == moduleName )
with expansion:
  "V:\T\wil\build\clang64debug\tests\cpplatest\witest.cpplatest.exe"
  ==
  "v:\T\wil\build\clang64debug\tests\cpplatest\witest.cpplatest.exe"
===============================================================================
test cases:    190 |    189 passed | 1 failed
assertions: 111716 | 111715 passed | 1 failed
```

I also overwrote the macro in the copy of WIL for an existing project and intentionally dropped the lock object.

```cpp
auto lock = wil::critical_section;
lock.lock(); // discarding lock lifetime object
```
`warning C4834: discarding return value of function with 'nodiscard' attribute`
`error C2220: the following warning is treated as an error`