### PR TITLE
Update most non-void returning const member functions to be [[nodiscard]]

### DIFF
--- a/include/wil/Tracelogging.h
+++ b/include/wil/Tracelogging.h
@@ -484,7 +484,7 @@ namespace wil
         }
 
     public:
-        TraceLoggingHProvider Provider_() const WI_NOEXCEPT
+        WI_NODISCARD TraceLoggingHProvider Provider_() const WI_NOEXCEPT
         {
             return m_providerHandle;
         }
@@ -500,7 +500,7 @@ namespace wil
             }
         }
 
-        bool IsEnabled_(UCHAR eventLevel /* WINEVENT_LEVEL_XXX, e.g. WINEVENT_LEVEL_VERBOSE */, ULONGLONG eventKeywords /* MICROSOFT_KEYWORD_XXX */) const WI_NOEXCEPT
+        WI_NODISCARD bool IsEnabled_(UCHAR eventLevel /* WINEVENT_LEVEL_XXX, e.g. WINEVENT_LEVEL_VERBOSE */, ULONGLONG eventKeywords /* MICROSOFT_KEYWORD_XXX */) const WI_NOEXCEPT
         {
             return ((m_providerHandle != nullptr) && TraceLoggingProviderEnabled(m_providerHandle, eventLevel, eventKeywords)) || __TRACELOGGING_TEST_HOOK_SET_ENABLED;
         }
@@ -630,7 +630,7 @@ namespace wil
         /*
         Returns a handle to the TraceLogging provider associated with this activity.
         */
-        TraceLoggingHProvider Provider() const
+        WI_NODISCARD TraceLoggingHProvider Provider() const
         {
             return TraceLoggingType::Provider();
         }
@@ -706,7 +706,7 @@ namespace wil
         /*
         Returns a handle to the TraceLogging provider associated with this activity.
         */
-        TraceLoggingHProvider Provider() const
+        WI_NODISCARD TraceLoggingHProvider Provider() const
         {
             return TraceLoggingType::Provider();
         }
@@ -940,7 +940,7 @@ namespace wil
         // In addition, for TlgReflector to work correctly, it must be possible for
         // TlgReflector to statically map from typeof(activity) to hProvider.
 
-        GUID const* zInternalRelatedId() const WI_NOEXCEPT
+        WI_NODISCARD GUID const* zInternalRelatedId() const WI_NOEXCEPT
         {
             return m_pActivityData->zInternalRelatedId();
         }
@@ -960,12 +960,12 @@ namespace wil
             return ActivityTraceLoggingType::Provider();
         }
 
-        GUID const* Id() const WI_NOEXCEPT
+        WI_NODISCARD GUID const* Id() const WI_NOEXCEPT
         {
             return m_pActivityData->Id();
         }
 
-        GUID const* providerGuid() const WI_NOEXCEPT
+        WI_NODISCARD GUID const* providerGuid() const WI_NOEXCEPT
         {
             return m_pActivityData->providerGuid();
         }
@@ -985,8 +985,8 @@ namespace wil
         {
             auto lock = LockExclusive(); m_pActivityData->SetRelatedActivityId(relatedActivityId);
         }
-        
-        inline bool IsRunning() const WI_NOEXCEPT
+
+        WI_NODISCARD inline bool IsRunning() const WI_NOEXCEPT
         {
             return m_pActivityData->NeedsStopped();
         }
@@ -1015,17 +1015,17 @@ namespace wil
         // Locking should not be required on these accessors as we only use this at reporting (which will only happen from
         // the final stop)
 
-        FailureInfo const * GetFailureInfo() WI_NOEXCEPT
+        FailureInfo const* GetFailureInfo() WI_NOEXCEPT
         {
             return m_pActivityData->GetFailureInfo();
         }
 
-        inline HRESULT GetResult() const WI_NOEXCEPT
+        WI_NODISCARD inline HRESULT GetResult() const WI_NOEXCEPT
         {
             return m_pActivityData->GetResult();
         }
 
-        details::StoredCallContextInfo *GetCallContext() const WI_NOEXCEPT
+        WI_NODISCARD details::StoredCallContextInfo* GetCallContext() const WI_NOEXCEPT
         {
             return m_pActivityData->GetCallContext();
         }
@@ -1165,7 +1165,7 @@ namespace wil
                 return ActivityTraceLoggingType::Provider();
             }
 
-            bool NeedsStopped() const WI_NOEXCEPT
+            WI_NODISCARD bool NeedsStopped() const WI_NOEXCEPT
             {
                 return BaseTy::IsStarted();
             }
@@ -1203,12 +1203,12 @@ namespace wil
                 m_stopCountExpected++;
             }
 
-            FailureInfo const *GetFailureInfo() const WI_NOEXCEPT
+            WI_NODISCARD FailureInfo const* GetFailureInfo() const WI_NOEXCEPT
             {
                 return (FAILED(m_result) && (m_result == m_failure.GetFailureInfo().hr)) ? &m_failure.GetFailureInfo() : nullptr;
             }
 
-            inline HRESULT GetResult() const WI_NOEXCEPT
+            WI_NODISCARD inline HRESULT GetResult() const WI_NOEXCEPT
             {
                 return m_result;
             }
@@ -1345,7 +1345,7 @@ namespace wil
             { ActivityBase::operator=(other); return *this; } \
         ActivityClassName& operator=(ActivityClassName &&other) WI_NOEXCEPT \
             { auto localActivity(wistd::move(*this)); ActivityBase::operator=(wistd::move(other)); return *this; } \
-        explicit operator bool() const WI_NOEXCEPT \
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT \
             { return IsRunning(); } \
         void StopWithResult(HRESULT hr) \
             { ActivityBase::Stop(hr); } \
@@ -3365,7 +3365,7 @@ WIL_WARN_DEPRECATED_1612_PRAGMA("IMPLEMENT_TRACELOGGING_CLASS")
         } \
         ActivityClassName(const ActivityClassName &) = default; \
         ActivityClassName(ActivityClassName &&) = default; \
-        TraceLoggingHProvider Provider() const \
+        WI_NODISCARD TraceLoggingHProvider Provider() const \
         { \
             return TraceLoggingType::Provider(); \
         } \

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -430,31 +430,31 @@ namespace wil
         //! @{
 
         //! Returns the address of the const internal pointer (does not release the pointer)
-        const pointer* addressof() const WI_NOEXCEPT
+        WI_NODISCARD const pointer* addressof() const WI_NOEXCEPT
         {
             return &m_ptr;
         }
 
         //! Returns 'true' if the pointer is assigned (NOT nullptr)
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return (m_ptr != nullptr);
         }
 
         //! Returns the pointer
-        pointer get() const WI_NOEXCEPT
+        WI_NODISCARD pointer get() const WI_NOEXCEPT
         {
             return m_ptr;
         }
 
         //! Allows direct calls against the pointer (AV on internal nullptr)
-        pointer operator->() const WI_NOEXCEPT
+        WI_NODISCARD pointer operator->() const WI_NOEXCEPT
         {
             return m_ptr;
         }
 
         //! Dereferences the pointer (AV on internal nullptr)
-        element_type_reference operator*() const WI_NOEXCEPT
+        WI_NODISCARD element_type_reference operator*() const WI_NOEXCEPT
         {
             return *m_ptr;
         }
@@ -488,7 +488,7 @@ namespace wil
         //!         `com_ptr_t` type will be @ref com_ptr or @ref com_ptr_failfast (matching the error handling form of the
         //!         pointer being queried (exception based or fail-fast).
         template <class U>
-        inline com_ptr_t<U, err_policy> query() const
+        WI_NODISCARD inline com_ptr_t<U, err_policy> query() const
         {
             static_assert(wistd::is_same<void, result>::value, "query requires exceptions or fail fast; use try_query or query_to");
             return com_ptr_t<U, err_policy>(m_ptr, details::tag_com_query());
@@ -611,7 +611,7 @@ namespace wil
         //!             not supported.  The returned `com_ptr_t` will have the same error handling policy (exceptions, failfast or error codes) as
         //!             the pointer being queried.
         template <class U>
-        inline com_ptr_t<U, err_policy> try_query() const
+        WI_NODISCARD inline com_ptr_t<U, err_policy> try_query() const
         {
             return com_ptr_t<U, err_policy>(m_ptr, details::tag_try_com_query());
         }
@@ -685,7 +685,7 @@ namespace wil
         //!         `com_ptr_t` type will be @ref com_ptr or @ref com_ptr_failfast (matching the error handling form of the
         //!         pointer being queried (exception based or fail-fast).
         template <class U>
-        inline com_ptr_t<U, err_policy> copy() const
+        WI_NODISCARD inline com_ptr_t<U, err_policy> copy() const
         {
             static_assert(wistd::is_same<void, result>::value, "copy requires exceptions or fail fast; use the try_copy or copy_to method");
             return com_ptr_t<U, err_policy>(m_ptr, details::tag_com_copy());
@@ -773,7 +773,7 @@ namespace wil
         //!             not supported or the pointer being queried is null.  The returned `com_ptr_t` will have the same error handling
         //!             policy (exceptions, failfast or error codes) as the pointer being queried.
         template <class U>
-        inline com_ptr_t<U, err_policy> try_copy() const
+        WI_NODISCARD inline com_ptr_t<U, err_policy> try_copy() const
         {
             return com_ptr_t<U, err_policy>(m_ptr, details::tag_try_com_copy());
         }
@@ -2852,7 +2852,7 @@ namespace wil
 
         //! Returns the current position being saved for the stream
         //! @returns The position, in bytes, being saved for the stream
-        unsigned long long position() const
+        WI_NODISCARD unsigned long long position() const
         {
             return m_position;
         }

--- a/include/wil/com_apartment_variable.h
+++ b/include/wil/com_apartment_variable.h
@@ -105,7 +105,7 @@ namespace wil
             std::any(*adapter)(void*);
             void* inner;
 
-            std::any operator()() const
+            WI_NODISCARD std::any operator()() const
             {
                 return adapter(inner);
             }

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -485,8 +485,8 @@ namespace wil
         {
         public:
             pointer_range(T begin_, T end_) : m_begin(begin_), m_end(end_) {}
-            T begin() const  { return m_begin; }
-            T end() const    { return m_end; }
+            WI_NODISCARD T begin() const  { return m_begin; }
+            WI_NODISCARD T end() const    { return m_end; }
         private:
             T m_begin;
             T m_end;

--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -115,7 +115,7 @@ namespace wil
                 m_priority(priority)
             {
             }
-            bool await_ready() const noexcept { return false; }
+            WI_NODISCARD bool await_ready() const noexcept { return false; }
 
             void await_suspend(details::coroutine_handle<> handle)
             {
@@ -225,9 +225,9 @@ namespace wil
                 typename = decltype(std::declval<U>().GetMany(std::declval<U>().Size(),
                     winrt::array_view<decltype(std::declval<U>().GetAt(0))>{}))>
             static constexpr bool get_value(int) { return true; }
-            template <typename> static constexpr bool get_value(...) { return false; }  
+            template <typename> static constexpr bool get_value(...) { return false; }
         public:
-            static constexpr bool value = get_value<T>(0);                                                                                                                         
+            static constexpr bool value = get_value<T>(0);
         };
 
         template<typename T> struct is_winrt_iterator_like {
@@ -235,9 +235,9 @@ namespace wil
             template <typename U,
                 typename = decltype(std::declval<U>().GetMany(winrt::array_view<decltype(std::declval<U>().Current())>{}))>
             static constexpr bool get_value(int) { return true; }
-            template <typename> static constexpr bool get_value(...) { return false; }  
+            template <typename> static constexpr bool get_value(...) { return false; }
         public:
-            static constexpr bool value = get_value<T>(0);                                                                                                                         
+            static constexpr bool value = get_value<T>(0);
         };
 
         template<typename T> constexpr T empty() noexcept
@@ -269,7 +269,7 @@ namespace wil
     interface that C++/WinRT projects those interfaces for (PropertySet, IMap<T,K>, etc.)
     Iterable-only types fetch content in units of 64. When used with an iterator, the returned
     vector contains the iterator's current position and any others after it.
-    */ 
+    */
     template<typename TSrc> auto to_vector(TSrc const& src)
     {
         if constexpr (details::is_winrt_vector_like<TSrc>::value)

--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -401,7 +401,7 @@ namespace wil
 
         // range based for requires operator!=, operator++ and operator* to do its work
         // on the type returned from begin() and end(), provide those here.
-        bool operator!=(const next_entry_offset_iterator& other) const { return current_ != other.current_; }
+        WI_NODISCARD bool operator!=(const next_entry_offset_iterator& other) const { return current_ != other.current_; }
 
         next_entry_offset_iterator& operator++()
         {
@@ -418,8 +418,8 @@ namespace wil
             return copy;
         }
 
-        reference operator*() const WI_NOEXCEPT { return *current_; }
-        pointer operator->() const WI_NOEXCEPT { return current_; }
+        WI_NODISCARD reference operator*() const WI_NOEXCEPT { return *current_; }
+        WI_NODISCARD pointer operator->() const WI_NOEXCEPT { return current_; }
 
         next_entry_offset_iterator<T> begin() { return *this; }
         next_entry_offset_iterator<T> end()   { return next_entry_offset_iterator<T>(); }

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -104,7 +104,7 @@ namespace wil
             m_dismissed = true;
         }
 
-        auto value() const WI_NOEXCEPT
+        WI_NODISCARD auto value() const WI_NOEXCEPT
         {
             return m_error;
         }
@@ -202,7 +202,7 @@ namespace wil
                 }
             }
 
-            bool is_valid() const WI_NOEXCEPT
+            WI_NODISCARD bool is_valid() const WI_NOEXCEPT
             {
                 return policy::is_valid(m_ptr);
             }
@@ -222,7 +222,7 @@ namespace wil
                 reset();
             }
 
-            pointer get() const WI_NOEXCEPT
+            WI_NODISCARD pointer get() const WI_NOEXCEPT
             {
                 return static_cast<pointer>(m_ptr);
             }
@@ -320,7 +320,7 @@ namespace wil
             other = wistd::move(self);
         }
 
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return storage_t::is_valid();
         }
@@ -342,7 +342,7 @@ namespace wil
             return put();
         }
 
-        pointer get() const WI_NOEXCEPT
+        WI_NODISCARD pointer get() const WI_NOEXCEPT
         {
             static_assert(!wistd::is_same<typename policy::pointer_access, details::pointer_access_none>::value, "get(): the raw handle value is not available for this resource class");
             return storage_t::get();
@@ -485,7 +485,7 @@ namespace wil
             }
 
             // Returns true if the scope_exit lambda is still going to be executed
-            explicit operator bool() const WI_NOEXCEPT
+            WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
             {
                 return m_call;
             }
@@ -547,7 +547,7 @@ namespace wil
             }
 
             // Returns true if the scope_exit lambda is still going to be executed
-            explicit operator bool() const WI_NOEXCEPT
+            WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
             {
                 return m_call;
             }
@@ -1009,100 +1009,100 @@ namespace wil
             other.m_size = size;
         }
 
-        iterator begin() WI_NOEXCEPT
+        WI_NODISCARD iterator begin() WI_NOEXCEPT
         {
             return (iterator(m_ptr));
         }
 
-        const_iterator begin() const WI_NOEXCEPT
+        WI_NODISCARD const_iterator begin() const WI_NOEXCEPT
         {
             return (const_iterator(m_ptr));
         }
 
-        iterator end() WI_NOEXCEPT
+        WI_NODISCARD iterator end() WI_NOEXCEPT
         {
             return (iterator(m_ptr + m_size));
         }
 
-        const_iterator end() const WI_NOEXCEPT
+        WI_NODISCARD const_iterator end() const WI_NOEXCEPT
         {
             return (const_iterator(m_ptr + m_size));
         }
 
-        const_iterator cbegin() const WI_NOEXCEPT
+        WI_NODISCARD const_iterator cbegin() const WI_NOEXCEPT
         {
             return (begin());
         }
 
-        const_iterator cend() const WI_NOEXCEPT
+        WI_NODISCARD const_iterator cend() const WI_NOEXCEPT
         {
             return (end());
         }
 
-        size_type size() const WI_NOEXCEPT
+        WI_NODISCARD size_type size() const WI_NOEXCEPT
         {
             return (m_size);
         }
 
-        bool empty() const WI_NOEXCEPT
+        WI_NODISCARD bool empty() const WI_NOEXCEPT
         {
             return (size() == size_type{});
         }
 
-        reference operator[](size_type position)
+        WI_NODISCARD reference operator[](size_type position)
         {
             WI_ASSERT(position < m_size);
             _Analysis_assume_(position < m_size);
             return (m_ptr[position]);
         }
 
-        const_reference operator[](size_type position) const
+        WI_NODISCARD const_reference operator[](size_type position) const
         {
             WI_ASSERT(position < m_size);
             _Analysis_assume_(position < m_size);
             return (m_ptr[position]);
         }
 
-        reference front()
+        WI_NODISCARD reference front()
         {
             WI_ASSERT(!empty());
             return (m_ptr[0]);
         }
 
-        const_reference front() const
+        WI_NODISCARD const_reference front() const
         {
             WI_ASSERT(!empty());
             return (m_ptr[0]);
         }
 
-        reference back()
+        WI_NODISCARD reference back()
         {
             WI_ASSERT(!empty());
             return (m_ptr[m_size - 1]);
         }
 
-        const_reference back() const
+        WI_NODISCARD const_reference back() const
         {
             WI_ASSERT(!empty());
             return (m_ptr[m_size - 1]);
         }
 
-        ValueType* data() WI_NOEXCEPT
+        WI_NODISCARD ValueType* data() WI_NOEXCEPT
         {
             return (m_ptr);
         }
 
-        const ValueType* data() const WI_NOEXCEPT
+        WI_NODISCARD const ValueType* data() const WI_NOEXCEPT
         {
             return (m_ptr);
         }
 
-        pointer get() const WI_NOEXCEPT
+        WI_NODISCARD pointer get() const WI_NOEXCEPT
         {
             return m_ptr;
         }
 
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return (m_ptr != pointer());
         }
@@ -1377,7 +1377,7 @@ namespace wil
         }
 
         //! Determine if the underlying source and token are valid
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return (m_token != invalid_token) && m_source;
         }
@@ -1472,7 +1472,7 @@ namespace wil
         }
 
         //! Retrieves the token
-        token_t get() const WI_NOEXCEPT
+        WI_NODISCARD token_t get() const WI_NOEXCEPT
         {
             return m_token;
         }
@@ -1572,7 +1572,7 @@ namespace wil
         }
 
         //! Returns true if the call this class was expected to make is still outstanding
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return (m_ptr != nullptr);
         }
@@ -1683,7 +1683,7 @@ namespace wil
         }
 
         //! Returns true if the call that was expected is still outstanding
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return m_call;
         }
@@ -1855,7 +1855,7 @@ namespace std
     template <typename storage_t>
     struct hash<wil::unique_any_t<storage_t>>
     {
-        size_t operator()(wil::unique_any_t<storage_t> const &val) const
+        WI_NODISCARD size_t operator()(wil::unique_any_t<storage_t> const &val) const
         {
             return (hash<typename wil::unique_any_t<storage_t>::pointer>()(val.get()));
         }
@@ -1929,7 +1929,7 @@ namespace wil {
             {
             }
 
-            bool is_valid() const WI_NOEXCEPT
+            WI_NODISCARD bool is_valid() const WI_NOEXCEPT
             {
                 return (m_ptr && m_ptr->is_valid());
             }
@@ -1958,7 +1958,7 @@ namespace wil {
             }
 
             template <typename allow_t = typename policy::pointer_access, typename wistd::enable_if<!wistd::is_same<allow_t, details::pointer_access_none>::value, int>::type = 0>
-            pointer get() const WI_NOEXCEPT
+            WI_NODISCARD pointer get() const WI_NOEXCEPT
             {
                 return (m_ptr ? m_ptr->get() : policy::invalid_value());
             }
@@ -1973,7 +1973,7 @@ namespace wil {
                 return m_ptr->addressof();
             }
 
-            long int use_count() const WI_NOEXCEPT
+            WI_NODISCARD long int use_count() const WI_NOEXCEPT
             {
                 return m_ptr.use_count();
             }
@@ -2069,7 +2069,7 @@ namespace wil {
             other = wistd::move(self);
         }
 
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return storage_t::is_valid();
         }
@@ -2086,7 +2086,7 @@ namespace wil {
             return put();
         }
 
-        pointer get() const WI_NOEXCEPT
+        WI_NODISCARD pointer get() const WI_NOEXCEPT
         {
             static_assert(!wistd::is_same<typename policy::pointer_access, details::pointer_access_none>::value, "get(): the raw handle value is not available for this resource class");
             return storage_t::get();
@@ -2215,12 +2215,12 @@ namespace wil {
             m_weakPtr.swap(other.m_weakPtr);
         }
 
-        bool expired() const WI_NOEXCEPT
+        WI_NODISCARD bool expired() const WI_NOEXCEPT
         {
             return m_weakPtr.expired();
         }
 
-        shared_t lock() const WI_NOEXCEPT
+        WI_NODISCARD shared_t lock() const WI_NOEXCEPT
         {
             return shared_t(m_weakPtr.lock());
         }
@@ -2249,7 +2249,7 @@ namespace std
     template <typename storage_t>
     struct hash<wil::shared_any_t<storage_t>>
     {
-        size_t operator()(wil::shared_any_t<storage_t> const &val) const
+        WI_NODISCARD size_t operator()(wil::shared_any_t<storage_t> const &val) const
         {
             return (hash<typename wil::shared_any_t<storage_t>::pointer>()(val.get()));
         }
@@ -2662,7 +2662,7 @@ namespace wil
 
         // Checks if a *manual reset* event is currently signaled.  The event must not be an auto-reset event.
         // Use when the event will only be set once (cancellation-style) or will only be reset by the polling thread
-        bool is_signaled() const WI_NOEXCEPT
+        WI_NODISCARD bool is_signaled() const WI_NOEXCEPT
         {
             return wil::event_is_signaled(storage_t::get());
         }
@@ -2794,7 +2794,7 @@ namespace wil
 
         // Checks if the event is currently signaled.
         // Note: Unlike Win32 auto-reset event objects, this will not reset the event.
-        bool is_signaled() const WI_NOEXCEPT
+        WI_NODISCARD bool is_signaled() const WI_NOEXCEPT
         {
             return !!ReadAcquire(&m_isSignaled);
         }
@@ -3449,7 +3449,7 @@ namespace wil
             void *pointer;
             size_t sizeBytes;
             SecureZeroData(void *pointer_, size_t sizeBytes_ = 0) WI_NOEXCEPT { pointer = pointer_; sizeBytes = sizeBytes_; }
-            operator void *() const WI_NOEXCEPT { return pointer; }
+            WI_NODISCARD operator void*() const WI_NOEXCEPT { return pointer; }
             static void Close(SecureZeroData data) WI_NOEXCEPT { ::SecureZeroMemory(data.pointer, data.sizeBytes); }
         };
     }
@@ -3658,7 +3658,7 @@ namespace wil
         }
 
         // Provide access to the inner event and the very common SetEvent() method on it.
-        unique_event_nothrow const& get_event() const WI_NOEXCEPT { return storage_t::get()->m_event; }
+        WI_NODISCARD unique_event_nothrow const& get_event() const WI_NOEXCEPT { return storage_t::get()->m_event; }
         void SetEvent() const WI_NOEXCEPT { storage_t::get()->m_event.SetEvent(); }
 
     private:
@@ -4530,8 +4530,8 @@ namespace wil
                 return S_OK;
             }
 
-            wchar_t* buffer() { WI_ASSERT(m_charBuffer != nullptr);  return m_charBuffer; }
-            const wchar_t* buffer() const { return m_charBuffer; }
+            WI_NODISCARD wchar_t* buffer() { WI_ASSERT(m_charBuffer != nullptr);  return m_charBuffer; }
+            WI_NODISCARD const wchar_t* buffer() const { return m_charBuffer; }
 
             HRESULT trim_at_existing_null(size_t length) { return make(buffer(), length); }
 
@@ -4664,7 +4664,7 @@ namespace wil
         HDC dc;
         HWND hwnd;
         window_dc(HDC dc_, HWND hwnd_ = nullptr) WI_NOEXCEPT { dc = dc_; hwnd = hwnd_; }
-        operator HDC() const WI_NOEXCEPT { return dc; }
+        WI_NODISCARD operator HDC() const WI_NOEXCEPT { return dc; }
         static void close(window_dc wdc) WI_NOEXCEPT { ::ReleaseDC(wdc.hwnd, wdc.dc); }
     };
     typedef unique_any<HDC, decltype(&window_dc::close), window_dc::close, details::pointer_access_all, window_dc> unique_hdc_window;
@@ -4674,7 +4674,7 @@ namespace wil
         HWND hwnd;
         PAINTSTRUCT ps;
         paint_dc(HDC hdc = nullptr) { ::ZeroMemory(this, sizeof(*this)); ps.hdc = hdc; }
-        operator HDC() const WI_NOEXCEPT { return ps.hdc; }
+        WI_NODISCARD operator HDC() const WI_NOEXCEPT { return ps.hdc; }
         static void close(paint_dc pdc) WI_NOEXCEPT { ::EndPaint(pdc.hwnd, &pdc.ps); }
     };
     typedef unique_any<HDC, decltype(&paint_dc::close), paint_dc::close, details::pointer_access_all, paint_dc> unique_hdc_paint;
@@ -4684,7 +4684,7 @@ namespace wil
         HGDIOBJ hgdi;
         HDC hdc;
         select_result(HGDIOBJ hgdi_, HDC hdc_ = nullptr) WI_NOEXCEPT { hgdi = hgdi_; hdc = hdc_; }
-        operator HGDIOBJ() const WI_NOEXCEPT { return hgdi; }
+        WI_NODISCARD operator HGDIOBJ() const WI_NOEXCEPT { return hgdi; }
         static void close(select_result sr) WI_NOEXCEPT { ::SelectObject(sr.hdc, sr.hgdi); }
     };
     typedef unique_any<HGDIOBJ, decltype(&select_result::close), select_result::close, details::pointer_access_all, select_result> unique_select_object;
@@ -5352,7 +5352,7 @@ namespace wil
         {
         }
 
-        pointer get() const
+        WI_NODISCARD pointer get() const
         {
             return m_globalMemory;
         }
@@ -5856,17 +5856,17 @@ namespace wil
             reset();
         }
 
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return m_wdfObject != WDF_NO_HANDLE;
         }
 
-        wdf_object_t get() const WI_NOEXCEPT
+        WI_NODISCARD wdf_object_t get() const WI_NOEXCEPT
         {
             return m_wdfObject;
         }
 
-        void* get_tag() const WI_NOEXCEPT
+        WI_NODISCARD void* get_tag() const WI_NOEXCEPT
         {
             return m_tag;
         }
@@ -6004,7 +6004,7 @@ namespace wil
             reset();
         }
 
-        WDFREQUEST get() const WI_NOEXCEPT
+        WI_NODISCARD WDFREQUEST get() const WI_NOEXCEPT
         {
             return m_wdfRequest;
         }
@@ -6056,7 +6056,7 @@ namespace wil
         }
 #endif
 
-        explicit operator bool() const WI_NOEXCEPT
+        WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
         {
             return m_wdfRequest != WDF_NO_HANDLE;
         }
@@ -6211,7 +6211,7 @@ namespace wil
 
             // Exists to satisfy the interconvertibility requirement for pointer_storage and
             // pointer.
-            explicit operator PKSPIN_LOCK() const
+            WI_NODISCARD explicit operator PKSPIN_LOCK() const
             {
                 return spinLock;
             }
@@ -6340,7 +6340,7 @@ namespace wil
             }
 
             // Checks if the event is currently signaled. Does not change the state of the event.
-            bool is_signaled() const WI_NOEXCEPT
+            WI_NODISCARD bool is_signaled() const WI_NOEXCEPT
             {
                 return ::KeReadStateEvent(const_cast<PRKEVENT>(&m_kernelEvent)) ? true : false;
             }
@@ -6676,7 +6676,7 @@ namespace wil
         class crypt_catalog_enumerator
         {
             wil::unique_hcatinfo m_hCatInfo;
-            const BYTE * m_hash;
+            const BYTE* m_hash;
             DWORD m_hashLen;
             bool m_initialized = false;
 
@@ -6686,7 +6686,7 @@ namespace wil
                     m_r(r)
                 {}
 
-                operator HCATINFO() const WI_NOEXCEPT
+                WI_NODISCARD operator HCATINFO() const WI_NOEXCEPT
                 {
                     return m_r.current();
                 }
@@ -6697,12 +6697,12 @@ namespace wil
                     return info;
                 }
 
-                bool operator==(wistd::nullptr_t) const WI_NOEXCEPT
+                WI_NODISCARD bool operator==(wistd::nullptr_t) const WI_NOEXCEPT
                 {
                     return m_r.m_hCatInfo == nullptr;
                 }
 
-                bool operator!=(wistd::nullptr_t) const WI_NOEXCEPT
+                WI_NODISCARD bool operator!=(wistd::nullptr_t) const WI_NOEXCEPT
                 {
                     return !(*this == nullptr);
                 }
@@ -6727,7 +6727,7 @@ namespace wil
                 iterator &operator=(const iterator &) = default;
                 iterator &operator=(iterator &&) = default;
 
-                bool operator==(const iterator &rhs) const WI_NOEXCEPT
+                WI_NODISCARD bool operator==(const iterator &rhs) const WI_NOEXCEPT
                 {
                     if (rhs.m_r == m_r)
                     {
@@ -6737,17 +6737,17 @@ namespace wil
                     return (*this == nullptr) && (rhs == nullptr);
                 }
 
-                bool operator!=(const iterator &rhs) const WI_NOEXCEPT
+                WI_NODISCARD bool operator!=(const iterator &rhs) const WI_NOEXCEPT
                 {
                     return !(rhs == *this);
                 }
 
-                bool operator==(wistd::nullptr_t) const WI_NOEXCEPT
+                WI_NODISCARD bool operator==(wistd::nullptr_t) const WI_NOEXCEPT
                 {
                     return nullptr == m_r || nullptr == m_r->current();
                 }
 
-                bool operator!=(wistd::nullptr_t) const WI_NOEXCEPT
+                WI_NODISCARD bool operator!=(wistd::nullptr_t) const WI_NOEXCEPT
                 {
                     return !(*this == nullptr);
                 }
@@ -6762,7 +6762,7 @@ namespace wil
                     return *this;
                 }
 
-                ref operator*() const WI_NOEXCEPT
+                WI_NODISCARD ref operator*() const WI_NOEXCEPT
                 {
                     return ref(*m_r);
                 }
@@ -6825,13 +6825,13 @@ namespace wil
                 // , m_initialized(false) // redundant
             {}
 
-            iterator begin() WI_NOEXCEPT
+            WI_NODISCARD iterator begin() WI_NOEXCEPT
             {
                 init();
                 return iterator(this);
             }
 
-            iterator end() const WI_NOEXCEPT
+            WI_NODISCARD iterator end() const WI_NOEXCEPT
             {
                 return iterator(nullptr);
             }

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -612,7 +612,7 @@ namespace wil
                 errors[errorCurrentIndex].Set(info, ::InterlockedIncrementNoFence(failureSequenceId));
             }
 
-            bool GetLastError(_Inout_ wil::FailureInfo& info, unsigned int minSequenceId, HRESULT matchRequirement) const
+            WI_NODISCARD bool GetLastError(_Inout_ wil::FailureInfo& info, unsigned int minSequenceId, HRESULT matchRequirement) const
             {
                 if (!errors)
                 {
@@ -959,7 +959,7 @@ namespace wil
                 m_ppThreadList = nullptr;
             }
 
-            bool IsWatching() const
+            WI_NODISCARD bool IsWatching() const
             {
                 return (m_threadId != 0);
             }
@@ -1249,12 +1249,12 @@ namespace wil
             m_callbackHolder.StopWatching();
         }
 
-        FailureInfo const *GetFailure()
+        FailureInfo const* GetFailure()
         {
             return (FAILED(m_failure.GetFailureInfo().hr) ? &(m_failure.GetFailureInfo()) : nullptr);
         }
 
-        bool NotifyFailure(FailureInfo const &failure) WI_NOEXCEPT override
+        bool NotifyFailure(FailureInfo const& failure) WI_NOEXCEPT override
         {
             // When we "cache" a failure, we bias towards trying to find the origin of the last HRESULT
             // generated, so we ignore subsequent failures on the same error code (assuming propagation).

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -1559,7 +1559,7 @@ namespace wil
                 return create(nullptr, cbData);
             }
 
-            void* get(_Out_opt_ size_t *pSize = nullptr) const WI_NOEXCEPT
+            WI_NODISCARD void* get(_Out_opt_ size_t *pSize = nullptr) const WI_NOEXCEPT
             {
                 if (pSize != nullptr)
                 {
@@ -1568,17 +1568,17 @@ namespace wil
                 return (m_pCopy == nullptr) ? nullptr : (m_pCopy + 1);
             }
 
-            size_t size() const WI_NOEXCEPT
+            WI_NODISCARD size_t size() const WI_NOEXCEPT
             {
                 return m_size;
             }
 
-            explicit operator bool() const WI_NOEXCEPT
+            WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
             {
                 return (m_pCopy != nullptr);
             }
 
-            bool unique() const WI_NOEXCEPT
+            WI_NODISCARD bool unique() const WI_NOEXCEPT
             {
                 return ((m_pCopy != nullptr) && (*m_pCopy == 1));
             }
@@ -1706,22 +1706,22 @@ namespace wil
                 return true;
             }
 
-            object_t* get() const WI_NOEXCEPT
+            WI_NODISCARD object_t* get() const WI_NOEXCEPT
             {
                 return (m_pCopy == nullptr) ? nullptr : &m_pCopy->m_object;
             }
 
-            explicit operator bool() const WI_NOEXCEPT
+            WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
             {
                 return (m_pCopy != nullptr);
             }
 
-            bool unique() const WI_NOEXCEPT
+            WI_NODISCARD bool unique() const WI_NOEXCEPT
             {
                 return ((m_pCopy != nullptr) && (m_pCopy->m_refCount == 1));
             }
 
-            object_t *operator->() const WI_NOEXCEPT
+            WI_NODISCARD object_t* operator->() const WI_NOEXCEPT
             {
                 return get();
             }
@@ -2044,7 +2044,7 @@ __WI_POP_WARNINGS
             return err;
         }
 
-        inline __declspec(noinline) DWORD GetLastErrorFail() WI_NOEXCEPT 
+        inline __declspec(noinline) DWORD GetLastErrorFail() WI_NOEXCEPT
         {
             __R_FN_LOCALS_FULL_RA;
             return GetLastErrorFail(__R_FN_CALL_FULL);
@@ -2530,7 +2530,7 @@ __WI_POP_WARNINGS
             SetFailureInfo(other);
         }
 
-        FailureInfo const & GetFailureInfo() const WI_NOEXCEPT
+        WI_NODISCARD FailureInfo const& GetFailureInfo() const WI_NOEXCEPT
         {
             return m_failureInfo;
         }
@@ -2606,7 +2606,7 @@ __WI_POP_WARNINGS
         }
 
         //! Returns the failed HRESULT that this exception represents.
-        _Always_(_Post_satisfies_(return < 0)) HRESULT GetErrorCode() const WI_NOEXCEPT
+        _Always_(_Post_satisfies_(return < 0)) WI_NODISCARD HRESULT GetErrorCode() const WI_NOEXCEPT
         {
             HRESULT const hr = m_failure.GetFailureInfo().hr;
             __analysis_assume(hr < 0);
@@ -2614,7 +2614,7 @@ __WI_POP_WARNINGS
         }
 
         //! Returns the failed NTSTATUS that this exception represents.
-        _Always_(_Post_satisfies_(return < 0)) NTSTATUS GetStatusCode() const WI_NOEXCEPT
+        _Always_(_Post_satisfies_(return < 0)) WI_NODISCARD NTSTATUS GetStatusCode() const WI_NOEXCEPT
         {
             NTSTATUS const status = m_failure.GetFailureInfo().status;
             __analysis_assume(status < 0);
@@ -2622,7 +2622,7 @@ __WI_POP_WARNINGS
         }
 
         //! Get a reference to the stored FailureInfo.
-        FailureInfo const & GetFailureInfo() const WI_NOEXCEPT
+        WI_NODISCARD FailureInfo const& GetFailureInfo() const WI_NOEXCEPT
         {
             return m_failure.GetFailureInfo();
         }
@@ -2634,7 +2634,7 @@ __WI_POP_WARNINGS
         }
 
         //! Provides a string representing the FailureInfo from this exception.
-        inline const char * __CLR_OR_THIS_CALL what() const WI_NOEXCEPT override
+        WI_NODISCARD inline const char* __CLR_OR_THIS_CALL what() const WI_NOEXCEPT override
         {
             if (!m_what)
             {

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -158,13 +158,13 @@ namespace wil
             : std::basic_string_view<TChar>(&str[0], str.size()) {}
 
         // basic_string_view [] precondition won't let us read view[view.size()]; so we define our own.
-        constexpr const TChar& operator[](size_type idx) const noexcept
+        WI_NODISCARD constexpr const TChar& operator[](size_type idx) const noexcept
         {
             WI_ASSERT(idx <= this->size() && this->data() != nullptr);
             return this->data()[idx];
         }
 
-        constexpr const TChar* c_str() const noexcept
+        WI_NODISCARD constexpr const TChar* c_str() const noexcept
         {
             WI_ASSERT(this->data() == nullptr || this->data()[this->size()] == 0);
             return this->data();

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -286,7 +286,7 @@ namespace wil
 
         ~TwoPhaseHStringConstructor() = default;
 
-        explicit operator PCWSTR() const
+        WI_NODISCARD explicit operator PCWSTR() const
         {
             // This is set by WindowsPromoteStringBuffer() which must be called to
             // construct this object via the static method Preallocate().
@@ -294,15 +294,15 @@ namespace wil
         }
 
         //! Returns a pointer for the buffer so it can be populated
-        wchar_t* Get() const { return const_cast<wchar_t*>(m_maker.buffer()); }
+        WI_NODISCARD wchar_t* Get() const { return const_cast<wchar_t*>(m_maker.buffer()); }
         //! Used to validate range of buffer when populating.
-        ULONG ByteSize() const { return m_characterLength * sizeof(wchar_t); }
+        WI_NODISCARD ULONG ByteSize() const { return m_characterLength * sizeof(wchar_t); }
 
         /** Ensure that the size of the data provided is consistent with the pre-allocated buffer.
         It seems that WindowsPreallocateStringBuffer() provides the null terminator in the buffer
         (based on testing) so this can be called before populating the buffer.
         */
-        HRESULT Validate(ULONG bytesRead) const
+        WI_NODISCARD HRESULT Validate(ULONG bytesRead) const
         {
             // Null termination is required for the buffer before calling WindowsPromoteStringBuffer().
             RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_DATA),
@@ -387,7 +387,7 @@ namespace wil
         using is_transparent = void;
 
         template <typename LhsT, typename RhsT>
-        auto operator()(const LhsT& lhs, const RhsT& rhs) const WI_NOEXCEPT ->
+        WI_NODISCARD auto operator()(const LhsT& lhs, const RhsT& rhs) const WI_NOEXCEPT ->
             decltype(details::hstring_compare<true, false>::less(lhs, rhs))
         {
             return details::hstring_compare<true, false>::less(lhs, rhs);
@@ -414,7 +414,7 @@ namespace wil
         using is_transparent = void;
 
         template <typename LhsT, typename RhsT>
-        auto operator()(const LhsT& lhs, const RhsT& rhs) const WI_NOEXCEPT ->
+        WI_NODISCARD auto operator()(const LhsT& lhs, const RhsT& rhs) const WI_NOEXCEPT ->
             decltype(details::hstring_compare<true, true>::less(lhs, rhs))
         {
             return details::hstring_compare<true, true>::less(lhs, rhs);
@@ -446,15 +446,15 @@ namespace wil
             {
                 type() = default;
                 type(T&& value) : m_value(wistd::forward<T>(value)) {}
-                operator T() const { return m_value; }
+                WI_NODISCARD operator T() const { return m_value; }
                 type& operator=(T&& value) { m_value = wistd::forward<T>(value); return *this; }
-                T Get() const { return m_value; }
+                WI_NODISCARD T Get() const { return m_value; }
 
                 // Returning T&& to support move only types
                 // In case of absence of T::operator=(T&&) a call to T::operator=(const T&) will happen
                 T&& Get()          { return wistd::move(m_value); }
 
-                HRESULT CopyTo(T* result) const { *result = m_value; return S_OK; }
+                WI_NODISCARD HRESULT CopyTo(T* result) const { *result = m_value; return S_OK; }
                 T* GetAddressOf()  { return &m_value; }
                 T* ReleaseAndGetAddressOf() { return &m_value; }
                 T* operator&()     { return &m_value; }
@@ -661,51 +661,51 @@ namespace wil
                 return *this;
             }
 
-            vector_iterator operator+(int n) const
+            WI_NODISCARD vector_iterator operator+(int n) const
             {
                 vector_iterator ret(*this);
                 ret += n;
                 return ret;
             }
 
-            vector_iterator operator-(int n) const
+            WI_NODISCARD vector_iterator operator-(int n) const
             {
                 vector_iterator ret(*this);
                 ret -= n;
                 return ret;
             }
 
-            ptrdiff_t operator-(const vector_iterator& other) const
+            WI_NODISCARD ptrdiff_t operator-(const vector_iterator& other) const
             {
                 return m_i - other.m_i;
             }
 
-            bool operator==(const vector_iterator& other) const
+            WI_NODISCARD bool operator==(const vector_iterator& other) const
             {
                 return m_i == other.m_i;
             }
 
-            bool operator!=(const vector_iterator& other) const
+            WI_NODISCARD bool operator!=(const vector_iterator& other) const
             {
                 return m_i != other.m_i;
             }
 
-            bool operator<(const vector_iterator& other) const
+            WI_NODISCARD bool operator<(const vector_iterator& other) const
             {
                 return m_i < other.m_i;
             }
 
-            bool operator>(const vector_iterator& other) const
+            WI_NODISCARD bool operator>(const vector_iterator& other) const
             {
                 return m_i > other.m_i;
             }
 
-            bool operator<=(const vector_iterator& other) const
+            WI_NODISCARD bool operator<=(const vector_iterator& other) const
             {
                 return m_i <= other.m_i;
             }
 
-            bool operator>=(const vector_iterator& other) const
+            WI_NODISCARD bool operator>=(const vector_iterator& other) const
             {
                 return m_i >= other.m_i;
             }
@@ -775,12 +775,12 @@ namespace wil
             {
             }
 
-            reference operator*() const
+            WI_NODISCARD reference operator*() const
             {
                 return m_range->m_currentElement;
             }
 
-            pointer operator->() const
+            WI_NODISCARD pointer operator->() const
             {
                 return wistd::addressof(m_range->m_currentElement);
             }
@@ -827,12 +827,12 @@ namespace wil
                 return *this;
             }
 
-            bool operator==(vector_iterator_nothrow const& other) const
+            WI_NODISCARD bool operator==(vector_iterator_nothrow const& other) const
             {
                 return FAILED(*m_range->m_result) || (m_i == other.m_i);
             }
 
-            bool operator!=(vector_iterator_nothrow const& other) const
+            WI_NODISCARD bool operator!=(vector_iterator_nothrow const& other) const
             {
                 return !operator==(other);
             }
@@ -935,12 +935,12 @@ namespace wil
                 return *this;
             }
 
-            bool operator==(iterable_iterator const& other) const
+            WI_NODISCARD bool operator==(iterable_iterator const& other) const
             {
                 return m_i == other.m_i;
             }
 
-            bool operator!=(iterable_iterator const& other) const
+            WI_NODISCARD bool operator!=(iterable_iterator const& other) const
             {
                 return !operator==(other);
             }
@@ -1100,22 +1100,22 @@ namespace wil
             {
             }
 
-            bool operator==(iterable_iterator_nothrow const& other) const
+            WI_NODISCARD bool operator==(iterable_iterator_nothrow const& other) const
             {
                 return FAILED(*m_range->m_result) || (m_i == other.m_i);
             }
 
-            bool operator!=(iterable_iterator_nothrow const& other) const
+            WI_NODISCARD bool operator!=(iterable_iterator_nothrow const& other) const
             {
                 return !operator==(other);
             }
 
-            reference operator*() const WI_NOEXCEPT
+            WI_NODISCARD reference operator*() const WI_NOEXCEPT
             {
                 return m_range->m_element;
             }
 
-            pointer operator->() const WI_NOEXCEPT
+            WI_NODISCARD pointer operator->() const WI_NOEXCEPT
             {
                 return wistd::addressof(m_range->m_element);
             }
@@ -1461,12 +1461,12 @@ namespace details
                 return S_OK;
             }
 
-            HANDLE GetEvent() const
+            WI_NODISCARD HANDLE GetEvent() const
             {
                 return m_completedEventHandle.get();
             }
 
-            ABI::Windows::Foundation::AsyncStatus GetStatus() const
+            WI_NODISCARD ABI::Windows::Foundation::AsyncStatus GetStatus() const
             {
                 return m_status;
             }
@@ -1935,12 +1935,12 @@ public:
         reset();
     }
 
-    explicit operator bool() const WI_NOEXCEPT
+    WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
     {
         return (m_token.Value != 0);
     }
 
-    Windows::Foundation::EventRegistrationToken get() const WI_NOEXCEPT
+    WI_NODISCARD Windows::Foundation::EventRegistrationToken get() const WI_NOEXCEPT
     {
         return m_token;
     }
@@ -2043,12 +2043,12 @@ public:
         reset();
     }
 
-    explicit operator bool() const WI_NOEXCEPT
+    WI_NODISCARD explicit operator bool() const WI_NOEXCEPT
     {
         return (m_token.value != 0);
     }
 
-    ::EventRegistrationToken get() const WI_NOEXCEPT
+    WI_NODISCARD ::EventRegistrationToken get() const WI_NOEXCEPT
     {
         return m_token;
     }

--- a/include/wil/wistd_config.h
+++ b/include/wil/wistd_config.h
@@ -476,37 +476,37 @@ namespace wistd     // ("Windows Implementation" std)
      template <class _T1, class _T2 = _T1>
      struct __less
      {
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
 
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T1& __x, const _T2& __y) const {return __x < __y;}
 
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T2& __x, const _T1& __y) const {return __x < __y;}
 
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T2& __x, const _T2& __y) const {return __x < __y;}
      };
 
      template <class _T1>
      struct __less<_T1, _T1>
      {
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
      };
 
      template <class _T1>
      struct __less<const _T1, _T1>
      {
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
      };
 
      template <class _T1>
      struct __less<_T1, const _T1>
      {
-     __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY __WI_LIBCPP_CONSTEXPR_AFTER_CXX11
      bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
      };
 

--- a/include/wil/wistd_functional.h
+++ b/include/wil/wistd_functional.h
@@ -325,7 +325,7 @@ namespace wistd     // ("Windows Implementation" std)
         void swap(function&);
 
         // function capacity:
-        __WI_LIBCPP_INLINE_VISIBILITY
+        __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
             __WI_LIBCPP_EXPLICIT operator bool() const WI_NOEXCEPT {return __f_;}
 
         // deleted overloads close possible hole in the type system

--- a/include/wil/wistd_memory.h
+++ b/include/wil/wistd_memory.h
@@ -106,7 +106,7 @@ namespace wistd     // ("Windows Implementation" std)
 #endif
 
       __WI_LIBCPP_INLINE_VISIBILITY reference __get() WI_NOEXCEPT { return __value_; }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       const_reference __get() const WI_NOEXCEPT { return __value_; }
 
     private:
@@ -141,7 +141,7 @@ namespace wistd     // ("Windows Implementation" std)
 #endif
 
       __WI_LIBCPP_INLINE_VISIBILITY reference __get() WI_NOEXCEPT { return *this; }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       const_reference __get() const WI_NOEXCEPT { return *this; }
     };
 
@@ -213,7 +213,7 @@ namespace wistd     // ("Windows Implementation" std)
         return static_cast<_Base1&>(*this).__get();
       }
 
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       typename _Base1::const_reference first() const WI_NOEXCEPT {
         return static_cast<_Base1 const&>(*this).__get();
       }
@@ -223,7 +223,7 @@ namespace wistd     // ("Windows Implementation" std)
         return static_cast<_Base2&>(*this).__get();
       }
 
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       typename _Base2::const_reference second() const WI_NOEXCEPT {
         return static_cast<_Base2 const&>(*this).__get();
       }
@@ -531,16 +531,16 @@ namespace wistd     // ("Windows Implementation" std)
         return *this;
       }
 
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       typename add_lvalue_reference<_Tp>::type
       operator*() const {
         return *__ptr_.first();
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       pointer operator->() const WI_NOEXCEPT {
         return __ptr_.first();
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       pointer get() const WI_NOEXCEPT {
         return __ptr_.first();
       }
@@ -548,11 +548,11 @@ namespace wistd     // ("Windows Implementation" std)
       deleter_type& get_deleter() WI_NOEXCEPT {
         return __ptr_.second();
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       const deleter_type& get_deleter() const WI_NOEXCEPT {
         return __ptr_.second();
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       __WI_LIBCPP_EXPLICIT operator bool() const WI_NOEXCEPT {
         return __ptr_.first() != nullptr;
       }
@@ -812,12 +812,12 @@ namespace wistd     // ("Windows Implementation" std)
         return *this;
       }
 
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       typename add_lvalue_reference<_Tp>::type
       operator[](size_t __i) const {
         return __ptr_.first()[__i];
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       pointer get() const WI_NOEXCEPT {
         return __ptr_.first();
       }
@@ -827,11 +827,11 @@ namespace wistd     // ("Windows Implementation" std)
         return __ptr_.second();
       }
 
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       const deleter_type& get_deleter() const WI_NOEXCEPT {
         return __ptr_.second();
       }
-      __WI_LIBCPP_INLINE_VISIBILITY
+      __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
       __WI_LIBCPP_EXPLICIT operator bool() const WI_NOEXCEPT {
         return __ptr_.first() != nullptr;
       }

--- a/include/wil/wistd_type_traits.h
+++ b/include/wil/wistd_type_traits.h
@@ -116,10 +116,10 @@ namespace wistd     // ("Windows Implementation" std)
         static __WI_LIBCPP_CONSTEXPR const _Tp      value = __v;
         typedef _Tp               value_type;
         typedef integral_constant type;
-        __WI_LIBCPP_INLINE_VISIBILITY
+        __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
             __WI_LIBCPP_CONSTEXPR operator value_type() const WI_NOEXCEPT {return value;}
 #if __WI_LIBCPP_STD_VER > 11
-        __WI_LIBCPP_INLINE_VISIBILITY
+        __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_INLINE_VISIBILITY
             constexpr value_type operator ()() const WI_NOEXCEPT {return value;}
 #endif
     };
@@ -2004,7 +2004,7 @@ namespace wistd     // ("Windows Implementation" std)
 #endif
      struct __WI_LIBCPP_TEMPLATE_VIS less : binary_function<_Tp, _Tp, bool>
      {
-     __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 __WI_LIBCPP_INLINE_VISIBILITY
+     __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 __WI_LIBCPP_INLINE_VISIBILITY
      bool operator()(const _Tp& __x, const _Tp& __y) const
           {return __x < __y;}
      };
@@ -2014,7 +2014,7 @@ namespace wistd     // ("Windows Implementation" std)
     struct __WI_LIBCPP_TEMPLATE_VIS less<void>
     {
         template <class _T1, class _T2>
-        __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 __WI_LIBCPP_INLINE_VISIBILITY
+        __WI_LIBCPP_NODISCARD_ATTRIBUTE __WI_LIBCPP_CONSTEXPR_AFTER_CXX11 __WI_LIBCPP_INLINE_VISIBILITY
         auto operator()(_T1&& __t, _T2&& __u) const
         __WI_NOEXCEPT_(noexcept(wistd::forward<_T1>(__t) < wistd::forward<_T2>(__u)))
         -> decltype        (wistd::forward<_T1>(__t) < wistd::forward<_T2>(__u))

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -27,6 +27,17 @@ jobs:
       call scripts\build_all.cmd
     displayName: 'Build x86'
 
+  # NOTE: We run the tests in the 32-bit cross-tools window out of convenience as this adds all necessary directories to
+  # the PATH that are necessary for finding the ASan/UBSan DLLs
+  - script: |
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat""
+      call scripts\runtests.cmd ~[LocalOnly]
+    displayName: 'Run x86 Tests'
+
+  - script: |
+      rmdir /s /q build
+    displayName: 'Clean x86 Output'
+
   - script: |
       call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       if %ERRORLEVEL% NEQ 0 goto :eof
@@ -42,4 +53,4 @@ jobs:
   - script: |
       call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat""
       call scripts\runtests.cmd ~[LocalOnly]
-    displayName: 'Run Tests'
+    displayName: 'Run x64 Tests'

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -562,7 +562,7 @@ TEST_CASE("ComTests::Test_ConstPointer", "[com][com_ptr]")
 
     REQUIRE(spUnk.get() != nullptr);
     REQUIRE(spUnk);
-    spUnk.addressof();
+    (void)spUnk.addressof();
     spUnk.copy_to(spUnkHelper.addressof());
     spUnk.copy_to(spInspectable.addressof());
     spUnk.copy_to(IID_PPV_ARGS(&spInspectable));
@@ -801,7 +801,7 @@ void TestSmartPointer(const Ptr& ptr1, const Ptr& ptr2)
         auto address = ptr1.addressof();
         REQUIRE(*address == ptr1.get());
         (void)static_cast<bool>(ptr1);
-        ptr1.get();
+        (void)ptr1.get();
         auto deref = ptr1.operator->();
         (void)deref;
         if (ptr1)
@@ -1452,7 +1452,7 @@ void TestSmartPointerQueryIidPpv(wistd::true_type, const Ptr& source)       // i
         if (source)
         {
             DestPtr dest;
-            source.query_to(IID_PPV_ARGS(&dest));
+            REQUIRE_NOERROR(source.query_to(IID_PPV_ARGS(&dest)));
             REQUIRE_ERROR(source.query_to(IID_PPV_ARGS(&never)));
             REQUIRE((dest && !never));
         }
@@ -1488,15 +1488,15 @@ void TestSmartPointerQueryIidPpv(wistd::true_type, const Ptr& source)       // i
         if (source)
         {
             DestPtr dest;
-            source.copy_to(IID_PPV_ARGS(&dest));
+            REQUIRE_NOERROR(source.copy_to(IID_PPV_ARGS(&dest)));
             REQUIRE_ERROR(source.copy_to(IID_PPV_ARGS(&never)));
             REQUIRE((dest && !never));
         }
         else
         {
             DestPtr dest;
-            source.copy_to(IID_PPV_ARGS(&dest));
-            source.copy_to(IID_PPV_ARGS(&never));
+            REQUIRE_NOERROR(source.copy_to(IID_PPV_ARGS(&dest)));
+            REQUIRE_NOERROR(source.copy_to(IID_PPV_ARGS(&never)));
             REQUIRE((!dest && !never));
         }
     }
@@ -1539,7 +1539,7 @@ void TestSmartPointerQuery(const Ptr& source)
         if (source)
         {
             DestPtr dest;
-            source.query_to(&dest);
+            REQUIRE_NOERROR(source.query_to(&dest));
             REQUIRE_ERROR(source.query_to(&never));
             REQUIRE((dest && !never));
         }
@@ -1589,15 +1589,15 @@ void TestSmartPointerQuery(const Ptr& source)
         if (source)
         {
             DestPtr dest;
-            source.copy_to(&dest);
+            REQUIRE_NOERROR(source.copy_to(&dest));
             REQUIRE_ERROR(source.copy_to(&never));
             REQUIRE((dest && !never));
         }
         else
         {
             DestPtr dest;
-            source.copy_to(&dest);
-            source.copy_to(&never);
+            REQUIRE_NOERROR(source.copy_to(&dest));
+            REQUIRE_NOERROR(source.copy_to(&never));
             REQUIRE((!dest && !never));
         }
     }

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1968,7 +1968,7 @@ TEST_CASE("WindowsInternalTests::WistdTests", "[resource][wistd]")
     sp->Method();
     decltype(sp) sp2;
     sp2 = wistd::move(sp);
-    sp2.get();
+    (void)sp2.get();
 
     wistd::unique_ptr<int> spConstruct;
     wistd::unique_ptr<int> spConstruct2 = nullptr;
@@ -1981,7 +1981,7 @@ TEST_CASE("WindowsInternalTests::WistdTests", "[resource][wistd]")
     spConstruct = std::move(spConstruct2);
     spConstruct.swap(spConstruct2);
     REQUIRE(*spConstruct4 == 4);
-    spConstruct4.get();
+    (void)spConstruct4.get();
     if (spConstruct4)
     {
     }


### PR DESCRIPTION
It's become a generally accepted pattern in C++ to make non-`void` returning `const` member functions be `[[nodiscard]]` (or in the case of Herb's cpp2, the default everywhere). The idea is that a `const` function is not modifying any state, and therefore the caller should be interested in anything the function returns. I also went ahead and addressed things in the `wistd` namespace (even though `std` doesn't have the attribute) with the thought that it should benefit callers in general. There are a couple of exceptions to this, though:
* Functions with "out"/"in out" parameters were kept as-is. This was to avoid breaking too much valid/correct code that either doesn't care about the return value or can deduce the return value by the side effects to the output parameter (e.g. functions that do a QI).
* Functions that may have irrelevant return values/types for some subset of input values. E.g. waiting with `INFINITE` time. This was also done to avoid breaking too much correct code.
* Functions that are "too generic" to the point where we can't make any assumptions about their semantics were left alone. E.g. `wistd::function::operator()`.

Functions were identified by a combination of `clang-query` and manual code inspection. The mostly correct matcher argument for `clang-query` that I used was:

```
m cxxMethodDecl(isConst(), isExpansionInFileMatching("include[/\\]wil[/\\].*"), unless(hasAttr("attr::WarnUnusedResult")), unless(ofClass(isLambda())), unless(isDeleted()), unless(returns(voidType())))
```

The list of `const` member functions that didn't have the attribute added are:
* `wistd::function::operator()` - can't statically determine the semantics of the call.
* `wil::event_t::wait` - callers can - and generally do - assume the call can't fail when called with `INFINITE` wait time.
* `wil::com_ptr_t::(try_)(query|copy)_to` - callers can - and sometimes do - deduce the return value from whether or not the output pointer is null.

This change does not:
* Address any non-`const` member functions with the exception of functions with the same name as a `const` function to reduce confusion (e.g. `begin`, etc.).
* Address any non-member or `static` functions, even though these may have similar semantics of not modifying state.
* Re-visit whether some non-`const` member functions can/should be made `const`.
* Do anything to prohibit violating this rule in the future. We'll just have to be vigilant going forward.

I chose not to tackle these to limit the scope. We can try and tackle these in another change, if desired.

The plan is to just `(void)` any existing offending calls that are found. The idea is more to catch bugs moving forward, not find/fix bugs that may or may not already exist.