### PR TITLE
Fix natvis for wistd types

### DIFF
--- a/natvis/wil.natvis
+++ b/natvis/wil.natvis
@@ -8,46 +8,80 @@
     PARTICULAR PURPOSE AND NONINFRINGEMENT.
 -->
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-    <Type Name="wistd::_Func_impl&lt;*&gt;">
-        <DisplayString>{_Callee._Object}</DisplayString>
+    <Type Name="wistd::default_delete&lt;*&gt;">
+        <DisplayString>default_delete</DisplayString>
+        <Expand />
+    </Type>
+
+    <Type Name="wistd::__compressed_pair_elem&lt;*,*,0&gt;">
+        <Intrinsic Name="get" Expression="__value_" />
+        <DisplayString>{get()}</DisplayString>
+        <Expand>
+            <ExpandedItem>get()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__compressed_pair_elem&lt;*,*,1&gt;">
+        <Intrinsic Name="get" Expression="*($T1*)this" />
+        <DisplayString>{get()}</DisplayString>
+        <Expand>
+            <ExpandedItem>get()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__compressed_pair&lt;*&gt;">
+        <Intrinsic Name="first" Expression="(static_cast&lt;_Base1*&gt;(this))->get()" />
+        <Intrinsic Name="second" Expression="(static_cast&lt;_Base2*&gt;(this))->get()" />
+        <DisplayString>({first()}, {second()})</DisplayString>
+        <Expand>
+            <Item Name="[first]">first()</Item>
+            <Item Name="[second]">second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__function::__func&lt;*&gt;">
+        <DisplayString>{__f_}</DisplayString>
         <Expand>
         </Expand>
     </Type>
 
     <Type Name="wistd::function&lt;*&gt;">
-        <DisplayString Condition="_Impl == 0">empty</DisplayString>
-        <DisplayString Condition="_Impl != 0">{*_Impl}</DisplayString>
+        <DisplayString Condition="__f_ == 0">empty</DisplayString>
+        <DisplayString Condition="__f_ != 0">{*__f_}</DisplayString>
         <Expand>
-            <ExpandedItem Condition="_Impl != 0">*_Impl</ExpandedItem>
+            <ExpandedItem Condition="__f_ != 0">*__f_</ExpandedItem>
         </Expand>
     </Type>
 
     <Type Name="wistd::unique_ptr&lt;*&gt;">
-        <DisplayString Condition="_Myptr == 0">empty</DisplayString>
-        <DisplayString Condition="_Myptr != 0">{*_Myptr}</DisplayString>
-        <StringView>_Myptr</StringView>
+        <SmartPointer Usage="Minimal">__ptr_.first()</SmartPointer>
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{*__ptr_.first()}</DisplayString>
         <Expand>
-            <Item Name="[pointer]" Condition="_Myptr != 0">_Myptr</Item>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
         </Expand>
     </Type>
 
-    <Type Name="wistd::unique_ptr&lt;wchar_t[*],*&gt;">
-        <DisplayString Condition="_Myptr == 0">empty</DisplayString>
-        <DisplayString Condition="_Myptr != 0">{_Myptr,su}</DisplayString>
-        <StringView>_Myptr</StringView>
+    <Type Name="wistd::unique_ptr&lt;wchar_t[],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),su}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
         <Expand>
-            <Item Name="[pointer]" Condition="_Myptr != 0">_Myptr</Item>
-            <Item Name="[length]" Condition="_Myptr != 0">wcslen(_Myptr)</Item>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">wcslen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
         </Expand>
     </Type>
 
-    <Type Name="wistd::unique_ptr&lt;char[*],*&gt;">
-        <DisplayString Condition="_Myptr == 0">empty</DisplayString>
-        <DisplayString Condition="_Myptr != 0">{_Myptr,s}</DisplayString>
-        <StringView>_Myptr</StringView>
+    <Type Name="wistd::unique_ptr&lt;char[],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),s}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
         <Expand>
-            <Item Name="[pointer]" Condition="_Myptr != 0">_Myptr</Item>
-            <Item Name="[length]" Condition="_Myptr != 0">strlen(_Myptr)</Item>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">strlen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
         </Expand>
     </Type>
 

--- a/natvis/wil.natvis
+++ b/natvis/wil.natvis
@@ -74,7 +74,29 @@
         </Expand>
     </Type>
 
+    <Type Name="wistd::unique_ptr&lt;wchar_t[*],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),su}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">wcslen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
     <Type Name="wistd::unique_ptr&lt;char[],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),s}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">strlen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;char[*],*&gt;">
         <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
         <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),s}</DisplayString>
         <StringView>__ptr_.first()</StringView>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,8 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../natvis/wil.natvis
     )
 
+add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/wil.natvis)
+
 add_subdirectory(app)
 add_subdirectory(cpplatest)
 add_subdirectory(noexcept)


### PR DESCRIPTION
History: The `wistd::` types used to be copied from MSVC's STL, however the open sourcing of WIL predates the open sourcing of the STL and the licensing for the STL hadn't been figured out by the time we went public. Therefore, we switched these implementations over to be a derivative of libcpp.

Since that transition, nobody has updated the natvis file to reflect the new implementations. This change rectifies that. Note that:
1. I've only tested on windbg (which is kind of annoying because there's already a version that ships with the debugger, or at least for the internal debugger). I have not yet figured out how to test on VS
2. There seems to occasionally be an issue with `__compressed_pair`. If I inspect something like `wistd::unique_ptr<int>`, everything looks right and the deleter shows as `default_delete`. However, if I instead inspect another type that uses something like `function_deleter`, I see the error `Unexpected failure to dereference object`. I'm unsure why this happens. I'm curious if it somehow has to do with EBO getting in the way, but that wouldn't explain why something like `default_delete` works fine. The experience otherwise isn't that bad. It'll still show the rest of the info, just give the error for the deleter, which nobody going to inspect anyway, especially since it has no state.

Also, as mentioned above, there seems to be a version of the natvis that ships with the internal debugger (and maybe the public version). The file seems to be pulled from the OS repo, which I've never sync'd before, so I'll be sure to do that for the next one.