### PR TITLE
Fix asan tests & disable ubsan tests temporarily post VS update

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,5 +96,6 @@ if (${ASAN_AVAILABLE})
 endif()
 
 if (${UBSAN_AVAILABLE})
-    add_subdirectory(sanitize-undefined-behavior)
+    # TODO: Disabled until https://github.com/microsoft/STL/issues/3568 is resolved
+    # add_subdirectory(sanitize-undefined-behavior)
 endif()

--- a/tests/sanitize-address/CMakeLists.txt
+++ b/tests/sanitize-address/CMakeLists.txt
@@ -12,6 +12,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_definitions(witest.asan PRIVATE
         # Not compatible with using lld-link
         -D_DISABLE_VECTOR_ANNOTATION
+        -D_DISABLE_STRING_ANNOTATION
         # See below; not compatible with exceptions
         -DCATCH_CONFIG_DISABLE_EXCEPTIONS
         )


### PR DESCRIPTION
A Visual Studio update broke us in two ways. The asan tests can be fixed with a macro while the ubsan tests need to be temporarily disabled to resolve a linker error. The latter is a known issue: https://github.com/microsoft/STL/issues/3568