### PR TITLE
Fix two cppwinrt related items - properties and vectors

### DIFF
--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -39,7 +39,7 @@ namespace wil
 
         using base_type = std::conditional_t<std::is_scalar_v<T> || std::is_final_v<T>, wil::details::single_threaded_property_storage<T>, T>;
 
-        const auto& operator()()
+        T operator()() const
         {
             return *this;
         }

--- a/include/wil/cppwinrt_helpers.h
+++ b/include/wil/cppwinrt_helpers.h
@@ -284,7 +284,7 @@ namespace wil
                 {
                     throw winrt::hresult_changed_state();
                 }
-                result.resize(actual);
+                result.resize(actual, details::empty<T>());
             }
             return result;
         }
@@ -300,7 +300,7 @@ namespace wil
                 auto fetched = src.GetMany({result.data() + lastSize, result.data() + lastSize + chunkSize });
                 if (fetched < chunkSize)
                 {
-                    result.resize(lastSize + fetched);
+                    result.resize(lastSize + fetched, details::empty<T>());
                     break;
                 }
             }

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -11,6 +11,16 @@
 #include <wil/winrt.h>
 #include <wil/resource.h>
 
+struct my_async_status : winrt::implements<my_async_status, winrt::Windows::Foundation::IAsyncInfo>
+{
+    wil::single_threaded_property<winrt::Windows::Foundation::AsyncStatus> Status{ winrt::Windows::Foundation::AsyncStatus::Started };
+    wil::single_threaded_property<winrt::hresult> ErrorCode;
+    wil::single_threaded_property<uint32_t> Id{ 16 };
+
+    void Cancel() {};
+    void Close() {};
+};
+
 TEST_CASE("CppWinRTAuthoringTests::Read", "[property]")
 {
     int value = 42;
@@ -28,6 +38,11 @@ TEST_CASE("CppWinRTAuthoringTests::Read", "[property]")
 
     wil::single_threaded_property<winrt::hstring> prop3;
     REQUIRE(prop3.empty());
+
+    auto my_status = winrt::make<my_async_status>();
+    REQUIRE(my_status.Status() == winrt::Windows::Foundation::AsyncStatus::Started);
+    REQUIRE(my_status.ErrorCode() == S_OK);
+    REQUIRE(my_status.Id() == 16);
 }
 
 TEST_CASE("CppWinRTAuthoringTests::ReadWrite", "[property]")

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -6,9 +6,12 @@
 #include <thread>
 #endif
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.ApplicationModel.Activation.h>
 #include <wil/cppwinrt_helpers.h>
 #include <winrt/Windows.System.h>
 #include <wil/cppwinrt_helpers.h> // Verify can include a second time to unlock more features
+
+using namespace winrt::Windows::ApplicationModel::Activation;
 
 #include "catch.hpp"
 
@@ -154,6 +157,13 @@ TEST_CASE("CppWinRTTests::VectorToVector", "[cppwinrt]")
                 REQUIRE(false);
             }
         }
+    }
+    {
+        std::vector<BackgroundActivatedEventArgs> src_vector;
+        src_vector.emplace_back(BackgroundActivatedEventArgs{ nullptr });
+        src_vector.emplace_back(BackgroundActivatedEventArgs{ nullptr });
+        auto sv = winrt::single_threaded_vector(copy_thing(src_vector));
+        REQUIRE(wil::to_vector(sv) == src_vector);
     }
     
     REQUIRE_THROWS(wil::to_vector(winrt::make<unstable_vector>()));


### PR DESCRIPTION
Properties need to use the non-const-ref return type, or they don't work with scalars and hresults and other things in real-world usage.

To-vector needs to account for collections whose elements are not default-constructable.

Tests added to verify both.