### PR TITLE
Update result_macros.h (using enum class instead of enum)

### DIFF
--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -1233,7 +1233,7 @@ namespace wil
 
         struct ResultStatus
         {
-            enum Kind : unsigned int { HResult, NtStatus };
+            enum class Kind : unsigned int { HResult, NtStatus };
 
             static ResultStatus FromResult(const HRESULT _hr)
             {


### PR DESCRIPTION
changed the _enum Kind : unsigned int { HResult, NtStatus };_:
```
struct ResultStatus
        {
            enum Kind : unsigned int { HResult, NtStatus };

            static ResultStatus FromResult(const HRESULT _hr)
            {
                return { _hr, wil::details::HrToNtStatus(_hr), Kind::HResult };
            }
            static ResultStatus FromStatus(const NTSTATUS _status)
            {
                return { wil::details::NtStatusToHr(_status), _status, Kind::NtStatus };
            }
            static ResultStatus FromFailureInfo(const FailureInfo& _failure)
            {
                return { _failure.hr, _failure.status, WI_IsFlagSet(_failure.flags, FailureFlags::NtStatus) ? Kind::NtStatus : Kind::HResult };
            }
            HRESULT hr = S_OK;
            NTSTATUS status = STATUS_SUCCESS;
            Kind kind = Kind::NtStatus;
        };
```

to the _enum class Kind : unsigned int { HResult, NtStatus };_:
```
struct ResultStatus
        {
            enum class Kind : unsigned int { HResult, NtStatus };

            static ResultStatus FromResult(const HRESULT _hr)
            {
                return { _hr, wil::details::HrToNtStatus(_hr), Kind::HResult };
            }
            static ResultStatus FromStatus(const NTSTATUS _status)
            {
                return { wil::details::NtStatusToHr(_status), _status, Kind::NtStatus };
            }
            static ResultStatus FromFailureInfo(const FailureInfo& _failure)
            {
                return { _failure.hr, _failure.status, WI_IsFlagSet(_failure.flags, FailureFlags::NtStatus) ? Kind::NtStatus : Kind::HResult };
            }
            HRESULT hr = S_OK;
            NTSTATUS status = STATUS_SUCCESS;
            Kind kind = Kind::NtStatus;
        };
```
for **Type Safety, Strong Typing, Scoped Names**. 