### PR TITLE
Adding macro RETURN_IF_FAILED_SUPPRESS_TELEMETRY_IF_EXPECTED

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -227,11 +227,14 @@ bool DoesCodeFailFast(TLambda&& callOp)
 {
     bool failFast = false;
     witest::detoured_thread_function<&wil::details::ReportFailure_Base<wil::FailureType::FailFast, false>> detour;
-    REQUIRE_SUCCEEDED(detour.reset(
-        [&](__R_FN_PARAMS_FULL, const wil::details::ResultStatus& resultPair, PCWSTR message, wil::details::ReportFailureOptions options) {
-            failFast = true;
-            wil::details::ReportFailure_Base<wil::FailureType::FailFast, true>(__R_FN_CALL_FULL, resultPair, message, options);
-        }));
+    REQUIRE_SUCCEEDED(detour.reset([&](__R_FN_PARAMS_FULL,
+                                       const wil::details::ResultStatus& resultPair,
+                                       PCWSTR message,
+                                       wil::details::ReportFailureOptions options,
+                                       wil::FailureFlags flags) {
+        failFast = true;
+        wil::details::ReportFailure_Base<wil::FailureType::FailFast, true>(__R_FN_CALL_FULL, resultPair, message, options, flags);
+    }));
 
     callOp();
 


### PR DESCRIPTION
Closes #425.

For the result macros, when one sets a telemetry fallback provider with SetResultTelemetryFallback() and a logging callback with SetResultLoggingCallback(), we always log and send telemetry for HRESULT failures in the RETURN_ macros.
The _EXPECTED macros allows one to skip the reporting for some expected HRESULTs, but that suppresses both logging and telemetry. There was no alternative if one wanted to always log failures but just suppress telemetry in case the HRESULT was expected.

The new macro `RETURN_IF_FAILED_SUPPRESS_TELEMETRY_IF_EXPECTED` returns an HRESULT if it failed, always logging those failures, but sends a suppressed telemetry callback if the HRESULT matches one of the expected HRESULT values.
The way this is done is leveraging the existing enum `FailureFlags::SuppressTelemetry`. This enum makes the telemetry callback be [called](https://github.com/microsoft/wil/blob/master/include/wil/result.h#L1069) with `alreadyReported` as `true`.

There is a new parameter `FailureFlags` to the internal ReturnHr methods in result_macros.h.

New tests were added to check the feature behavior.