### PR TITLE
Fix & Parallelize the CI pipelines

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -51,6 +51,7 @@ jobs:
       if %ERRORLEVEL% NEQ 0 goto :eof
       echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
     displayName: 'Install Clang'
+    condition: eq($(compiler), 'clang')
 
   - script: |
       call scripts\call-vcvars.cmd $(arch)
@@ -64,5 +65,6 @@ jobs:
 
   - script: |
       call scripts\call-vcvars.cmd $(arch)
+      set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=1
       call scripts\runtests.cmd ~[LocalOnly]
-    displayName: 'Run $(compiler) $(arch)$(build-type) Tests'
+    displayName: 'Test $(compiler) $(arch)$(build-type)'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -16,11 +16,11 @@ jobs:
     matrix:
       ${{each compiler in variables.compileres}}:
         ${{each arch in variables.architectures}}:
-          ${{each build-type in variables.buildTypes}}:
-            ${{compiler}}-${{arch}}-${{build-type}}:
+          ${{each buildType in variables.buildTypes}}:
+            ${{compiler}}-${{arch}}-${{buildType}}:
               compiler: ${{compiler}}
               arch: ${{arch}}
-              build-type: ${{build-type}}
+              build-type: ${{buildType}}
 
   pool:
     vmImage: 'windows-2022'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
       ${{each compiler in variables.compileres}}
         ${{each arch in variables.architectures}}
           ${{each build-type in variables.buildTypes}}
-            ${{compiler}}-${{arch}}-${{build-type}}
+            ${{compiler}}-${{arch}}-${{build-type}}:
               compiler: ${{compiler}}
               arch: ${{arch}}
               build-type: ${{build-type}}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -14,9 +14,9 @@ jobs:
 
   strategy:
     matrix:
-      - ${{each compiler in split(variables.compileres, ',')}}
-        - ${{each arch in split(variables.architectures, ',')}}
-          - ${{each build-type in split(variables.buildTypes, ',')}}
+      ${{each compiler in split(variables.compileres, ',')}}
+        ${{each arch in split(variables.architectures, ',')}}
+          ${{each build-type in split(variables.buildTypes, ',')}}
             ${{compiler}}-${{arch}}-${{build-type}}
               compiler: ${{compiler}}
               arch: ${{arch}}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -7,6 +7,41 @@ jobs:
 - job: BuildAndTest
   timeoutInMinutes: 360
 
+  strategy:
+    matrix:
+      clang-x86-debug:
+        compiler: clang
+        arch: x86
+        build-type: debug
+      msvc-x86-debug:
+        compiler: msvc
+        arch: x86
+        build-type: debug
+      clang-x86-relwithdebinfo:
+        compiler: clang
+        arch: x86
+        build-type: relwithdebinfo
+      msvc-x86-relwithdebinfo:
+        compiler: msvc
+        arch: x86
+        build-type: relwithdebinfo
+      clang-x64-debug:
+        compiler: clang
+        arch: x64
+        build-type: debug
+      msvc-x64-debug:
+        compiler: msvc
+        arch: x64
+        build-type: debug
+      clang-x64-relwithdebinfo:
+        compiler: clang
+        arch: x64
+        build-type: relwithdebinfo
+      msvc-x64-relwithdebinfo:
+        compiler: msvc
+        arch: x64
+        build-type: relwithdebinfo
+
   pool:
     vmImage: 'windows-2022'
 
@@ -18,39 +53,16 @@ jobs:
     displayName: 'Install Clang'
 
   - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
+      call scripts\call-vcvars.cmd $(arch)
       if %ERRORLEVEL% NEQ 0 goto :eof
       
-      call scripts\init_all.cmd --fast
-      if %ERRORLEVEL% NEQ 0 goto :eof
-      
-      call scripts\build_all.cmd
-    displayName: 'Build x86'
-
-  # NOTE: We run the tests in the 32-bit cross-tools window out of convenience as this adds all necessary directories to
-  # the PATH that are necessary for finding the ASan/UBSan DLLs
-  - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
-      call scripts\runtests.cmd ~[LocalOnly]
-    displayName: 'Run x86 Tests'
-
-  - script: |
-      rmdir /s /q build
-    displayName: 'Clean x86 Output'
-
-  - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      if %ERRORLEVEL% NEQ 0 goto :eof
-      
-      call scripts\init_all.cmd --fast
+      call scripts\init.cmd -c $(compiler) -b $(build-type) --fast
       if %ERRORLEVEL% NEQ 0 goto :eof
       
       call scripts\build_all.cmd
-    displayName: 'Build x64'
+    displayName: 'Build $(compiler) $(arch)$(build-type)'
 
-  # NOTE: We run the tests in the 32-bit cross-tools window out of convenience as this adds all necessary directories to
-  # the PATH that are necessary for finding the ASan/UBSan DLLs
   - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      call scripts\call-vcvars.cmd $(arch)
       call scripts\runtests.cmd ~[LocalOnly]
-    displayName: 'Run x64 Tests'
+    displayName: 'Run $(compiler) $(arch)$(build-type) Tests'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
 
   strategy:
     matrix:
-      ${{each compiler in split(variables.compileres, ',')}}:
+      ${{each compiler in split(variables.compilers, ',')}}:
         ${{each arch in split(variables.architectures, ',')}}:
           ${{each buildType in split(variables.buildTypes, ',')}}:
             ${{compiler}}-${{arch}}-${{buildType}}:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -7,40 +7,20 @@ jobs:
 - job: BuildAndTest
   timeoutInMinutes: 360
 
+  variables:
+    compilers: clang,msvc
+    architectures: x86,x64
+    buildTypes: debug,relwithdebinfo
+
   strategy:
     matrix:
-      clang-x86-debug:
-        compiler: clang
-        arch: x86
-        build-type: debug
-      msvc-x86-debug:
-        compiler: msvc
-        arch: x86
-        build-type: debug
-      clang-x86-relwithdebinfo:
-        compiler: clang
-        arch: x86
-        build-type: relwithdebinfo
-      msvc-x86-relwithdebinfo:
-        compiler: msvc
-        arch: x86
-        build-type: relwithdebinfo
-      clang-x64-debug:
-        compiler: clang
-        arch: x64
-        build-type: debug
-      msvc-x64-debug:
-        compiler: msvc
-        arch: x64
-        build-type: debug
-      clang-x64-relwithdebinfo:
-        compiler: clang
-        arch: x64
-        build-type: relwithdebinfo
-      msvc-x64-relwithdebinfo:
-        compiler: msvc
-        arch: x64
-        build-type: relwithdebinfo
+      - ${{each compiler in split(variables.compileres, ',')}}
+        - ${{each arch in split(variables.architectures, ',')}}
+          - ${{each build-type in split(variables.buildTypes, ',')}}
+            ${{compiler}}-${{arch}}-${{build-type}}
+              compiler: ${{compiler}}
+              arch: ${{arch}}
+              build-type: ${{build-type}}
 
   pool:
     vmImage: 'windows-2022'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
 
   steps:
   - script: |
-      choco install llvm
+      choco upgrade llvm -y --version=17
       if %ERRORLEVEL% NEQ 0 goto :eof
       echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
     displayName: 'Install Clang'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -14,9 +14,9 @@ jobs:
 
   strategy:
     matrix:
-      ${{each compiler in variables.compileres}}
-        ${{each arch in variables.architectures}}
-          ${{each build-type in variables.buildTypes}}
+      ${{each compiler in variables.compileres}}:
+        ${{each arch in variables.architectures}}:
+          ${{each build-type in variables.buildTypes}}:
             ${{compiler}}-${{arch}}-${{build-type}}:
               compiler: ${{compiler}}
               arch: ${{arch}}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
 
   steps:
   - script: |
-      choco upgrade llvm -y --version=17
+      choco upgrade llvm -y --version=17.0.6
       if %ERRORLEVEL% NEQ 0 goto :eof
       echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
     displayName: 'Install Clang'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       if %ERRORLEVEL% NEQ 0 goto :eof
       echo ##vso[task.setvariable variable=PATH]%PATH%;C:\Program Files\LLVM\bin
     displayName: 'Install Clang'
-    condition: eq($(compiler), 'clang')
+    condition: eq(variables['compiler'], 'clang')
 
   - script: |
       call scripts\call-vcvars.cmd $(arch)

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   # NOTE: We run the tests in the 32-bit cross-tools window out of convenience as this adds all necessary directories to
   # the PATH that are necessary for finding the ASan/UBSan DLLs
   - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat""
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
       call scripts\runtests.cmd ~[LocalOnly]
     displayName: 'Run x86 Tests'
 
@@ -51,6 +51,6 @@ jobs:
   # NOTE: We run the tests in the 32-bit cross-tools window out of convenience as this adds all necessary directories to
   # the PATH that are necessary for finding the ASan/UBSan DLLs
   - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat""
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       call scripts\runtests.cmd ~[LocalOnly]
     displayName: 'Run x64 Tests'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -8,15 +8,15 @@ jobs:
   timeoutInMinutes: 360
 
   variables:
-    compilers: [ clang, msvc ]
-    architectures: [ x86, x64 ]
-    buildTypes: [ debug, relwithdebinfo ]
+    compilers: 'clang,msvc'
+    architectures: 'x86,x64'
+    buildTypes: 'debug,relwithdebinfo'
 
   strategy:
     matrix:
-      ${{each compiler in variables.compileres}}:
-        ${{each arch in variables.architectures}}:
-          ${{each buildType in variables.buildTypes}}:
+      ${{each compiler in split(variables.compileres, ',')}}:
+        ${{each arch in split(variables.architectures, ',')}}:
+          ${{each buildType in split(variables.buildTypes, ',')}}:
             ${{compiler}}-${{arch}}-${{buildType}}:
               compiler: ${{compiler}}
               arch: ${{arch}}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -8,15 +8,15 @@ jobs:
   timeoutInMinutes: 360
 
   variables:
-    compilers: clang,msvc
-    architectures: x86,x64
-    buildTypes: debug,relwithdebinfo
+    compilers: [ clang, msvc ]
+    architectures: [ x86, x64 ]
+    buildTypes: [ debug, relwithdebinfo ]
 
   strategy:
     matrix:
-      ${{each compiler in split(variables.compileres, ',')}}
-        ${{each arch in split(variables.architectures, ',')}}
-          ${{each build-type in split(variables.buildTypes, ',')}}
+      ${{each compiler in variables.compileres}}
+        ${{each arch in variables.architectures}}
+          ${{each build-type in variables.buildTypes}}
             ${{compiler}}-${{arch}}-${{build-type}}
               compiler: ${{compiler}}
               arch: ${{arch}}

--- a/scripts/call-vcvars.cmd
+++ b/scripts/call-vcvars.cmd
@@ -1,0 +1,15 @@
+@echo off
+
+:: NOTE: Intentionally not specifying 'setlocal' as we want the side-effects of calling 'vcvars' to affect the caller
+
+:: NOTE: This is primarily intended to be used by the bulid pipelines, hence the hard-coded paths, and might not be
+::       generally useful. The following check is intended to help diagnose such possible issues
+if NOT EXIST "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
+    echo ERROR: Could not locate 'vcvars' batch file. This script is intended to be run from a build machine & exit /B 1
+)
+
+if /I "%1"=="x86" (
+    call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
+) else if /I "%1"=="x64" (
+    call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+) else echo ERROR: Requires one of 'x86' or 'x64' & exit /B 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 elseif(${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
     set(HAS_DEBUG_INFO TRUE)
 endif()
+# Release & MinSizeRel => keep all false
 
 set(ASAN_AVAILABLE FALSE)
 set(UBSAN_AVAILABLE FALSE)
@@ -94,8 +95,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     # Address Sanitizer is available for all architectures and build types, but warns/errors if debug info is not enabled
     set(ASAN_AVAILABLE ${HAS_DEBUG_INFO})
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # Address Sanitizer is not available with debug libraries
-    set(ASAN_AVAILABLE NOT ${DEBUG_BUILD})
+    # Sanitizers are not available with debug libraries
+    # Starting with Clang 17, there appears to be some issue where linking to the dynamic asan libraries seems to think that
+    # things like 'operator new' are present in the executable, but only for x64 for some reason
+    set(ASAN_AVAILABLE NOT ${DEBUG_BUILD} AND $ENV{Platform} STREQUAL "x86")
     set(UBSAN_AVAILABLE NOT ${DEBUG_BUILD})
 endif()
 


### PR DESCRIPTION
There's a few things here:
1. Some time ago, likely around when I needed to switch to running tests in the architecture-specific VS command prompt, we effectively stopped running the x64 tests because the pipeline has a copy/paste error where it runs the _x86_ vcvars script. This has been fixed here.
2. I've updated the pipeline to upgrade the version of LLVM installed to 17. This is because the build machines already have version 16 installed, so we've been running validation on an old version. The reason I explicitly specified a version is so that the pipeline doesn't randomly start failing for folks in the future for unrelated reasons.
3. With the switch to Clang version 17, the ASan tests have started failing for x64. I've noticed this locally for quite some time, however I haven't dug too deep into it because the CI seems to have still been working. Disabling them for now until I have adequate time to look into it.
4. I have parallelized the pipeline so that each individual architecture+compiler+build type runs in parallel. This should cut our CI validation times from like ~2.5 hours to <20 min or so. cc @dmachaj who will be happy about this.