### PR TITLE
Wait for the overlapped operation to be signaled as canceled

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -622,6 +622,9 @@ namespace wil
                     if (m_folderHandle)
                     {
                         CancelIoEx(m_folderHandle.get(), &m_overlapped);
+
+                        DWORD dummy;
+                        GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &dummy, TRUE);
                     }
 
                     // Wait for callbacks to complete.

--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -623,8 +623,8 @@ namespace wil
                     {
                         CancelIoEx(m_folderHandle.get(), &m_overlapped);
 
-                        DWORD dummy;
-                        GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &dummy, TRUE);
+                        DWORD bytesTransferredIgnored = 0;
+                        GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &bytesTransferredIgnored, TRUE);
                     }
 
                     // Wait for callbacks to complete.


### PR DESCRIPTION
let the OS set the `internal` flag to STATUS_CANCELED). If the wil::unique_folder_change_reader_nothrow handle is destroyed before doing that, a random memory corruption or crash might occur.