### PR TITLE
Attempt to guard zstring_view against reading out of bounds

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -143,9 +143,8 @@ namespace wil
 
         template<size_t stringArrayLength>
         constexpr basic_zstring_view(const TChar(&stringArray)[stringArrayLength]) noexcept
-            : std::basic_string_view<TChar>(&stringArray[0])
+            : std::basic_string_view<TChar>(&stringArray[0], length_n(&stringArray[0], stringArrayLength))
         {
-            if (stringArrayLength < this->size()) { WI_STL_FAIL_FAST_IF(true); }
         }
 
         // Construct from nul-terminated char ptr. To prevent this from overshadowing array construction,
@@ -172,6 +171,15 @@ namespace wil
         }
 
     private:
+        // Bounds-checked version of char_traits::length, like strnlen. Requires that the input contains a null terminator.
+        static constexpr size_type length_n(_In_reads_opt_(buf_size) const TChar* str, size_type buf_size) noexcept
+        {
+            const std::basic_string_view<TChar> view(str, buf_size);
+            auto pos = view.find_first_of(TChar());
+            if (pos == view.npos) { WI_STL_FAIL_FAST_IF(true); }
+            return pos;
+        }
+
         // The following basic_string_view methods must not be allowed because they break the nul-termination.
         using std::basic_string_view<TChar>::swap;
         using std::basic_string_view<TChar>::remove_suffix;

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -107,6 +107,13 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
     REQUIRE_CRASH((wil::zstring_view{ &badCharArray[0][0], _countof(badCharArray[0]) }));
     REQUIRE_CRASH((wil::zstring_view{ badCharArray[0] }));
 
+    // Test constructing with a NULL one character past the valid range, guarding against off-by-one errors
+    // Overloads taking an explicit length trust the user that they ensure valid memory follows the buffer
+    static constexpr char badCharArrayOffByOne[2][3] = {{'a', 'b', 'c' }, {}};
+    const wil::zstring_view fromTerminatedCharArray(&badCharArrayOffByOne[0][0], _countof(badCharArrayOffByOne[0]));
+    REQUIRE(fromLiteral == fromTerminatedCharArray);
+    REQUIRE_CRASH((wil::zstring_view{ badCharArrayOffByOne[0] }));
+
     // Test constructing from custom string type
     CustomNoncopyableString customString;
     wil::zstring_view fromCustomString(customString);
@@ -161,6 +168,13 @@ TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
     static constexpr wchar_t badCharArray[2][3] = {{ L'a', L'b', L'c' }, { L'a', L'b', L'c' } };
     REQUIRE_CRASH((wil::zwstring_view{ &badCharArray[0][0], _countof(badCharArray[0]) }));
     REQUIRE_CRASH((wil::zwstring_view{ badCharArray[0] }));
+
+    // Test constructing with a NULL one character past the valid range, guarding against off-by-one errors
+    // Overloads taking an explicit length trust the user that they ensure valid memory follows the buffer
+    static constexpr wchar_t badCharArrayOffByOne[2][3] = {{ L'a', L'b', L'c' }, {}};
+    const wil::zwstring_view fromTerminatedCharArray(&badCharArrayOffByOne[0][0], _countof(badCharArrayOffByOne[0]));
+    REQUIRE(fromLiteral == fromTerminatedCharArray);
+    REQUIRE_CRASH((wil::zwstring_view{ badCharArrayOffByOne[0] }));
 
     // Test constructing from custom string type
     CustomNoncopyableString customString;


### PR DESCRIPTION
Following the discussion in #271, this PR serves as an attempt to fixup `zstring_view` constructors against a possible out-of-bounds read:
1. `basic_zstring_view(const TChar(&stringArray)[stringArrayLength])` constructor ignored the passed array length and passed the buffer straight to an underlying `string_view` constructor, which in turn attempted to determine the length of the string. If the passed buffer contains no null terminator, it'd read out of bounds. The current tests didn't fail on this, because they pass on a crash - so even if a read access violation happened, it'd be caught and registered as a pass.
With my change, the constructor assumes that the buffer contains a null terminator, and it determines the length safely via a bounds-checked variation of `char_traits::length` (that unfortunately doesn't exist out of the box!). If no null terminator is found in the passed buffer, construction fails.
New tests have been added where a null terminator sits one character/byte past the passed buffer. Without my changes, these strings constructed with no error, while they should not have.
2. In theory, `basic_zstring_view(const TChar* pStringData, size_type stringLength)` still potentially reads past a passed buffer, but since the size parameter there is explicit, I decided against changing it - otherwise it could break some valid cases where the user ensures that the passed buffer is null terminated. I think this is a valid assumption, far more believeable one than in the first case where the user was trusted with null terminating an implicitly-sized buffer.

However, there is a downside to the current approach - as you can notice from newly added "passing" tests, `pStringData[stringLength] != 0` check disqualifies the second constructor from being truly `constexpr` since it reads out of bounds of the buffer! This should potentially be thought of as a bug too, but I'm not sure if the fix is to change the logic of this constructor, or just to make it not `constexpr`.

Resolves #271