### PR TITLE
Add RECT helpers

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -286,6 +286,56 @@ namespace wil
     }
 #pragma endregion
 
+#pragma region RECT helpers
+    template<typename rect_type>
+    constexpr auto rect_width(rect_type rect)
+    {
+        return rect.right - rect.left;
+    }
+
+    template<typename rect_type>
+    constexpr auto rect_width(rect_type* rect)
+    {
+        return rect->right - rect->left;
+    }
+
+    template<typename rect_type>
+    constexpr auto rect_height(rect_type rect)
+    {
+        return rect.bottom - rect.top;
+    }
+
+    template<typename rect_type>
+    constexpr auto rect_height(rect_type* rect)
+    {
+        return rect->bottom - rect->top;
+    }
+
+    template<typename rect_type>
+    constexpr auto rect_is_empty(rect_type rect)
+    {
+        return (rect.left >= rect.right) || (rect.top >= rect.bottom);
+    }
+
+    template<typename rect_type>
+    constexpr auto rect_is_empty(rect_type* rect)
+    {
+        return (rect->left >= rect->right) || (rect->top >= rect->bottom);
+    }
+
+    template<typename rect_type, typename point_type>
+    constexpr auto rect_contains_point(rect_type rect, point_type point)
+    {
+        return (point.x >= rect.left) && (point.x < rect.right) && (point.y >= rect.top) && (point.y < rect.bottom);
+    }
+
+    template<typename rect_type, typename point_type>
+    constexpr auto rect_contains_point(rect_type* rect, point_type point)
+    {
+        return (point.x >= rect->left) && (point.x < rect->right) && (point.y >= rect->top) && (point.y < rect->bottom);
+    }
+#pragma endregion
+
     // Use to adapt Win32 APIs that take a fixed size buffer into forms that return
     // an allocated buffer. Supports many types of string representation.
     // See comments below on the expected behavior of the callback.

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -310,6 +310,17 @@ namespace wil
     {
         return (point.x >= rect.left) && (point.x < rect.right) && (point.y >= rect.top) && (point.y < rect.bottom);
     }
+
+    template<typename rect_type, typename length_type>
+    constexpr rect_type rect_from_size(length_type x, length_type y, length_type width, length_type height)
+    {
+        rect_type rect;
+        rect.left = x;
+        rect.top = y;
+        rect.right = x + width;
+        rect.bottom = y + height;
+        return rect;
+    }
 #pragma endregion
 
     // Use to adapt Win32 APIs that take a fixed size buffer into forms that return

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -288,51 +288,27 @@ namespace wil
 
 #pragma region RECT helpers
     template<typename rect_type>
-    constexpr auto rect_width(rect_type rect)
+    constexpr auto rect_width(rect_type const& rect)
     {
         return rect.right - rect.left;
     }
 
     template<typename rect_type>
-    constexpr auto rect_width(rect_type* rect)
-    {
-        return rect->right - rect->left;
-    }
-
-    template<typename rect_type>
-    constexpr auto rect_height(rect_type rect)
+    constexpr auto rect_height(rect_type const& rect)
     {
         return rect.bottom - rect.top;
     }
 
     template<typename rect_type>
-    constexpr auto rect_height(rect_type* rect)
-    {
-        return rect->bottom - rect->top;
-    }
-
-    template<typename rect_type>
-    constexpr auto rect_is_empty(rect_type rect)
+    constexpr auto rect_is_empty(rect_type const& rect)
     {
         return (rect.left >= rect.right) || (rect.top >= rect.bottom);
     }
 
-    template<typename rect_type>
-    constexpr auto rect_is_empty(rect_type* rect)
-    {
-        return (rect->left >= rect->right) || (rect->top >= rect->bottom);
-    }
-
     template<typename rect_type, typename point_type>
-    constexpr auto rect_contains_point(rect_type rect, point_type point)
+    constexpr auto rect_contains_point(rect_type const& rect, point_type const& point)
     {
         return (point.x >= rect.left) && (point.x < rect.right) && (point.y >= rect.top) && (point.y < rect.bottom);
-    }
-
-    template<typename rect_type, typename point_type>
-    constexpr auto rect_contains_point(rect_type* rect, point_type point)
-    {
-        return (point.x >= rect->left) && (point.x < rect->right) && (point.y >= rect->top) && (point.y < rect->bottom);
     }
 #pragma endregion
 

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -2540,33 +2540,21 @@ TEST_CASE("WindowsInternalTests::RectHelperTests", "[win32_helpers]")
     RECT nonNormalizedRect{ 300, 300, 0, 0 };
 
     REQUIRE(wil::rect_width(rect) == 150);
-    REQUIRE(wil::rect_width(&rect) == 150);
     REQUIRE(wil::rect_height(rect) == 200);
-    REQUIRE(wil::rect_height(&rect) == 200);
 
     // rect_is_empty should work like user32's IsRectEmpty
     REQUIRE_FALSE(wil::rect_is_empty(rect));
-    REQUIRE_FALSE(wil::rect_is_empty(&rect));
     REQUIRE(wil::rect_is_empty(emptyRectAtOrigin));
-    REQUIRE(wil::rect_is_empty(&emptyRectAtOrigin));
     REQUIRE(wil::rect_is_empty(emptyRectNotAtOrigin));
-    REQUIRE(wil::rect_is_empty(&emptyRectNotAtOrigin));
     REQUIRE(wil::rect_is_empty(nonNormalizedRect));
-    REQUIRE(wil::rect_is_empty(&nonNormalizedRect));
 
     // rect_contains_point should work like user32's PtInRect
     REQUIRE(wil::rect_contains_point(rect, insidePoint));
-    REQUIRE(wil::rect_contains_point(&rect, insidePoint));
     REQUIRE(wil::rect_contains_point(rect, leftEdgePoint));
-    REQUIRE(wil::rect_contains_point(&rect, leftEdgePoint));
     REQUIRE(wil::rect_contains_point(rect, topEdgePoint));
-    REQUIRE(wil::rect_contains_point(&rect, topEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(rect, rightEdgePoint));
-    REQUIRE_FALSE(wil::rect_contains_point(&rect, rightEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(rect, bottomEdgePoint));
-    REQUIRE_FALSE(wil::rect_contains_point(&rect, bottomEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(nonNormalizedRect, insidePoint));
-    REQUIRE_FALSE(wil::rect_contains_point(&nonNormalizedRect, insidePoint));
 }
 
 TEST_CASE("WindowsInternalTests::InitOnceNonTests")

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -2557,7 +2557,10 @@ TEST_CASE("WindowsInternalTests::RectHelperTests", "[win32_helpers]")
     REQUIRE_FALSE(wil::rect_contains_point(nonNormalizedRect, insidePoint));
 
     auto rectFromSize = wil::rect_from_size<RECT>(50, 100, 150, 200);
-    REQUIRE(!!EqualRect(&rectFromSize, &rect));
+    REQUIRE(rectFromSize.left == rect.left);
+    REQUIRE(rectFromSize.top == rect.top);
+    REQUIRE(rectFromSize.right == rect.right);
+    REQUIRE(rectFromSize.bottom == rect.bottom);
 }
 
 TEST_CASE("WindowsInternalTests::InitOnceNonTests")

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -2526,6 +2526,49 @@ TEST_CASE("WindowsInternalTests::Win32HelperTests", "[win32_helpers]")
     REQUIRE(systemTimePlusOneHour64 == (systemTime64 + wil::filetime_duration::one_hour));
 }
 
+TEST_CASE("WindowsInternalTests::RectHelperTests", "[win32_helpers]")
+{
+    RECT rect{ 50, 100, 200, 300 };
+    POINT leftEdgePoint{ 50, 150 };
+    POINT topEdgePoint{ 100, 100 };
+    POINT rightEdgePoint{ 200, 150 };
+    POINT bottomEdgePoint{ 100, 300 };
+    POINT insidePoint{ 150, 150};
+
+    RECT emptyRectAtOrigin{};
+    RECT emptyRectNotAtOrigin{ 50, 50, 50, 50 };
+    RECT nonNormalizedRect{ 300, 300, 0, 0 };
+
+    REQUIRE(wil::rect_width(rect) == 150);
+    REQUIRE(wil::rect_width(&rect) == 150);
+    REQUIRE(wil::rect_height(rect) == 200);
+    REQUIRE(wil::rect_height(&rect) == 200);
+
+    // rect_is_empty should work like user32's IsRectEmpty
+    REQUIRE_FALSE(wil::rect_is_empty(rect));
+    REQUIRE_FALSE(wil::rect_is_empty(&rect));
+    REQUIRE(wil::rect_is_empty(emptyRectAtOrigin));
+    REQUIRE(wil::rect_is_empty(&emptyRectAtOrigin));
+    REQUIRE(wil::rect_is_empty(emptyRectNotAtOrigin));
+    REQUIRE(wil::rect_is_empty(&emptyRectNotAtOrigin));
+    REQUIRE(wil::rect_is_empty(nonNormalizedRect));
+    REQUIRE(wil::rect_is_empty(&nonNormalizedRect));
+
+    // rect_contains_point should work like user32's PtInRect
+    REQUIRE(wil::rect_contains_point(rect, insidePoint));
+    REQUIRE(wil::rect_contains_point(&rect, insidePoint));
+    REQUIRE(wil::rect_contains_point(rect, leftEdgePoint));
+    REQUIRE(wil::rect_contains_point(&rect, leftEdgePoint));
+    REQUIRE(wil::rect_contains_point(rect, topEdgePoint));
+    REQUIRE(wil::rect_contains_point(&rect, topEdgePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(rect, rightEdgePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(&rect, rightEdgePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(rect, bottomEdgePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(&rect, bottomEdgePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(nonNormalizedRect, insidePoint));
+    REQUIRE_FALSE(wil::rect_contains_point(&nonNormalizedRect, insidePoint));
+}
+
 TEST_CASE("WindowsInternalTests::InitOnceNonTests")
 {
     bool called = false;

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -2555,6 +2555,8 @@ TEST_CASE("WindowsInternalTests::RectHelperTests", "[win32_helpers]")
     REQUIRE_FALSE(wil::rect_contains_point(rect, rightEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(rect, bottomEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(nonNormalizedRect, insidePoint));
+
+    REQUIRE(wil::rect_from_size<RECT>(50, 100, 150, 200) == rect);
 }
 
 TEST_CASE("WindowsInternalTests::InitOnceNonTests")

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -2556,7 +2556,8 @@ TEST_CASE("WindowsInternalTests::RectHelperTests", "[win32_helpers]")
     REQUIRE_FALSE(wil::rect_contains_point(rect, bottomEdgePoint));
     REQUIRE_FALSE(wil::rect_contains_point(nonNormalizedRect, insidePoint));
 
-    REQUIRE(wil::rect_from_size<RECT>(50, 100, 150, 200) == rect);
+    auto rectFromSize = wil::rect_from_size<RECT>(50, 100, 150, 200);
+    REQUIRE(!!EqualRect(&rectFromSize, &rect));
 }
 
 TEST_CASE("WindowsInternalTests::InitOnceNonTests")


### PR DESCRIPTION
Helper functions to get the width or height of a rectangle are commonly copy-and-pasted in code that deals with win32 user interfaces. (Microsoft-internal folks can search the OS repo for "RectWidth" to see evidence of this.) It's a small thing since the implementations are trivial, but it would be nice to have a canonical copy of these in wil for new projects.

This PR adds five functions in win32_helpers.h:

- rect_width
- rect_height
- rect_is_empty
- rect_contains_point
- rect_from_size

The function templates work on the Windows SDK types RECT, RECTL, D2D_RECT_F, D2D_RECT_U, or any other type with the same shape. <s>There are also versions which operate on pointers to rectangles like the user32 functions PtInRect and IsRectEmpty do.</s>