### PR TITLE
Fixes unused padding and uninitialized variable

### DIFF
--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -239,8 +239,8 @@ namespace wil
     //! Detects if one or more embedded null is present in an HSTRING.
     inline bool HasEmbeddedNull(_In_opt_ HSTRING value)
     {
-        BOOL hasEmbeddedNull;
-        WindowsStringHasEmbeddedNull(value, &hasEmbeddedNull);
+        BOOL hasEmbeddedNull = FALSE;
+        (void)WindowsStringHasEmbeddedNull(value, &hasEmbeddedNull);
         return hasEmbeddedNull != FALSE;
     }
 


### PR DESCRIPTION
Our code quality scanners found this uninitialized variable and this unused padding in the result status structure.

Fix the uninit variable by ... initializing it. Also, throw away the results of the check; the only time this method fails if it's passed a `nullptr` and the non-string can't have embedded nulls.

Fix the padding by converting a bool to a full 32-bit value.  Another improvement would be to convert it to `std::variant<HRESULT, NTSTATUS>` or similar, compressing it into 8 bytes instead of 12.  Initial review suggests that some parts of the code do expect distinct hresult/statuscode values to transit the layers, though, so we'll have to run additional tests on that. For now, just fix the padding by making them addressable at init and copy time.

The updated assembly shows we're no longer leaving bytes in the caller uninitialized:

```asm
0:000> u `witest!result_macros.h:3084+`
witest!wil::details::ResultFromCaughtExceptionInternal+0x5e [C:\Users\jonwis\source\repos\wil\include\wil\result_macros.h @ 3084]:
00000001`4012df3e 85c0            test    eax,eax
00000001`4012df40 7921            jns     witest!wil::details::ResultFromCaughtExceptionInternal+0x83 (00000001`4012df63)
00000001`4012df42 8bc8            mov     ecx,eax
00000001`4012df44 e8215ceeff      call    witest!ILT+76645(?HrToNtStatusdetailswilYAJJZ) (00000001`40013b6a)
00000001`4012df49 44893e          mov     dword ptr [rsi],r15d
00000001`4012df4c 894604          mov     dword ptr [rsi+4],eax
00000001`4012df4f 897e08          mov     dword ptr [rsi+8],edi
00000001`4012df52 488bc6          mov     rax,rsi
```

Fixes #281 