### PR TITLE
Unblock Address Sanitizer Tests for Clang/x86

### DIFF
--- a/cmake/common_build_flags.cmake
+++ b/cmake/common_build_flags.cmake
@@ -12,10 +12,18 @@ macro(replace_cxx_flag pattern text)
 endmacro()
 
 # Fixup default compiler settings
-add_compile_options(
-    # Be as strict as reasonably possible, since we want to support consumers using strict warning levels
-    /W4 /WX
+if (MSVC)
+    add_compile_options(
+        # Be as strict as reasonably possible, since we want to support consumers using strict warning levels
+        /W4 /WX
+        )
+else()
+    # Clang with non-MSVC commandline syntax
+    add_compile_options(
+        # Effectively the same as /W4 /WX
+        -Wall -Werror
     )
+endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(

--- a/scripts/init.cmd
+++ b/scripts/init.cmd
@@ -142,6 +142,8 @@ goto :init
     :: Formulate CMake arguments
     if %GENERATOR%==ninja set CMAKE_ARGS=%CMAKE_ARGS% -G Ninja
 
+    :: NOTE: clang++ seems to currently have an issue handling SEH & destructors, so use clang-cl for now which, for
+    :: some reason, doesn't seem to have the same issue
     if %COMPILER%==clang set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
     if %COMPILER%==msvc set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,14 +34,19 @@ include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
 
 # The build pipelines have limitations that local development environments do not, so turn a few knobs
 if (${FAST_BUILD})
-    replace_cxx_flag("/GR" "/GR-") # Disables RTTI
+    if (MSVC)
+        replace_cxx_flag("/GR" "/GR-") # Disables RTTI
+    else()
+        add_compile_options(-fno-rtti)
+    endif()
+
     add_definitions(-DCATCH_CONFIG_FAST_COMPILE -DWIL_FAST_BUILD)
 endif()
 
 # For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
 # functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
 # revert to the desired (and default) inlining behavior as that exercises more interesting code paths
-if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+if (MSVC AND ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
     # TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
     # replace_cxx_flag("/Ob1" "/Ob2")
 endif()
@@ -63,7 +68,9 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../natvis/wil.natvis
     )
 
-add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/wil.natvis)
+if (MSVC)
+    add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/wil.natvis)
+endif()
 
 add_subdirectory(app)
 add_subdirectory(cpplatest)

--- a/tests/noexcept/CMakeLists.txt
+++ b/tests/noexcept/CMakeLists.txt
@@ -2,7 +2,12 @@
 add_executable(witest.noexcept)
 
 # Turn off exceptions for this test
-replace_cxx_flag("/EHsc" "/EHs-c-")
+if (MSVC)
+    replace_cxx_flag("/EHsc" "/EHs-c-")
+else()
+    target_compile_options(witest.noexcept PRIVATE -fno-exceptions)
+endif()
+
 target_compile_definitions(witest.noexcept PRIVATE
     -DCATCH_CONFIG_DISABLE_EXCEPTIONS
     )

--- a/tests/sanitize-address/CMakeLists.txt
+++ b/tests/sanitize-address/CMakeLists.txt
@@ -18,7 +18,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         )
 
     # Clang ASan on Windows has issues with exceptions: https://github.com/google/sanitizers/issues/749
-    replace_cxx_flag("/EHsc" "/EHs-c-")
+    if (MSVC)
+        replace_cxx_flag("/EHsc" "/EHs-c-")
+    else()
+        target_compile_options(witest.asan PRIVATE -fno-exceptions)
+    endif()
 
     if ($ENV{Platform} STREQUAL "x86")
         target_link_libraries(witest.asan PRIVATE


### PR DESCRIPTION
For some reason, `__asan_default_options` doesn't seem to be having an impact for x86 w/ Clang (at the least). I'm also having issues running the Address Sanitizer tests for x64 locally, but I don't think that's something that's been impacting the CI builds, so I'm going to put that on hold. Hopefully this is enough to unblock CI builds.

This also contains some changes to get builds to work when clang/clang++ are used as the compilers instead of clang-cl. The init script has been kept the same because there seems to be some issues with clang++ and SEH at the moment.