### PR TITLE
[C++/WinRT] Fix wil::simple_event and wil::typed_event with C++/WinRT

### DIFF
--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -87,9 +87,9 @@ namespace wil
     {
         template<typename T>
         struct event_base {
-            winrt::event_token operator()(T&& handler)
+            winrt::event_token operator()(const T& handler)
             {
-                return m_handler.add(std::forward<T>(handler));
+                return m_handler.add(handler);
             }
 
             auto operator()(const winrt::event_token& token) noexcept

--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -115,7 +115,7 @@ namespace wil
     struct untyped_event : wil::details::event_base<winrt::Windows::Foundation::EventHandler<T>> {};
 
     /**
-     * @brief A default event handler that mapsg to [Windows.Foundation.TypedEventHandler](https://docs.microsoft.com/uwp/api/windows.foundation.typedeventhandler-2).
+     * @brief A default event handler that maps to [Windows.Foundation.TypedEventHandler](https://docs.microsoft.com/uwp/api/windows.foundation.typedeventhandler-2).
      * @tparam T The event data type.
      * @details Usage example:
      * @code

--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -112,10 +112,10 @@ namespace wil
      * @tparam T The event data type.
     */
     template<typename T>
-    struct simple_event : wil::details::event_base<winrt::Windows::Foundation::EventHandler<T>> {};
+    struct untyped_event : wil::details::event_base<winrt::Windows::Foundation::EventHandler<T>> {};
 
     /**
-     * @brief A default event handler that maps to [Windows.Foundation.TypedEventHandler](https://docs.microsoft.com/uwp/api/windows.foundation.typedeventhandler-2).
+     * @brief A default event handler that mapsg to [Windows.Foundation.TypedEventHandler](https://docs.microsoft.com/uwp/api/windows.foundation.typedeventhandler-2).
      * @tparam T The event data type.
      * @details Usage example:
      * @code

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -201,6 +201,7 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
     });
     winrt::get_self<Test>(test)->Closed.invoke(test, nullptr);
     REQUIRE(invoked == true);
+    test.Closed(token);
 }
 #endif // WINRT_Windows_Foundation_H
 

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -4,7 +4,9 @@
 // check if at least C++17
 #if _MSVC_LANG >= 201703L
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Data.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
 #endif
 
 #include <wil/cppwinrt_authoring.h>
@@ -19,6 +21,18 @@ struct my_async_status : winrt::implements<my_async_status, winrt::Windows::Foun
 
     void Cancel() {};
     void Close() {};
+};
+
+// This type has a settable property
+struct my_pointer_args : winrt::implements<my_pointer_args, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs>
+{
+    wil::single_threaded_rw_property<bool> Handled{ false };
+    wil::single_threaded_property<bool> IsGenerated{ false };
+    wil::single_threaded_property<winrt::Windows::System::VirtualKeyModifiers> KeyModifiers{ winrt::Windows::System::VirtualKeyModifiers::None };
+    wil::single_threaded_property<winrt::Windows::UI::Xaml::Input::Pointer> Pointer{ nullptr };
+
+    winrt::Windows::UI::Input::PointerPoint GetCurrentPoint(winrt::Windows::UI::Xaml::UIElement const&) { throw winrt::hresult_not_implemented(); }
+    winrt::Windows::Foundation::Collections::IVector<winrt::Windows::UI::Input::PointerPoint> GetIntermediatePoints(winrt::Windows::UI::Xaml::UIElement const&) { throw winrt::hresult_not_implemented(); }
 };
 
 TEST_CASE("CppWinRTAuthoringTests::Read", "[property]")
@@ -77,6 +91,11 @@ TEST_CASE("CppWinRTAuthoringTests::ReadWrite", "[property]")
     REQUIRE(prop3 == "baz");
     prop3alias = "foo";
     REQUIRE(prop3 == "foo");
+
+    auto my_args = winrt::make<my_pointer_args>();
+    REQUIRE(my_args.Handled() == false);
+    my_args.Handled(true);
+    REQUIRE(my_args.Handled() == true);
 }
 
 TEST_CASE("CppWinRTAuthoringTests::ReadWriteFromReadOnly", "[property]")
@@ -161,6 +180,27 @@ TEST_CASE("CppWinRTAuthoringTests::Events", "[property]")
     auto token2 = test.MyTypedEvent([](winrt::Windows::Foundation::IInspectable, int args) { REQUIRE(args == 42); });
     test.MyTypedEvent.invoke(nullptr, 42);
     test.MyTypedEvent(token2);
+}
+
+TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
+{
+    struct Test : winrt::implements<Test, winrt::Windows::Foundation::IMemoryBufferReference>
+    {
+        wil::single_threaded_property<uint32_t> Capacity{ 0 };
+        wil::typed_event<winrt::Windows::Foundation::IMemoryBufferReference, winrt::Windows::Foundation::IInspectable> Closed;
+
+        void Close() { throw winrt::hresult_not_implemented(); }
+        void Dispose() { throw winrt::hresult_not_implemented(); }
+    };
+
+    auto test = winrt::make<Test>();
+    bool invoked = false;
+    auto token = test.Closed([&](winrt::Windows::Foundation::IMemoryBufferReference, winrt::Windows::Foundation::IInspectable)
+    {
+        invoked = true;
+    });
+    winrt::get_self<Test>(test)->Closed.invoke(test, nullptr);
+    REQUIRE(invoked == true);
 }
 #endif // WINRT_Windows_Foundation_H
 

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -168,7 +168,7 @@ TEST_CASE("CppWinRTAuthoringTests::Events", "[property]")
 {
     struct Test
     {
-        wil::simple_event<int> MyEvent;
+        wil::untyped_event<int> MyEvent;
 
         wil::typed_event<winrt::Windows::Foundation::IInspectable, int> MyTypedEvent;
     } test;


### PR DESCRIPTION
Today, `wil::simple_event` and `wil::typed_event` will fail to compile when used with an IDL event. This change fixes `event_base` so it works with C++/WinRT's generated code.

## What changed?

* `&&` to `const&` (and remove `std::forward`)

### Why?

C++/WinRT generates event code that looks like this:

```cpp
int32_t __stdcall add_Dismissed(void* handler, winrt::event_token* token) noexcept final try
{
    zero_abi<winrt::event_token>(token);
    typename D::abi_guard guard(this->shim());
    *token = detach_from<winrt::event_token>(this->shim().Dismissed(*reinterpret_cast<winrt::Windows::Foundation::TypedEventHandler<winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable> const*>(&handler)));
    return 0;
}
```

which, notably, casts `handler` to a `const&`. But `wil::details::event_base` looks like this:

```cpp
struct event_base {
    winrt::event_token operator()(T&& handler)
    {
        return m_handler.add(std::forward<T>(handler));
    }

    // ...
}
```

This doesn't work. In fact, [Sklar's initial implementation](https://github.com/asklar/xaml-islands/blob/31c4e0c2e30eca9b90790dd83ed9062cd66bcba5/inc/cppxaml/XamlProperty.h#L32-L34) uses `const&` properly.

This change reverts to that initial implementation, using `const&` instead of `&&`.

## How tested?

* [x] PR tests pass.
* [x] With change deployed locally, C++/WinRT generated code can consume `wil::typed_event` without compiler errors.