### PR TITLE
Additional test coverage for restricted error info

### DIFF
--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -15,6 +15,7 @@ using namespace winrt::Windows::ApplicationModel::Activation;
 
 #include "catch.hpp"
 #include <roerrorapi.h>
+#include "common.h"
 
 // HRESULT values that C++/WinRT throws as something other than winrt::hresult_error - e.g. a type derived from
 // winrt::hresult_error, std::*, etc.
@@ -651,6 +652,7 @@ TEST_CASE("CppWinRTTests::ResumeForegroundTests", "[cppwinrt]")
 TEST_CASE("CppWinRTTests::ThrownExceptionWithMessage", "[cppwinrt]")
 {
     SetRestrictedErrorInfo(nullptr);
+
     []()
     {
         try
@@ -659,14 +661,16 @@ TEST_CASE("CppWinRTTests::ThrownExceptionWithMessage", "[cppwinrt]")
         }
         CATCH_RETURN();
     }();
-    winrt::com_ptr<IRestrictedErrorInfo> errorInfo;
-    winrt::check_hresult(GetRestrictedErrorInfo(errorInfo.put()));
-    REQUIRE(errorInfo != nullptr);
-    wil::unique_bstr description;
-    wil::unique_bstr restrictedDescription;
-    wil::unique_bstr capabilitySid;
-    HRESULT errorCode;
-    winrt::check_hresult(errorInfo->GetErrorDetails(&description, &errorCode, &restrictedDescription, &capabilitySid));
-    REQUIRE(errorCode == E_ACCESSDENIED);
-    REQUIRE(wcscmp(restrictedDescription.get(), L"Puppies not allowed") == 0);
+    witest::RequireRestrictedErrorInfo(E_ACCESSDENIED, L"Puppies not allowed");
+
+    []()
+    {
+        try
+        {
+            winrt::check_hresult(E_INVALIDARG);
+            return S_OK;
+        }
+        CATCH_RETURN();
+    }();
+    witest::RequireRestrictedErrorInfo(E_INVALIDARG, L"The parameter is incorrect.\r\n");
 }

--- a/tests/ResultTests.cpp
+++ b/tests/ResultTests.cpp
@@ -578,20 +578,6 @@ TEST_CASE("ResultTests::AutomaticOriginationOnFailure", "[result]")
     REQUIRE(S_FALSE == GetRestrictedErrorInfo(&restrictedErrorInformation));
 }
 
-void ExpectRestrictedError(HRESULT err, LPCWSTR text)
-{
-    wil::com_ptr_nothrow<IRestrictedErrorInfo> errorInfo;
-    REQUIRE_SUCCEEDED(GetRestrictedErrorInfo(&errorInfo));
-    wil::unique_bstr description;
-    wil::unique_bstr restrictedDescription;
-    wil::unique_bstr capabilitySid;
-    HRESULT errorCode;
-    REQUIRE(errorInfo != nullptr);
-    REQUIRE_SUCCEEDED(errorInfo->GetErrorDetails(&description, &errorCode, &restrictedDescription, &capabilitySid));
-    REQUIRE(err == errorCode);
-    REQUIRE(wcscmp(restrictedDescription.get(), text) == 0);
-}
-
 TEST_CASE("ResultTests::OriginatedWithMessagePreserved", "[result]")
 {
     SetRestrictedErrorInfo(nullptr);

--- a/tests/ResultTests.cpp
+++ b/tests/ResultTests.cpp
@@ -594,14 +594,15 @@ void ExpectRestrictedError(HRESULT err, LPCWSTR text)
 
 TEST_CASE("ResultTests::OriginatedWithMessagePreserved", "[result]")
 {
+    SetRestrictedErrorInfo(nullptr);
+
 #ifdef WIL_ENABLE_EXCEPTIONS
     try
     {
         THROW_HR_MSG(E_FAIL, "Puppies not allowed");
     }
     catch (...) {}
-    ExpectRestrictedError(E_FAIL, L"Puppies not allowed");
-    SetRestrictedErrorInfo(nullptr);
+    witest::RequireRestrictedErrorInfo(E_FAIL, L"Puppies not allowed");
 
     []()
     {
@@ -611,8 +612,7 @@ TEST_CASE("ResultTests::OriginatedWithMessagePreserved", "[result]")
         }
         CATCH_RETURN();
     }();
-    ExpectRestrictedError(HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION), L"std::exception: Puppies not allowed");
-    SetRestrictedErrorInfo(nullptr);
+    witest::RequireRestrictedErrorInfo(HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION), L"std::exception: Puppies not allowed");
 
 #endif
 
@@ -620,8 +620,7 @@ TEST_CASE("ResultTests::OriginatedWithMessagePreserved", "[result]")
     {
         RETURN_HR_MSG(E_FAIL, "Puppies not allowed");
     }();
-    ExpectRestrictedError(E_FAIL, L"Puppies not allowed");
-    SetRestrictedErrorInfo(nullptr);
+    witest::RequireRestrictedErrorInfo(E_FAIL, L"Puppies not allowed");
 }
 
 #endif


### PR DESCRIPTION
In #337, @dmachaj asked for specific tests on the C++/WinRT and C++ integration for error origination.  This change adds that coverage for posterity.