### PR TITLE
Fix folder_change_reader_state destructor hang. 

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -624,10 +624,15 @@ namespace wil
 
                     if (m_folderHandle)
                     {
-                        CancelIoEx(m_folderHandle.get(), &m_overlapped);
+                       BOOL cancelRes = CancelIoEx(m_folderHandle.get(), &m_overlapped);
 
-                        DWORD bytesTransferredIgnored = 0;
-                        GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &bytesTransferredIgnored, TRUE);
+                       // no pending operation to cancel. Maybe StartIo returned 
+                       // an error?
+                       if (!(cancelRes == FALSE && ::GetLastError() == ERROR_NOT_FOUND)) 
+                       {
+                           DWORD bytesTransferredIgnored = 0;
+                           GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &bytesTransferredIgnored, TRUE);
+                       }
                     }
 
                     // Wait for callbacks to complete.

--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -624,15 +624,15 @@ namespace wil
 
                     if (m_folderHandle)
                     {
-                       BOOL cancelRes = CancelIoEx(m_folderHandle.get(), &m_overlapped);
+                        BOOL cancelRes = CancelIoEx(m_folderHandle.get(), &m_overlapped);
 
-                       // no pending operation to cancel. Maybe StartIo returned 
-                       // an error?
-                       if (!(cancelRes == FALSE && ::GetLastError() == ERROR_NOT_FOUND)) 
-                       {
-                           DWORD bytesTransferredIgnored = 0;
-                           GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &bytesTransferredIgnored, TRUE);
-                       }
+                        // no pending operation to cancel. Maybe StartIo returned 
+                        // an error?
+                        if (!(cancelRes == FALSE && ::GetLastError() == ERROR_NOT_FOUND)) 
+                        {
+                            DWORD bytesTransferredIgnored = 0;
+                            GetOverlappedResult(m_folderHandle.get(), &m_overlapped, &bytesTransferredIgnored, TRUE);
+                        }
                     }
 
                     // Wait for callbacks to complete.


### PR DESCRIPTION
If there is no pending operation, CancelIoEx returns an error and GetOverlappedResult hangs.
This is a fix for an issue introduced in #326. If **CancelIoEx** returns `FALSE` && `GetLastError() == ERROR_NOT_FOUND` then there is no pending operation, and `GetOverlappedResult` might hang. The hang can happen if you delete the monitored folder after receiving a completion notification but before calling again `StartIo`