### PR TITLE
Use wistd::min instead of Windows.h min

### DIFF
--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -2261,7 +2261,7 @@ __WI_POP_WARNINGS
         {
             size_t cchLen = UntrustedStringLength(reinterpret_cast<TString>(pStart), (pEnd - pStart) / sizeof((*ppszBufferString)[0]));
             *ppszBufferString = (cchLen > 0) ? reinterpret_cast<TString>(pStart) : nullptr;
-            auto pReturn = min(pEnd, pStart + ((cchLen + 1) * sizeof((*ppszBufferString)[0])));
+            auto pReturn = (wistd::min)(pEnd, pStart + ((cchLen + 1) * sizeof((*ppszBufferString)[0])));
             __analysis_assume((pReturn >= pStart) && (pReturn <= pEnd));
             return pReturn;
         }


### PR DESCRIPTION
The latter is not guarenteed to be available for some projects which have NOMINMAX defined somewhere before a Windows.h include.