### PR TITLE
Defining a string literal marker for zwstring_view

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -188,7 +188,6 @@ namespace wil
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
 
-    // Add the literal operator here
     constexpr zwstring_view operator "" _zw(const wchar_t* str, std::size_t len) noexcept {
         return zwstring_view(str, len);
     }

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -187,6 +187,11 @@ namespace wil
 
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
+
+    // Add the literal operator here
+    constexpr zwstring_view operator "" _zw(const wchar_t* str, std::size_t len) noexcept {
+        return zwstring_view(str, len);
+    }
 #endif // _HAS_CXX17
 
 } // namespace wil

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -120,7 +120,7 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
     REQUIRE(fromCustomString == (PCSTR)customString);
 }
 
-TEST_CASE("StlTests::TestZWStringView  literal", "[zwstring_view]") {
+TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
     using namespace wil;
 
     SECTION("Literal creates correct zwstring_view") {

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -120,6 +120,17 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
     REQUIRE(fromCustomString == (PCSTR)customString);
 }
 
+TEST_CASE("StlTests::TestZWStringView  literal", "[zwstring_view]") {
+    using namespace wil;
+
+    SECTION("Literal creates correct zwstring_view") {
+        auto str = L"Hello, world!"_zw;
+        REQUIRE(str.length() == 13);
+        REQUIRE(str[0] == L'H');
+        REQUIRE(str[12] == L'!');
+    }
+}
+
 TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
 {
     // Test empty cases


### PR DESCRIPTION
Defining a string literal marker for zwstring_view.

Testing:
Added test cases 