### PR TITLE
Handle ERROR_HANDLE_EOF as success case in wil::GetFileInfo<FileStreamInfo>

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -886,25 +886,25 @@ namespace wil
 
         MAP_INFOCLASS_TO_STRUCT(FileBasicInfo, FILE_BASIC_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileStandardInfo, FILE_STANDARD_INFO, true, 0);
-        MAP_INFOCLASS_TO_STRUCT(FileNameInfo, FILE_NAME_INFO, false, 32);
-        MAP_INFOCLASS_TO_STRUCT(FileRenameInfo, FILE_RENAME_INFO, false, 32);
+        MAP_INFOCLASS_TO_STRUCT(FileNameInfo, FILE_NAME_INFO, false, 64);
+        MAP_INFOCLASS_TO_STRUCT(FileRenameInfo, FILE_RENAME_INFO, false, 64);
         MAP_INFOCLASS_TO_STRUCT(FileDispositionInfo, FILE_DISPOSITION_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileAllocationInfo, FILE_ALLOCATION_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileEndOfFileInfo, FILE_END_OF_FILE_INFO, true, 0);
-        MAP_INFOCLASS_TO_STRUCT(FileStreamInfo, FILE_STREAM_INFO, false, 32);
+        MAP_INFOCLASS_TO_STRUCT(FileStreamInfo, FILE_STREAM_INFO, false, 64);
         MAP_INFOCLASS_TO_STRUCT(FileCompressionInfo, FILE_COMPRESSION_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileAttributeTagInfo, FILE_ATTRIBUTE_TAG_INFO, true, 0);
-        MAP_INFOCLASS_TO_STRUCT(FileIdBothDirectoryInfo, FILE_ID_BOTH_DIR_INFO, false, 4096);
+        MAP_INFOCLASS_TO_STRUCT(FileIdBothDirectoryInfo, FILE_ID_BOTH_DIR_INFO, false, 8192);
         MAP_INFOCLASS_TO_STRUCT(FileIdBothDirectoryRestartInfo, FILE_ID_BOTH_DIR_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileIoPriorityHintInfo, FILE_IO_PRIORITY_HINT_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileRemoteProtocolInfo, FILE_REMOTE_PROTOCOL_INFO, true, 0);
-        MAP_INFOCLASS_TO_STRUCT(FileFullDirectoryInfo, FILE_FULL_DIR_INFO, false, 4096);
+        MAP_INFOCLASS_TO_STRUCT(FileFullDirectoryInfo, FILE_FULL_DIR_INFO, false, 8192);
         MAP_INFOCLASS_TO_STRUCT(FileFullDirectoryRestartInfo, FILE_FULL_DIR_INFO, true, 0);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
         MAP_INFOCLASS_TO_STRUCT(FileStorageInfo, FILE_STORAGE_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileAlignmentInfo, FILE_ALIGNMENT_INFO, true, 0);
         MAP_INFOCLASS_TO_STRUCT(FileIdInfo, FILE_ID_INFO, true, 0);
-        MAP_INFOCLASS_TO_STRUCT(FileIdExtdDirectoryInfo, FILE_ID_EXTD_DIR_INFO, false, 4096);
+        MAP_INFOCLASS_TO_STRUCT(FileIdExtdDirectoryInfo, FILE_ID_EXTD_DIR_INFO, false, 8192);
         MAP_INFOCLASS_TO_STRUCT(FileIdExtdDirectoryRestartInfo, FILE_ID_EXTD_DIR_INFO, true, 0);
 #endif
 
@@ -940,6 +940,10 @@ namespace wil
                     else if (lastError == ERROR_INVALID_PARAMETER) // operation not supported by file system
                     {
                         return HRESULT_FROM_WIN32(lastError);
+                    }
+                    else if ((lastError == ERROR_HANDLE_EOF) && (infoClass == FileStreamInfo))
+                    {
+                        break;
                     }
                     else
                     {

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -641,14 +641,15 @@ TEST_CASE("FileSystemTests::GetFileInfo<FileStreamInfo>", "[filesystem]")
 {
 #ifdef WIL_ENABLE_EXCEPTIONS
     auto path = wil::ExpandEnvironmentStringsW<std::wstring>(L"%TEMP%");
-
     wil::unique_hfile handle(CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS, nullptr));
     THROW_LAST_ERROR_IF(!handle.is_valid());
 
     // Test the ERROR_HANDLE_EOF case with a folder
-    auto streamInfo = wil::GetFileInfo<FileStreamInfo>(handle.get());
+    wistd::unique_ptr<FILE_STREAM_INFO> streamInfo;
+    auto hr = wil::GetFileInfoNoThrow<FileStreamInfo>(handle.get(), streamInfo);
+    REQUIRE(hr == S_OK);
 #endif
 }
 

--- a/tests/FileSystemTests.cpp
+++ b/tests/FileSystemTests.cpp
@@ -637,6 +637,21 @@ TEST_CASE("FileSystemTests::QueryFullProcessImageNameW and GetModuleFileNameW", 
 #endif
 }
 
+TEST_CASE("FileSystemTests::GetFileInfo<FileStreamInfo>", "[filesystem]")
+{
+#ifdef WIL_ENABLE_EXCEPTIONS
+    auto path = wil::ExpandEnvironmentStringsW<std::wstring>(L"%TEMP%");
+
+    wil::unique_hfile handle(CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS, nullptr));
+    THROW_LAST_ERROR_IF(!handle.is_valid());
+
+    // Test the ERROR_HANDLE_EOF case with a folder
+    auto streamInfo = wil::GetFileInfo<FileStreamInfo>(handle.get());
+#endif
+}
+
 TEST_CASE("FileSystemTests::QueryFullProcessImageNameW", "[filesystem]")
 {
     WCHAR fullName[MAX_PATH * 4];


### PR DESCRIPTION
`ERROR_HANDLE_EOF` can be returned in a success case (see [docs](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfileinformationbyhandleex?devlangs=cpp&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(WINBASE%252FGetFileInformationByHandleEx)%3Bk(GetFileInformationByHandleEx)%3Bk(DevLang-C%252B%252B)%3Bk(TargetOS-Windows)%26rd%3Dtrue#remarks)), convert that error code into success.

here is a work around for those that don't have this yet.

```cpp
wistd::unique_ptr<FILE_STREAM_INFO> streamInfo;
std::ignore = wil::GetFileInfoNoThrow<FileStreamInfo>(handle.get(), streamInfo);
```

I've also increased the buffer sizes to reduce need for re-allocation/re-query.