### PR TITLE
Fix malloc spy conflict with CppWinRTAuthoringTests::NotifyPropertyChanged

### DIFF
--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -212,7 +212,7 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
 TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly]")
 {
 #if defined(WIL_ENABLE_EXCEPTIONS)
-    auto uninit = wil::RoInitialize_failfast(RO_INIT_SINGLETHREADED);
+    auto uninit = wil::RoInitialize_failfast(RO_INIT_MULTITHREADED);
     // We need to initialize the XAML core in order to instantiate a PropertyChangedEventArgs.
     // Do all the work on a separate DispatcherQueue thread so we can shut it down cleanly
     // and make sure COM is completely cleaned up before we finish the test.

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -209,7 +209,7 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 
-TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly]")
+TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property]")
 {
 #if defined(WIL_ENABLE_EXCEPTIONS)
     auto uninit = wil::RoInitialize_failfast(RO_INIT_MULTITHREADED);
@@ -220,7 +220,7 @@ TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly
     auto controller = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
     winrt::handle dispatcherThreadHandle;
 
-    controller.DispatcherQueue().TryEnqueue([&]
+    winrt::check_bool(controller.DispatcherQueue().TryEnqueue([&]
         {
             winrt::check_bool(DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), dispatcherThreadHandle.put(), SYNCHRONIZE, FALSE, 0));
             auto manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
@@ -265,8 +265,8 @@ TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly
                 test.PropertyChanged(token);
             }
             manager.Close();
-        });
-    controller.ShutdownQueueAsync().get();
+        }));
+    controller.ShutdownQueueAsync();
     // Make sure the dispatcher thread has terminated and shut down COM.
     // Give CoUninitialize a generous 5 seconds to complete.
     REQUIRE(WaitForSingleObject(dispatcherThreadHandle.get(), 5000) == WAIT_OBJECT_0);

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -206,57 +206,70 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
 #endif // WINRT_Windows_Foundation_H
 
 #if defined(WINRT_Windows_UI_Xaml_Data_H)
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 
-// This test cannot run in the same process as the malloc spies tests in wiTest.cpp
-// MSFT_internal: https://task.ms/44191550
 TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly]")
 {
 #if defined(WIL_ENABLE_EXCEPTIONS)
     auto uninit = wil::RoInitialize_failfast(RO_INIT_SINGLETHREADED);
     // We need to initialize the XAML core in order to instantiate a PropertyChangedEventArgs.
-    auto manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
-    {
-        struct Test : winrt::implements<Test, winrt::Windows::UI::Xaml::Data::INotifyPropertyChanged>, wil::notify_property_changed_base<Test>
-        {
-            wil::single_threaded_notifying_property<int> MyProperty;
-            Test() : INIT_NOTIFYING_PROPERTY(MyProperty, 42) {}
-        };
-        auto test = winrt::make<Test>();
-        auto testImpl = winrt::get_self<Test>(test);
-        bool notified = false;
-        auto token = test.PropertyChanged([&](winrt::Windows::Foundation::IInspectable, winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs args)
-            {
-                REQUIRE(args.PropertyName() == L"MyProperty");
-                REQUIRE(testImpl->MyProperty() == 43);
-                notified = true;
-            });
+    // Do all the work on a separate DispatcherQueue thread so we can shut it down cleanly
+    // and make sure COM is completely cleaned up before we finish the test.
 
-        testImpl->MyProperty(43);
-        REQUIRE(notified);
-        test.PropertyChanged(token);
-        REQUIRE(testImpl->MyProperty.Name() == L"MyProperty");
-    }
-    {
-        struct Test : winrt::implements<Test, winrt::Windows::UI::Xaml::Data::INotifyPropertyChanged>, wil::notify_property_changed_base<Test>
-        {
-            WIL_NOTIFYING_PROPERTY(int, MyProperty, 42);
-        };
-        auto test = winrt::make<Test>();
-        auto testImpl = winrt::get_self<Test>(test);
-        bool notified = false;
-        auto token = test.PropertyChanged([&](winrt::Windows::Foundation::IInspectable, winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs args)
-            {
-                REQUIRE(args.PropertyName() == L"MyProperty");
-                REQUIRE(testImpl->MyProperty() == 43);
-                notified = true;
-            });
+    auto controller = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
+    winrt::handle dispatcherThreadHandle;
 
-        testImpl->MyProperty(43);
-        REQUIRE(notified);
-        test.PropertyChanged(token);
-    }
-    manager.Close();
+    controller.DispatcherQueue().TryEnqueue([&]
+        {
+            winrt::check_bool(DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), dispatcherThreadHandle.put(), SYNCHRONIZE, FALSE, 0));
+            auto manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
+            {
+                struct Test : winrt::implements<Test, winrt::Windows::UI::Xaml::Data::INotifyPropertyChanged>, wil::notify_property_changed_base<Test>
+                {
+                    wil::single_threaded_notifying_property<int> MyProperty;
+                    Test() : INIT_NOTIFYING_PROPERTY(MyProperty, 42) {}
+                };
+                auto test = winrt::make<Test>();
+                auto testImpl = winrt::get_self<Test>(test);
+                bool notified = false;
+                auto token = test.PropertyChanged([&](winrt::Windows::Foundation::IInspectable, winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs args)
+                    {
+                        REQUIRE(args.PropertyName() == L"MyProperty");
+                        REQUIRE(testImpl->MyProperty() == 43);
+                        notified = true;
+                    });
+
+                testImpl->MyProperty(43);
+                REQUIRE(notified);
+                test.PropertyChanged(token);
+                REQUIRE(testImpl->MyProperty.Name() == L"MyProperty");
+            }
+            {
+                struct Test : winrt::implements<Test, winrt::Windows::UI::Xaml::Data::INotifyPropertyChanged>, wil::notify_property_changed_base<Test>
+                {
+                    WIL_NOTIFYING_PROPERTY(int, MyProperty, 42);
+                };
+                auto test = winrt::make<Test>();
+                auto testImpl = winrt::get_self<Test>(test);
+                bool notified = false;
+                auto token = test.PropertyChanged([&](winrt::Windows::Foundation::IInspectable, winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs args)
+                    {
+                        REQUIRE(args.PropertyName() == L"MyProperty");
+                        REQUIRE(testImpl->MyProperty() == 43);
+                        notified = true;
+                    });
+
+                testImpl->MyProperty(43);
+                REQUIRE(notified);
+                test.PropertyChanged(token);
+            }
+            manager.Close();
+        });
+    controller.ShutdownQueueAsync().get();
+    // Make sure the dispatcher thread has terminated and shut down COM.
+    // Give CoUninitialize a generous 5 seconds to complete.
+    REQUIRE(WaitForSingleObject(dispatcherThreadHandle.get(), 5000) == WAIT_OBJECT_0);
 #endif
 }
 #endif // msvc


### PR DESCRIPTION
The CppWinRTAuthoringTests::NotifyPropertyChanged test did not clean up everything before it exited. This resulted in COM remaining initialized at process termination, and that in turn resulted in adverse interactions with the malloc spy test, since the "emergency cleanup" calls CoTaskMemFree, and since COM was put into "possible malloc spy" mode, it tries to take a lock to protect the potential malloc spy. But that lock no longer exists, since COM has shut down, and things spiral downhill.

The NotifyPropertyChanged test tries to clean up the WindowsXamlManager, but it didn't realize that Close() is an asynchronous call that queues work back to the current thread's DispatcherQueue for final cleanup. The old test just returned immediately and never pumped messages any more, which resulted in the cleanup never happening.

To ensure we clean up the WindowsXamlManager, we create our own DispatcherQueue for the XAML work. Since it's our DispatcherQueue, we can call ShutdownQueueAsync to clean it up. ShutdownQueueAsync completes when the queue has shut down, but before the thread uninitializes COM. We wait for the DispatcherQueue thread to exit, so that we know for sure that it has definitely uninitialized COM. Only then do we allow the test to complete.

This cleans up the leaked COM initialization and avoids a condition crash during "emergency cleanup", thereby resolving a longstanding problem with the automated unit tests.

The diff looks big because of a change in indentation. Turn on "ignore whitespace" to see the actual change.