### PR TITLE
Work around noexcept-in-type-system VS2017 bug

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2547,7 +2547,7 @@ namespace wil
     }
 
     template <ULONG flags = 0>
-    using unique_private_namespace = unique_any_handle_null_only<decltype(details::ClosePrivateNamespaceHelper<flags>), &details::ClosePrivateNamespaceHelper<flags>>;
+    using unique_private_namespace = unique_any_handle_null_only<void(__stdcall*)(HANDLE) WI_PFN_NOEXCEPT, &details::ClosePrivateNamespaceHelper<flags>>;
 
     using unique_private_namespace_close = unique_private_namespace<>;
     using unique_private_namespace_destroy = unique_private_namespace<PRIVATE_NAMESPACE_FLAG_DESTROY>;


### PR DESCRIPTION
Fixes #302 

TL;DR - as I recall from vague understanding in the past - is that MSVC's "noexcept in the type system" update for C++17 "infected" pre-C++17 compilations, specifically for `decltype`. From what I recall when this initially started to impact us, `decltype` includes `noexcept` in the type, but that makes it impossible to assign/bind anything to such a function pointer since the `noexcept` gets dropped (as it should pre-C++17). VS2017 seems to be _even more_ broken than this as allegedly even building with C++17 as the standard produces an error.

This change explicitly declares the function pointer type so that the issue will not be observed with the buggy version of the compiler. Ideally, we could just drop the type and use `auto`, but that's also a C++17 feature :/