### PR TITLE
Add support for zwstring_view to natvis. Fix parse error in natvis XML

### DIFF
--- a/natvis/wil.natvis
+++ b/natvis/wil.natvis
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) Microsoft. All rights reserved.
     This code is licensed under the MIT License.
@@ -6,7 +7,6 @@
     TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
     PARTICULAR PURPOSE AND NONINFRINGEMENT.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
     <Type Name="wistd::_Func_impl&lt;*&gt;">
         <DisplayString>{_Callee._Object}</DisplayString>
@@ -100,6 +100,19 @@
         <DisplayString>{m_ptr}</DisplayString>
         <Expand>
             <ExpandedItem>m_ptr</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wil::basic_zstring_view&lt;*&gt;">
+        <Intrinsic Name="size" Expression="_Mysize" />
+        <Intrinsic Name="data" Expression="_Mydata" />
+        <DisplayString>{_Mydata,[_Mysize]}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
+            <ArrayItems>
+                <Size>size()</Size>
+                <ValuePointer>data()</ValuePointer>
+            </ArrayItems>
         </Expand>
     </Type>
 </AutoVisualizer>

--- a/natvis/wil.natvis
+++ b/natvis/wil.natvis
@@ -109,10 +109,6 @@
         <DisplayString>{_Mydata,[_Mysize]}</DisplayString>
         <Expand>
             <Item Name="[size]" ExcludeView="simple">size()</Item>
-            <ArrayItems>
-                <Size>size()</Size>
-                <ValuePointer>data()</ValuePointer>
-            </ArrayItems>
         </Expand>
     </Type>
 </AutoVisualizer>


### PR DESCRIPTION
Closes #265

## Why is this change being made?
I recently began using wil::zwstring_view in a new project and when debugging in windbg the visualization for these string types is not very good.  They must be manually expanded to see the contents of the string.  The experience is worse than std::wstring_view.

## Briefly summarize what changed
This string type is a thin wrapper over `std::basic_string_view` so I just copied the natvis for that type and updated the name so it knows to use it.

There was also a preexisting warning when loading the XML because the `<?xml...>` element was not the first bytes of the file.  I'm not sure if that was breaking things or just a warning but I fixed it regardless.

## How was this change tested?
I created an empty console app and added WIL to it.  I added a `wil::zwstring_view` variable and debugged the project with windbg.  The edits were made to the wil.natvis that came with the WIL NuGet package.

### Before this change
<img width="537" alt="image" src="https://user-images.githubusercontent.com/46852402/194925567-66520979-743a-4a61-a8f5-9471fe5b5ed8.png">


### After this change
<img width="538" alt="image" src="https://user-images.githubusercontent.com/46852402/194925674-fc3fb9ca-f517-4e6e-91cd-a24da2e9b99f.png">

Note that the value is visible without expanding it.  The size is also newly visible.