### PR TITLE
Add the notion of "checked iterators" to WIL

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -324,7 +324,9 @@ static_assert(WIL_EXCEPTION_MODE <= 2, "Invalid exception mode");
 // definitions differ based on the definition of WIL_ITERATOR_DEBUG_LEVEL in different namespaces
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
 #define __WI_ITR_NAMESPACE WI_PASTE(itr, WIL_ITERATOR_DEBUG_LEVEL)
-#define __WI_ITR_NAMESPACE_BEGIN inline namespace __WI_ITR_NAMESPACE {
+#define __WI_ITR_NAMESPACE_BEGIN \
+    inline namespace __WI_ITR_NAMESPACE \
+    {
 #define __WI_ITR_NAMESPACE_END }
 #else
 #define __WI_ITR_NAMESPACE

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -1114,6 +1114,9 @@ auto to_vector(VectorType* src)
 #endif
 
 #pragma region error code base IIterable<>
+
+__WI_ITR_NAMESPACE_BEGIN
+
 template <typename T>
 class iterable_range_nothrow
 {
@@ -1279,6 +1282,8 @@ private:
     int m_index = 0;
 #endif
 };
+
+__WI_ITR_NAMESPACE_END
 
 #pragma endregion
 

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -868,8 +868,8 @@ public:
 #endif
             m_i += n;
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
-            FAIL_FAST_ASSERT_MSG(m_i >= 0, "Decrementing a vector_iterator_nothrow past the 0th index");
-            FAIL_FAST_ASSERT_MSG(m_i <= m_range->m_size, "Incrementing a vector_iterator_nothrow past the end");
+            // NOTE: 'm_i' is unsigned, hence the single check for increment/decrement
+            FAIL_FAST_ASSERT_MSG(m_i <= m_range->m_size, "Incrementing/decrementing a vector_iterator_nothrow out of range");
 #endif
             m_range->get_at_current(m_i);
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
@@ -1004,9 +1004,12 @@ public:
 
         iterable_iterator& operator=(const iterable_iterator& other)
         {
-            m_iterator = other.m_iterator;
-            m_i = other.m_i;
-            err_policy::HResult(other.m_element.CopyTo(m_element.ReleaseAndGetAddressOf()));
+            if (this != wistd::addressof(other))
+            {
+                m_iterator = other.m_iterator;
+                m_i = other.m_i;
+                err_policy::HResult(other.m_element.CopyTo(m_element.ReleaseAndGetAddressOf()));
+            }
             return *this;
         }
 
@@ -1240,9 +1243,9 @@ public:
             return *this;
         }
 
-        iterable_range_nothrow operator++(int)
+        iterable_iterator_nothrow operator++(int)
         {
-            iterable_range_nothrow old(*this);
+            iterable_iterator_nothrow old(*this);
             ++*this;
             return old;
         }

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -905,10 +905,8 @@ public:
 
     vector_iterator_nothrow begin()
     {
-#if WIL_ITERATOR_DEBUG_LEVEL == 2
-        // All iterators share the same state, so creating multiple begin/end iterators is fairly indicitave of a bug
-        FAIL_FAST_ASSERT_MSG(m_version == 0, "Calling begin() more than once on a vector_range_nothrow");
-#endif
+        // NOTE: Calling 'begin()' more than once is explicitly allowed as a way to reset the range, however because state is
+        // shared between all iterators, this invalidates previously created iterators
         get_at_current(0);
         return vector_iterator_nothrow(this, 0);
     }
@@ -1257,7 +1255,8 @@ public:
     iterable_iterator_nothrow begin()
     {
 #if WIL_ITERATOR_DEBUG_LEVEL == 2
-        // All iterators share the same state, so creating multiple begin/end iterators is fairly indicitave of a bug
+        // The IIterator we hold only advances forward; we can't reset it back to the beginning. Calling this method more than
+        // once will very likely lead to unexpected behavior.
         FAIL_FAST_ASSERT_MSG(m_index == 0, "Calling begin() on an already advanced vector_range_nothrow");
 #endif
         return iterable_iterator_nothrow(this, this->m_iterator ? 0 : -1);

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -827,9 +827,9 @@ public:
         WI_NODISCARD pointer operator->() const
         {
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
-            FAIL_FAST_IF_MSG(m_version != m_range->m_version, "Dereferencing an out-of-date vector_iterator_nothrow");
-            FAIL_FAST_IF_MSG(m_i >= m_range->m_size, "Dereferencing an 'end' iterator");
-            FAIL_FAST_IF_MSG(FAILED(*m_range->m_result), "Dereferencing a vector_iterator_nothrow in a failed state");
+            FAIL_FAST_ASSERT_MSG(m_version == m_range->m_version, "Dereferencing an out-of-date vector_iterator_nothrow");
+            FAIL_FAST_ASSERT_MSG(m_i < m_range->m_size, "Dereferencing an 'end' iterator");
+            FAIL_FAST_ASSERT_MSG(SUCCEEDED(*m_range->m_result), "Dereferencing a vector_iterator_nothrow in a failed state");
 #endif
             return wistd::addressof(m_range->m_currentElement);
         }
@@ -863,13 +863,13 @@ public:
 #if WIL_ITERATOR_DEBUG_LEVEL == 2
             // This is _technically_ safe because we are not reading the out-of-date cached value, however having two active
             // copies of iterators is generally a sign of problematic code with a bug waiting to happen
-            FAIL_FAST_IF_MSG(
-                m_version != m_range->m_version, "Incrementing/decrementing an out-of-date copy of a vector_iterator_nothrow");
+            FAIL_FAST_ASSERT_MSG(
+                m_version == m_range->m_version, "Incrementing/decrementing an out-of-date copy of a vector_iterator_nothrow");
 #endif
             m_i += n;
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
-            FAIL_FAST_IF_MSG(m_i < 0, "Decrementing a vector_iterator_nothrow past the 0th index");
-            FAIL_FAST_IF_MSG(m_i > m_range->m_size, "Incrementing a vector_iterator_nothrow past the end");
+            FAIL_FAST_ASSERT_MSG(m_i >= 0, "Decrementing a vector_iterator_nothrow past the 0th index");
+            FAIL_FAST_ASSERT_MSG(m_i <= m_range->m_size, "Incrementing a vector_iterator_nothrow past the end");
 #endif
             m_range->get_at_current(m_i);
 #if WIL_ITERATOR_DEBUG_LEVEL > 0
@@ -907,7 +907,7 @@ public:
     {
 #if WIL_ITERATOR_DEBUG_LEVEL == 2
         // Almost certainly signals something wrong; there should be one iterator pair per object
-        FAIL_FAST_IF_MSG(m_version != 0, "Calling begin() more than once on a vector_range_nothrow");
+        FAIL_FAST_ASSERT_MSG(m_version == 0, "Calling begin() more than once on a vector_range_nothrow");
 #endif
         get_at_current(0);
         return vector_iterator_nothrow(this, 0);

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -869,7 +869,7 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     FAIL("Unreachable; the above operation should cause process termination");
 #elif 1 // Dereferencing in a failed state
     points->Clear();
-    (void)(*++pointsBegin);
+    (void)(*++pointsBegin); // Fails
     FAIL("Unreachable; the above operation should cause process termination");
 #elif WIL_ITERATOR_DEBUG_LEVEL == 2
 #if 1 // Incrementing an out of date iterator

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -849,7 +849,7 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     auto pointsRange = wil::get_range_nothrow(points.Get());
     [[maybe_unused]] auto pointsBegin = pointsRange.begin();
     [[maybe_unused]] auto pointsEnd = pointsRange.end();
-#if 1 // Dereferencing a post-incremented iterator
+#if 1   // Dereferencing a post-incremented iterator
     // This will fail because post-increment returns a copy to the iterator in its original state. This returned iterator is out
     // of date (and therefore dereferencing it will fail the assertion)
     (void)*pointsBegin++; // Fails
@@ -1087,7 +1087,7 @@ TEST_CASE("WinRTTests::IterableRangeTest", "[winrt][iterable_range]")
     auto pointsRange = wil::get_range_nothrow(points.Get());
     [[maybe_unused]] auto pointsBegin = pointsRange.begin();
     [[maybe_unused]] auto pointsEnd = pointsRange.end();
-#if 1 // Dereferencing a post-incremented iterator
+#if 1   // Dereferencing a post-incremented iterator
     // This will fail because post-increment returns a copy to the iterator in its original state. This returned iterator is out
     // of date (and therefore dereferencing it will fail the assertion)
     (void)*pointsBegin++; // Fails

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -699,7 +699,8 @@ TEST_CASE("WinRTTests::TimeTTests", "[winrt][time_t]")
     REQUIRE(time1.UniversalTime == time2.UniversalTime);
 }
 
-ComPtr<IVector<IInspectable*>> MakeSampleInspectableVector(UINT32 count = 5)
+template <template <typename> class ResultT = IVector>
+ComPtr<ResultT<IInspectable*>> MakeSampleInspectableVector(UINT32 count = 5)
 {
     auto result = Make<FakeVector<IInspectable*>>();
     REQUIRE(result);
@@ -717,7 +718,8 @@ ComPtr<IVector<IInspectable*>> MakeSampleInspectableVector(UINT32 count = 5)
     return result;
 }
 
-ComPtr<IVector<HSTRING>> MakeSampleStringVector()
+template <template <typename> class ResultT = IVector>
+ComPtr<ResultT<HSTRING>> MakeSampleStringVector()
 {
     auto result = Make<FakeVector<HSTRING>>();
     REQUIRE(result);
@@ -731,7 +733,8 @@ ComPtr<IVector<HSTRING>> MakeSampleStringVector()
     return result;
 }
 
-ComPtr<IVector<Point>> MakeSamplePointVector(int count = 5)
+template <template <typename> class ResultT = IVector>
+ComPtr<ResultT<Point>> MakeSamplePointVector(int count = 5)
 {
     auto result = Make<FakeVector<Point>>();
     REQUIRE(result);
@@ -841,6 +844,43 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
         REQUIRE(index++ == itr->Get().X);
     }
 
+    // The following are examples of code that will trigger an assertion failure/fail-fast due to unsafe iterator use
+#if 0 && (WIL_ITERATOR_DEBUG_LEVEL > 0)
+    auto pointsRange = wil::get_range_nothrow(points.Get());
+    [[maybe_unused]] auto pointsBegin = pointsRange.begin();
+    [[maybe_unused]] auto pointsEnd = pointsRange.end();
+#if 1 // Dereferencing a post-incremented iterator
+    // This will fail because post-increment returns a copy to the iterator in its original state. This returned iterator is out
+    // of date (and therefore dereferencing it will fail the assertion)
+    (void)*pointsBegin++; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Dereferincing an iterator invalidated by a second call to 'begin'
+    (void)pointsRange.begin();
+    (void)*pointsBegin; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Dereferencing an end iterator
+    (void)*pointsEnd; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Incrementing an end iterator
+    ++pointsEnd; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Decrementing a begin iterator
+    --pointsBegin; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Dereferencing in a failed state
+    points->Clear();
+    (void)(*++pointsBegin);
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif WIL_ITERATOR_DEBUG_LEVEL == 2
+#if 1 // Incrementing an out of date iterator
+    auto pointsBeginCopy = pointsBegin;
+    ++pointsBegin;
+    ++pointsBeginCopy; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#endif
+#endif
+#endif
+
 #if (defined WIL_ENABLE_EXCEPTIONS)
     idx = 0;
     for (const auto& i : wil::get_range(inspectables.Get()))
@@ -943,6 +983,7 @@ TEST_CASE("WinRTTests::VectorRangeLeakTest", "[winrt][vector_range]")
     inspectables = nullptr; // clear all refs to verifyNotLeaked
     REQUIRE_SUCCEEDED(hr);
     REQUIRE(GetComObjectRefCount(verifyNotLeaked.Get()) == 1);
+    verifyNotLeaked.Reset();
 
     inspectables = MakeSampleInspectableVector();
     for (const auto& ptr : wil::get_range_failfast(inspectables.Get()))
@@ -954,6 +995,7 @@ TEST_CASE("WinRTTests::VectorRangeLeakTest", "[winrt][vector_range]")
     }
     inspectables = nullptr; // clear all refs to verifyNotLeaked
     REQUIRE(GetComObjectRefCount(verifyNotLeaked.Get()) == 1);
+    verifyNotLeaked.Reset();
 
 #if (defined WIL_ENABLE_EXCEPTIONS)
     inspectables = MakeSampleInspectableVector();
@@ -966,6 +1008,176 @@ TEST_CASE("WinRTTests::VectorRangeLeakTest", "[winrt][vector_range]")
     }
     inspectables = nullptr; // clear all refs to verifyNotLeaked
     REQUIRE(GetComObjectRefCount(verifyNotLeaked.Get()) == 1);
+    verifyNotLeaked.Reset();
+#endif
+}
+
+TEST_CASE("WinRTTests::IterableRangeTest", "[winrt][iterable_range]")
+{
+    auto uninit = wil::RoInitialize_failfast();
+
+    auto inspectables = MakeSampleInspectableVector();
+    unsigned count = 0;
+    REQUIRE_SUCCEEDED(inspectables->get_Size(&count));
+    ComPtr<IIterable<IInspectable*>> inspIterable;
+    REQUIRE_SUCCEEDED(inspectables.As(&inspIterable));
+
+    unsigned idx = 0;
+    HRESULT success = S_OK;
+    for (const auto& i : wil::get_range_nothrow(inspIterable.Get(), &success))
+    {
+        // Duplications are not a typo - they verify the thing is callable twice
+
+        UINT32 value;
+        ComPtr<IReference<UINT32>> intRef;
+        REQUIRE_SUCCEEDED(i.CopyTo(IID_PPV_ARGS(&intRef)));
+        REQUIRE_SUCCEEDED(intRef->get_Value(&value));
+        REQUIRE(idx == value);
+        REQUIRE_SUCCEEDED(i.CopyTo(IID_PPV_ARGS(&intRef)));
+        REQUIRE_SUCCEEDED(intRef->get_Value(&value));
+        REQUIRE(idx == value);
+
+        ++idx;
+
+        HString rtc;
+        REQUIRE_SUCCEEDED(i->GetRuntimeClassName(rtc.GetAddressOf()));
+        REQUIRE_SUCCEEDED(i->GetRuntimeClassName(rtc.GetAddressOf()));
+    }
+    REQUIRE_SUCCEEDED(success);
+    REQUIRE(count == idx);
+
+    auto strings = MakeSampleStringVector<IIterable>();
+    for (const auto& i : wil::get_range_nothrow(strings.Get(), &success))
+    {
+        REQUIRE(i.Get());
+        REQUIRE(i.Get());
+    }
+    REQUIRE_SUCCEEDED(success);
+
+    int index = 0;
+    auto points = MakeSamplePointVector<IIterable>();
+    for (auto value : wil::get_range_nothrow(points.Get(), &success))
+    {
+        REQUIRE(index++ == value.Get().X);
+    }
+    REQUIRE_SUCCEEDED(success);
+
+    // operator-> should not clear out the pointer
+    auto inspRange = wil::get_range_nothrow(inspIterable.Get());
+    for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
+    {
+        REQUIRE(itr->Get());
+    }
+
+    auto strRange = wil::get_range_nothrow(strings.Get());
+    for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
+    {
+        REQUIRE(itr->Get());
+    }
+
+    index = 0;
+    auto pointRange = wil::get_range_nothrow(points.Get());
+    for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
+    {
+        REQUIRE(index++ == itr->Get().X);
+    }
+
+    // The following are examples of code that will trigger an assertion failure/fail-fast due to unsafe iterator use
+#if 0 && (WIL_ITERATOR_DEBUG_LEVEL > 0)
+    auto pointsRange = wil::get_range_nothrow(points.Get());
+    [[maybe_unused]] auto pointsBegin = pointsRange.begin();
+    [[maybe_unused]] auto pointsEnd = pointsRange.end();
+#if 1 // Dereferencing a post-incremented iterator
+    // This will fail because post-increment returns a copy to the iterator in its original state. This returned iterator is out
+    // of date (and therefore dereferencing it will fail the assertion)
+    (void)*pointsBegin++; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Dereferencing an end iterator
+    (void)*pointsEnd; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Incrementing an end iterator
+    ++pointsEnd; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Dereferencing in a failed state
+    ComPtr<IVector<Point>> pointsVector;
+    REQUIRE_SUCCEEDED(points.As(&pointsVector));
+    pointsVector->Clear();
+    (void)(*++pointsBegin); // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#elif 1 // Incrementing an out of date iterator
+    auto pointsBeginCopy = pointsBegin;
+    ++pointsBegin;
+    ++pointsBeginCopy; // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#endif
+#if WIL_ITERATOR_DEBUG_LEVEL == 2
+#if 1 // Calling 'begin' again after the first iterator has advanced
+    ++pointsBegin;
+    (void)pointsRange.begin(); // Fails
+    FAIL("Unreachable; the above operation should cause process termination");
+#endif
+#endif
+#endif
+
+#if (defined WIL_ENABLE_EXCEPTIONS)
+    idx = 0;
+    for (const auto& i : wil::get_range(inspIterable.Get()))
+    {
+        // Duplications are not a typo - they verify the thing is callable twice
+
+        UINT32 value;
+        ComPtr<IReference<UINT32>> intRef;
+        REQUIRE_SUCCEEDED(i.CopyTo(IID_PPV_ARGS(&intRef)));
+        REQUIRE_SUCCEEDED(intRef->get_Value(&value));
+        REQUIRE(idx == value);
+        REQUIRE_SUCCEEDED(i.CopyTo(IID_PPV_ARGS(&intRef)));
+        REQUIRE_SUCCEEDED(intRef->get_Value(&value));
+        REQUIRE(idx == value);
+
+        ++idx;
+
+        HString rtc;
+        REQUIRE_SUCCEEDED(i->GetRuntimeClassName(rtc.GetAddressOf()));
+        REQUIRE_SUCCEEDED(i->GetRuntimeClassName(rtc.GetAddressOf()));
+    }
+    REQUIRE(count == idx);
+
+    for (const auto& i : wil::get_range(strings.Get()))
+    {
+        REQUIRE(i.Get());
+        REQUIRE(i.Get());
+    }
+
+    index = 0;
+    for (auto value : wil::get_range(points.Get()))
+    {
+        REQUIRE(index++ == value.Get().X);
+    }
+
+    // Iterator self-assignment is a nop.
+    {
+        auto inspRange2 = wil::get_range(inspIterable.Get());
+        auto itr = inspRange2.begin();
+        REQUIRE(itr != inspRange2.end()); // should have something in it
+        auto& ref = *itr;
+        auto val = ref;
+        itr = itr;
+        REQUIRE(val == ref);
+        itr = std::move(itr);
+        REQUIRE(val == ref);
+    }
+
+    {
+        auto strRange2 = wil::get_range(strings.Get());
+        auto itr = strRange2.begin();
+        REQUIRE(itr != strRange2.end()); // should have something in it
+        auto& ref = *itr;
+        auto val = ref.Get();
+        itr = itr;
+        REQUIRE(val == ref);
+        itr = std::move(itr);
+        REQUIRE(val == ref.Get());
+    }
 #endif
 }
 

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -822,29 +822,23 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     REQUIRE_SUCCEEDED(success);
 
     // operator-> should not clear out the pointer
+    auto inspRange = wil::get_range_nothrow(inspectables.Get());
+    for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
     {
-        auto inspRange = wil::get_range_nothrow(inspectables.Get());
-        for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
-        {
-            REQUIRE(itr->Get());
-        }
+        REQUIRE(itr->Get());
     }
 
+    auto strRange = wil::get_range_nothrow(strings.Get());
+    for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
     {
-        auto strRange = wil::get_range_nothrow(strings.Get());
-        for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
-        {
-            REQUIRE(itr->Get());
-        }
+        REQUIRE(itr->Get());
     }
 
+    index = 0;
+    auto pointRange = wil::get_range_nothrow(points.Get());
+    for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
     {
-        index = 0;
-        auto pointRange = wil::get_range_nothrow(points.Get());
-        for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
-        {
-            REQUIRE(index++ == itr->Get().X);
-        }
+        REQUIRE(index++ == itr->Get().X);
     }
 
 #if (defined WIL_ENABLE_EXCEPTIONS)
@@ -883,36 +877,27 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     }
 
     // operator-> should not clear out the pointer
+    for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
     {
-        auto inspRange = wil::get_range_nothrow(inspectables.Get()); // Reset the range
-        for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
-        {
-            REQUIRE(itr->Get());
-        }
+        REQUIRE(itr->Get());
     }
 
+    for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
     {
-        auto strRange = wil::get_range_nothrow(strings.Get());
-        for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
-        {
-            REQUIRE(itr->Get());
-        }
+        REQUIRE(itr->Get());
     }
 
+    index = 0;
+    for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
     {
-        index = 0;
-        auto pointRange = wil::get_range_nothrow(points.Get());
-        for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
-        {
-            REQUIRE(index++ == itr->Get().X);
-        }
+        REQUIRE(index++ == itr->Get().X);
     }
 
     // Iterator self-assignment is a nop.
     {
-        auto inspRange = wil::get_range(inspectables.Get());
-        auto itr = inspRange.begin();
-        REQUIRE(itr != inspRange.end()); // should have something in it
+        auto inspRange2 = wil::get_range(inspectables.Get());
+        auto itr = inspRange2.begin();
+        REQUIRE(itr != inspRange2.end()); // should have something in it
         auto& ref = *itr;
         auto val = ref;
         itr = itr;
@@ -922,9 +907,9 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     }
 
     {
-        auto strRange = wil::get_range(strings.Get());
-        auto itr = strRange.begin();
-        REQUIRE(itr != strRange.end()); // should have something in it
+        auto strRange2 = wil::get_range(strings.Get());
+        auto itr = strRange2.begin();
+        REQUIRE(itr != strRange2.end()); // should have something in it
         auto& ref = *itr;
         auto val = ref.Get();
         itr = itr;

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -822,23 +822,29 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     REQUIRE_SUCCEEDED(success);
 
     // operator-> should not clear out the pointer
-    auto inspRange = wil::get_range_nothrow(inspectables.Get());
-    for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
     {
-        REQUIRE(itr->Get());
+        auto inspRange = wil::get_range_nothrow(inspectables.Get());
+        for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
+        {
+            REQUIRE(itr->Get());
+        }
     }
 
-    auto strRange = wil::get_range_nothrow(strings.Get());
-    for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
     {
-        REQUIRE(itr->Get());
+        auto strRange = wil::get_range_nothrow(strings.Get());
+        for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
+        {
+            REQUIRE(itr->Get());
+        }
     }
 
-    index = 0;
-    auto pointRange = wil::get_range_nothrow(points.Get());
-    for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
     {
-        REQUIRE(index++ == itr->Get().X);
+        index = 0;
+        auto pointRange = wil::get_range_nothrow(points.Get());
+        for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
+        {
+            REQUIRE(index++ == itr->Get().X);
+        }
     }
 
 #if (defined WIL_ENABLE_EXCEPTIONS)
@@ -877,27 +883,36 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     }
 
     // operator-> should not clear out the pointer
-    for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
     {
-        REQUIRE(itr->Get());
+        auto inspRange = wil::get_range_nothrow(inspectables.Get()); // Reset the range
+        for (auto itr = inspRange.begin(); itr != inspRange.end(); ++itr)
+        {
+            REQUIRE(itr->Get());
+        }
     }
 
-    for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
     {
-        REQUIRE(itr->Get());
+        auto strRange = wil::get_range_nothrow(strings.Get());
+        for (auto itr = strRange.begin(); itr != strRange.end(); ++itr)
+        {
+            REQUIRE(itr->Get());
+        }
     }
 
-    index = 0;
-    for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
     {
-        REQUIRE(index++ == itr->Get().X);
+        index = 0;
+        auto pointRange = wil::get_range_nothrow(points.Get());
+        for (auto itr = pointRange.begin(); itr != pointRange.end(); ++itr)
+        {
+            REQUIRE(index++ == itr->Get().X);
+        }
     }
 
     // Iterator self-assignment is a nop.
     {
-        auto inspRange2 = wil::get_range(inspectables.Get());
-        auto itr = inspRange2.begin();
-        REQUIRE(itr != inspRange2.end()); // should have something in it
+        auto inspRange = wil::get_range(inspectables.Get());
+        auto itr = inspRange.begin();
+        REQUIRE(itr != inspRange.end()); // should have something in it
         auto& ref = *itr;
         auto val = ref;
         itr = itr;
@@ -907,9 +922,9 @@ TEST_CASE("WinRTTests::VectorRangeTest", "[winrt][vector_range]")
     }
 
     {
-        auto strRange2 = wil::get_range(strings.Get());
-        auto itr = strRange2.begin();
-        REQUIRE(itr != strRange2.end()); // should have something in it
+        auto strRange = wil::get_range(strings.Get());
+        auto itr = strRange.begin();
+        REQUIRE(itr != strRange.end()); // should have something in it
         auto& ref = *itr;
         auto val = ref.Get();
         itr = itr;


### PR DESCRIPTION
Background: a couple months or so ago someone reported a number of "gotchas" when using the `wil::vector_iterator_nothrow` type, most of which stem from the fact that the iterator shares state with its "range" object. This means that some operations such as maintaining multiple copies of an iterator (or, similarly, calling `begin()` multiple times) range from risky to guaranteed unexpected behavior. For example, if you increment one iterator and then dereference another, there's a good chance that the result of the dereference is not what you are expecting (since the contents will be for the iterator that you incremented).

This adds the notion of "checked" or "debug" iterators to WIL, which closely follows [MSVC's debug iterator support](https://learn.microsoft.com/cpp/standard-library/debug-iterator-support). Similar to MSVC's `_ITERATOR_DEBUG_LEVEL` define, this introduces the `WIL_ITERATOR_DEBUG_LEVEL` define which can take on the values 0, 1, or 2 - similar to [MSVC's counterpart](https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170):
* `0` - No checks are enabled (default for `Release` builds)
* `1` - Checks are enabled for operations that are _guaranteed_ to be incorrect (e.g. dereferencing an out-of-date iterator)
* `2` - Checks are enabled for operations that are both guaranteed to be incorrect as well as operations that are dangerous and likely to be problematic in the long run (default for `Debug` builds). E.g. advancing an out-of-date iterator as this is an operation that will cause issues in code that does a conditional advance depending on the number of elements (as is the case with `std::advance` on an input iterator).

For a more in-depth example, consider the scenario that was originally reported - trying to use `vector_range_nothrow` with `std::lower_bound`. There are a couple issues here (e.g. `std::distance` is both slow and destructive to the shared state), but let's focus on the more obvious issue - there are lots of operations on copies of iterators. Consider the vector contents `[0, 1, 2]`. If we're looking for the value `2` things will _probably_ work out okay since we advance to index `1` for the first mid-point check, see that the value is less than `2`, advance one more, see that the value is not less than `2`, and then the search is done. If we're instead looking for the value `1` or `2`, then things will probably blow up in one way or another. In both cases, we'll see that `1` is not less than either number and will instead look at the earlier elements. This involves advancing the begin iterator by zero elements - something that will be a no-op - meaning that the algorithm will end up seeing the value `1` when dereferencing the iterator instead of `0`. This will end up returning the wrong iterator that when dereferenced returns the correct value when looking for `1`, and the correct iterator that when dereferenced returns the incorrect value when looking for `0`. With `WIL_ITERATOR_DEBUG_LEVEL` set to `1`, the code will _not_ fail the assertion when looking for `2`, but _will_ fail the assertion when looking for `0` or `1`. With `WIL_ITERATOR_DEBUG_LEVEL` set to `2`, the code will _always_ fail the assertion.

For now, I've only touched the `nothrow` iterators in `winrt.h` as these have shared state and it's comparatively easy to find yourself in a position where an operation is unsafe. Skimming around, there are some other iterators that would benefit from having similar checking (looking at you `com_iterator`), however no simple mechanism exists for adding these checks without also adding a breaking change (e.g. adding a new requirement that `com_iterator` not outlive the result from `make_range`)