### PR TITLE
Fix doc typo: unique_prop_variant_default_init

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -792,7 +792,7 @@ namespace wil
     ~~~
     typedef wil::unique_struct<PROPVARIANT, decltype(&::PropVariantClear), ::PropVariantClear> unique_prop_variant_default_init;
 
-    unique_prop_variant propvariant;
+    unique_prop_variant_default_init propvariant;
     SomeFunction(&propvariant);
     ~~~
 


### PR DESCRIPTION
First `unique_prop_variant` should be `unique_prop_variant_default_init`.