### PR TITLE
Disable 'NotifyPropertyChanged' since it crashes when run locally

### DIFF
--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -210,7 +210,7 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
 
 // This test cannot run in the same process as the malloc spies tests in wiTest.cpp
 // MSFT_internal: https://task.ms/44191550
-TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly]")
+TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][.]")
 {
 #if defined(WIL_ENABLE_EXCEPTIONS)
     auto uninit = wil::RoInitialize_failfast(RO_INIT_SINGLETHREADED);


### PR DESCRIPTION
The test currently is marked with `[LocalOnly]` so that it doesn't run on CI machines, however this breaks scripts even when running locally (and is annoying with a post-mortem debugger). Disabling it entirely for now