### PR TITLE
Update filesystem.h (extra checking the argument of is_extended_length_path)

### DIFF
--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -19,6 +19,7 @@
 #include <combaseapi.h> // Needed for CoTaskMemFree() used in output of some helpers.
 #include <winbase.h> // LocalAlloc
 #include <PathCch.h>
+#include <cassert>
 #include "wistd_type_traits.h"
 #include "result.h"
 #include "win32_helpers.h"
@@ -29,6 +30,7 @@ namespace wil
     //! Determines if a path is an extended length path that can be used to access paths longer than MAX_PATH.
     inline bool is_extended_length_path(_In_ PCWSTR path)
     {
+        assert(path != NULL);
         return wcsncmp(path, L"\\\\?\\", 4) == 0;
     }
 


### PR DESCRIPTION
Since "path" is the argument of wcsncmp and due to SAL (declared in corecrt_wstring.h) for wcsncmp function the "path" can not be NULL that related with "Warning C6011":

_// corecrt_wstring.h_
```
_Check_return_
_ACRTIMP int __cdecl wcsncmp(
    _In_reads_or_z_(_MaxCount) wchar_t const* _String1,
    _In_reads_or_z_(_MaxCount) wchar_t const* _String2,
    _In_                       size_t         _MaxCount
    );
```

Also additionally,  parameter of "is_extended_length_path" function is also declared as _In_ (SAL):

_// filesystem.h (current header)_
inline bool is_extended_length_path(_In_ PCWSTR path)

To prevent this the "path" parameter should be checked via assert or adding if statement:

assert(path != NULL);