### PR TITLE
add wil::str_raw_ptr for winrt::hstring

### DIFF
--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -284,6 +284,11 @@ namespace wil
         return static_cast<HSTRING>(winrt::get_abi(object));
     }
 
+    inline auto str_raw_ptr(const winrt::hstring& str) noexcept
+    {
+        return str.c_str();
+    }
+
     template <typename T>
     auto put_abi(T& object) noexcept
     {


### PR DESCRIPTION
avoid having to use .c_str() in wil scenarios like `wil::str_printf()`, `wil::str_concat()`

```cpp
winrt::hstring hsvalue{ L"C" };
hs = wil::str_concat<wil::unique_hstring>(L"A", L"B", hsvalue);
```

instead of `hsvalue.c_str()`