### PR TITLE
co_await resume_any_apartment(async) resumes in any apartment

### DIFF
--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -226,7 +226,7 @@ namespace winrt
 namespace wil::details
 {
     // Detect whether the C++/WinRT version uses v1 or v2 cancellation.
-    constexpr bool v2_await_cancellation = minor_version_from_string(CPPWINRT_VERSION) >= 230207;
+    inline constexpr bool v2_await_cancellation = minor_version_from_string(CPPWINRT_VERSION) >= 230207;
     template<typename Derived>
     using winrt_cancellation_base = std::conditional_t<v2_await_cancellation, winrt::cancellable_awaiter<Derived>, winrt::enable_await_cancellation>;
 
@@ -349,7 +349,7 @@ namespace wil
     ~~~
     */
     template<typename Async>
-    auto resume_any_apartment(Async&& async)
+    inline auto resume_any_apartment(Async&& async)
     {
         return details::agile_await_adapter<Async>{ async };
     }


### PR DESCRIPTION
This lets you override the default "return to the original apartment" behavior of `co_await`'ing an `IAsyncInfo`.

This is the C++/WinRT counterpart to C# `ConfigureAwait(false)`.

This is basically a copy of the C++/WinRT awaiter, but with the one line of apartment-switching code deleted. Unfortunately, it's a good amount of code that has to be duplicated.

The code is made a bit more complicated by the fact that it has to deal with two sets of client options:

* C++/WinRT version 230207 introduced a breaking change in how custom awaiters support cancellation propagation, so we generate different cancellation support depending on which C++/WinRT version you are using.
* Avoiding a memory corruption bug in MSVC pre-standardization coroutines. This is fixed in VS version 16.11, but pre-16.11 and post-16.11 pre-standardization coroutines are ABI compatible, so changing behavior based on the VS version could lead to ODR violations. Instead, we key off the ABI breaking change in MSVC standardized coroutines in C++20, since the ABI break prevents you from linking pre-standardized coroutines with standardized coroutines. (This is the same solution that C++/WinRT itself uses.)

The `resume_any_apartment` helper activates if you include `cppwinrt_helpers.h` after `winrt/Windows.Foundation.h`. You can include `cppwinrt_helpers.h` multiple times, and any new features are activated based on whatever headers you've included since the previous time you include `cppwinrt_helpers.h`.

Fixes #274