### PR TITLE
Remove no longer needed workarounds

### DIFF
--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -322,7 +322,7 @@ TEST_CASE("CppWinRTTests::ModuleReference", "[cppwinrt]")
     REQUIRE(peek_module_ref_count() == initial);
 }
 
-#if (!defined(__clang__) && defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
+#if (defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 
 // Define our own custom dispatcher that we can force it to behave in certain ways.
 // wil::resume_foreground supports any dispatcher that has a dispatcher_traits.

--- a/tests/cpplatest/CMakeLists.txt
+++ b/tests/cpplatest/CMakeLists.txt
@@ -6,18 +6,9 @@ set(CMAKE_CXX_STANDARD 20)
 project(witest.cpplatest)
 add_executable(witest.cpplatest)
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    # Clang is not compatible with the experimental coroutine header, so temporarily disable some headers until full
-    # C++20 support is available
-    set(COROUTINE_SOURCES)
-else()
-    set(COROUTINE_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ComApartmentVariableTests.cpp)
-endif()
-
 target_sources(witest.cpplatest PUBLIC
     ${COMMON_SOURCES}
-    ${COROUTINE_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ComApartmentVariableTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRTTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRT20Tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../StlTests.cpp


### PR DESCRIPTION
Clang has changed a lot since then, and now it has support for coroutines and all that too!