### PR TITLE
Add GetWindowsDirectoryW to win32_helpers.h

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -867,7 +867,6 @@ namespace wil
     // TODO: add support for these and other similar APIs.
     // GetShortPathNameW()
     // GetLongPathNameW()
-    // GetWindowsDirectory()
     // GetTempDirectory()
 
     /// @cond

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -550,6 +550,24 @@ namespace wil
         });
     }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
+    template <typename string_type, size_t stackBufferLength = 256>
+    HRESULT GetWindowsDirectoryW(string_type& result) WI_NOEXCEPT
+    {
+        return wil::AdaptFixedSizeToAllocatedResult<string_type, stackBufferLength>(result,
+            [&](_Out_writes_(valueLength) PWSTR value, size_t valueLength, _Out_ size_t* valueLengthNeededWithNul) -> HRESULT
+        {
+            *valueLengthNeededWithNul = ::GetWindowsDirectoryW(value, static_cast<DWORD>(valueLength));
+            RETURN_LAST_ERROR_IF(*valueLengthNeededWithNul == 0);
+            if (*valueLengthNeededWithNul < valueLength)
+            {
+                (*valueLengthNeededWithNul)++; // it fit, account for the null
+            }
+            return S_OK;
+        });
+    }
+#endif
+
 #ifdef WIL_ENABLE_EXCEPTIONS
     /** Expands the '%' quoted environment variables in 'input' using ExpandEnvironmentStringsW(); */
     template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
@@ -605,6 +623,16 @@ namespace wil
         THROW_IF_FAILED((wil::GetModuleFileNameExW<string_type, initialBufferLength>(process, module, result)));
         return result;
     }
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
+    template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
+    string_type GetWindowsDirectoryW()
+    {
+        string_type result;
+        THROW_IF_FAILED((wil::GetWindowsDirectoryW<string_type, stackBufferLength>(result)));
+        return result;
+    }
+#endif
 
     template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
     string_type QueryFullProcessImageNameW(HANDLE processHandle = GetCurrentProcess(), DWORD flags = 0)

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -404,6 +404,29 @@ TEST_CASE("FileSystemTests::VerifyGetSystemDirectoryW", "[filesystem]")
     REQUIRE(CompareStringOrdinal(pathToTest.get(), -1, trueSystemDir.get(), -1, TRUE) == CSTR_EQUAL);
 }
 
+TEST_CASE("FileSystemTests::VerifyGetWindowsDirectoryW", "[filesystem]")
+{
+    wil::unique_cotaskmem_string pathToTest;
+    REQUIRE_SUCCEEDED(wil::GetWindowsDirectoryW(pathToTest));
+
+    // allocate based on the string that wil::GetWindowsDirectoryW returned
+    size_t length = wcslen(pathToTest.get()) + 1;
+    auto trueSystemDir = wil::make_cotaskmem_string_nothrow(nullptr, length);
+    REQUIRE(GetWindowsDirectoryW(trueSystemDir.get(), static_cast<UINT>(length)) > 0);
+
+    REQUIRE(CompareStringOrdinal(pathToTest.get(), -1, trueSystemDir.get(), -1, TRUE) == CSTR_EQUAL);
+
+    // Force AdaptFixed* to realloc. Test stack boundary with small initial buffer limit, c_stackBufferLimitTest
+    REQUIRE_SUCCEEDED((wil::GetWindowsDirectoryW<wil::unique_cotaskmem_string, c_stackBufferLimitTest>(pathToTest)));
+
+    // allocate based on the string that wil::GetWindowsDirectoryW returned
+    length = wcslen(pathToTest.get()) + 1;
+    trueSystemDir = wil::make_cotaskmem_string_nothrow(nullptr, length);
+    REQUIRE(GetWindowsDirectoryW(trueSystemDir.get(), static_cast<UINT>(length)) > 0);
+
+    REQUIRE(CompareStringOrdinal(pathToTest.get(), -1, trueSystemDir.get(), -1, TRUE) == CSTR_EQUAL);
+}
+
 struct has_operator_pcwstr
 {
     PCWSTR value;


### PR DESCRIPTION
I also removed the relevant TODO from `include/wil/filesystem.h`. I figured `win32_helpers.h` is a better place for it since `GetSystemDirectoryW` is already there.