### PR TITLE
Define a string literal marker for zwstring_view

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -187,6 +187,10 @@ namespace wil
 
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
+
+    constexpr zwstring_view operator "" _zw(const wchar_t* str, std::size_t len) noexcept {
+        return zwstring_view(str, len);
+    }
 #endif // _HAS_CXX17
 
 } // namespace wil

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -188,13 +188,16 @@ namespace wil
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
 
-    constexpr zstring_view operator "" _zv(const char* str, std::size_t len) noexcept {
-        return zstring_view(str, len);
-    }
+    inline namespace literals {
+        constexpr zstring_view operator "" _zv(const char* str, std::size_t len) noexcept {
+            return zstring_view(str, len);
+        }
 
-    constexpr zwstring_view operator "" _zv(const wchar_t* str, std::size_t len) noexcept {
-        return zwstring_view(str, len);
+        constexpr zwstring_view operator "" _zv(const wchar_t* str, std::size_t len) noexcept {
+            return zwstring_view(str, len);
+        }
     }
+    
 #endif // _HAS_CXX17
 
 } // namespace wil

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -188,11 +188,11 @@ namespace wil
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
 
-    constexpr zstring_view operator "" zv(const char* str, std::size_t len) noexcept {
+    constexpr zstring_view operator "" _zv(const char* str, std::size_t len) noexcept {
         return zstring_view(str, len);
     }
 
-    constexpr zwstring_view operator "" zv(const wchar_t* str, std::size_t len) noexcept {
+    constexpr zwstring_view operator "" _zv(const wchar_t* str, std::size_t len) noexcept {
         return zwstring_view(str, len);
     }
 #endif // _HAS_CXX17

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -188,7 +188,11 @@ namespace wil
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
 
-    constexpr zwstring_view operator "" _zw(const wchar_t* str, std::size_t len) noexcept {
+    constexpr zstring_view operator "" zv(const char* str, std::size_t len) noexcept {
+        return zstring_view(str, len);
+    }
+
+    constexpr zwstring_view operator "" zv(const wchar_t* str, std::size_t len) noexcept {
         return zwstring_view(str, len);
     }
 #endif // _HAS_CXX17

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -188,7 +188,8 @@ namespace wil
     using zstring_view = basic_zstring_view<char>;
     using zwstring_view = basic_zstring_view<wchar_t>;
 
-    inline namespace literals {
+    inline namespace literals
+    {
         constexpr zstring_view operator "" _zv(const char* str, std::size_t len) noexcept {
             return zstring_view(str, len);
         }

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -120,6 +120,17 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
     REQUIRE(fromCustomString == (PCSTR)customString);
 }
 
+TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
+    using namespace wil;
+
+    SECTION("Literal creates correct zwstring_view") {
+        auto str = L"Hello, world!"_zw;
+        REQUIRE(str.length() == 13);
+        REQUIRE(str[0] == L'H');
+        REQUIRE(str[12] == L'!');
+    }
+}
+
 TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
 {
     // Test empty cases

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -123,10 +123,20 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
 
     SECTION("Literal creates correct zwstring_view") {
-        auto str = L"Hello, world!"_zw;
+        auto str = L"Hello, world!"zv;
         REQUIRE(str.length() == 13);
         REQUIRE(str[0] == L'H');
         REQUIRE(str[12] == L'!');
+    }
+}
+
+TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]") {
+
+    SECTION("Literal creates correct zstring_view") {
+        auto str = "Hello, world!"zv;
+        REQUIRE(str.length() == 13);
+        REQUIRE(str[0] == 'H');
+        REQUIRE(str[12] == '!');
     }
 }
 

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -11,6 +11,7 @@ struct dummy
 {
     char value;
 };
+using namespace wil::literals;
 // Specialize std::allocator<> so that we don't actually allocate/deallocate memory
 dummy g_memoryBuffer[256];
 namespace std

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -11,7 +11,11 @@ struct dummy
 {
     char value;
 };
-using namespace wil::literals;
+
+#if _HAS_CXX17
+    using namespace wil::literals;
+#endif // _HAS_CXX17
+
 // Specialize std::allocator<> so that we don't actually allocate/deallocate memory
 dummy g_memoryBuffer[256];
 namespace std

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -123,7 +123,7 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
 
     SECTION("Literal creates correct zwstring_view") {
-        auto str = L"Hello, world!"zv;
+        auto str = L"Hello, world!"_zv;
         REQUIRE(str.length() == 13);
         REQUIRE(str[0] == L'H');
         REQUIRE(str[12] == L'!');
@@ -133,7 +133,7 @@ TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
 TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]") {
 
     SECTION("Literal creates correct zstring_view") {
-        auto str = "Hello, world!"zv;
+        auto str = "Hello, world!"_zv;
         REQUIRE(str.length() == 13);
         REQUIRE(str[0] == 'H');
         REQUIRE(str[12] == '!');

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -11,7 +11,6 @@ struct dummy
 {
     char value;
 };
-using namespace wil;
 // Specialize std::allocator<> so that we don't actually allocate/deallocate memory
 dummy g_memoryBuffer[256];
 namespace std

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -11,7 +11,7 @@ struct dummy
 {
     char value;
 };
-
+using namespace wil;
 // Specialize std::allocator<> so that we don't actually allocate/deallocate memory
 dummy g_memoryBuffer[256];
 namespace std
@@ -121,7 +121,6 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 }
 
 TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]") {
-    using namespace wil;
 
     SECTION("Literal creates correct zwstring_view") {
         auto str = L"Hello, world!"_zw;


### PR DESCRIPTION
Issue : https://github.com/microsoft/wil/issues/384

Added a literal that produced a wil::zwstring_view.

Added a simple test case to validate it.