### PR TITLE
Only run the NotifyPropertyChanged test locally

### DIFF
--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -209,7 +209,8 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 
-TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property]")
+// This test seems to have issues on the CI machines, so enabling only when run locally
+TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property][LocalOnly]")
 {
 #if defined(WIL_ENABLE_EXCEPTIONS)
     auto uninit = wil::RoInitialize_failfast(RO_INIT_MULTITHREADED);
@@ -220,7 +221,7 @@ TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property]")
     auto controller = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
     winrt::handle dispatcherThreadHandle;
 
-    winrt::check_bool(controller.DispatcherQueue().TryEnqueue([&]
+    auto enqueueResult = controller.DispatcherQueue().TryEnqueue([&]
         {
             winrt::check_bool(DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), dispatcherThreadHandle.put(), SYNCHRONIZE, FALSE, 0));
             auto manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
@@ -265,7 +266,8 @@ TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property]")
                 test.PropertyChanged(token);
             }
             manager.Close();
-        }));
+        });
+    REQUIRE(enqueueResult);
     controller.ShutdownQueueAsync();
     // Make sure the dispatcher thread has terminated and shut down COM.
     // Give CoUninitialize a generous 5 seconds to complete.


### PR DESCRIPTION
Seems to still have issues running on CI machines. Idk if it's an issue running with Xaml there or if the timeout is too short (doubtful). Either way, it's too flakey on the CI machines, so disabling it for now