### PR TITLE
Add WI_NOEXCEPT for verify functions

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -687,32 +687,32 @@ boolean, BOOLEAN, and classes with an explicit bool cast.
 @param val The logical bool expression
 @return A C++ bool representing the evaluation of `val`. */
 template <typename T, __R_ENABLE_IF_IS_CLASS(T)>
-_Post_satisfies_(return == static_cast<bool>(val)) __forceinline constexpr bool verify_bool(const T& val)
+_Post_satisfies_(return == static_cast<bool>(val)) __forceinline constexpr bool verify_bool(const T& val) WI_NOEXCEPT
 {
     return static_cast<bool>(val);
 }
 
 template <typename T, __R_ENABLE_IF_IS_NOT_CLASS(T)>
-__forceinline constexpr bool verify_bool(T /*val*/)
+__forceinline constexpr bool verify_bool(T /*val*/) WI_NOEXCEPT
 {
     static_assert(!wistd::is_same<T, T>::value, "Wrong Type: bool/BOOL/BOOLEAN/boolean expected");
     return false;
 }
 
 template <>
-_Post_satisfies_(return == val) __forceinline constexpr bool verify_bool<bool>(bool val)
+_Post_satisfies_(return == val) __forceinline constexpr bool verify_bool<bool>(bool val) WI_NOEXCEPT
 {
     return val;
 }
 
 template <>
-_Post_satisfies_(return == (val != 0)) __forceinline constexpr bool verify_bool<int>(int val)
+_Post_satisfies_(return == (val != 0)) __forceinline constexpr bool verify_bool<int>(int val) WI_NOEXCEPT
 {
     return (val != 0);
 }
 
 template <>
-_Post_satisfies_(return == (val != 0)) __forceinline constexpr bool verify_bool<unsigned char>(unsigned char val)
+_Post_satisfies_(return == (val != 0)) __forceinline constexpr bool verify_bool<unsigned char>(unsigned char val) WI_NOEXCEPT
 {
     return (val != 0);
 }
@@ -723,7 +723,7 @@ accept any `int` value as long as that is the underlying typedef behind `BOOL`.
 @param val The Win32 BOOL returning expression
 @return A Win32 BOOL representing the evaluation of `val`. */
 template <typename T>
-_Post_satisfies_(return == val) __forceinline constexpr int verify_BOOL(T val)
+_Post_satisfies_(return == val) __forceinline constexpr int verify_BOOL(T val) WI_NOEXCEPT
 {
     // Note: Written in terms of 'int' as BOOL is actually:  typedef int BOOL;
     static_assert((wistd::is_same<T, int>::value), "Wrong Type: BOOL expected");
@@ -752,7 +752,7 @@ RETURN_HR_IF(static_cast<HRESULT>(UIA_E_NOTSUPPORTED), (patternId != UIA_DragPat
 @param hr The HRESULT returning expression
 @return An HRESULT representing the evaluation of `val`. */
 template <typename T>
-_Post_satisfies_(return == hr) inline constexpr long verify_hresult(T hr)
+_Post_satisfies_(return == hr) inline constexpr long verify_hresult(T hr) WI_NOEXCEPT
 {
     // Note: Written in terms of 'long' as HRESULT is actually:  typedef _Return_type_success_(return >= 0) long HRESULT
     static_assert(wistd::is_same<T, long>::value, "Wrong Type: HRESULT expected");
@@ -781,7 +781,7 @@ NT_RETURN_IF_FALSE(static_cast<NTSTATUS>(STATUS_NOT_SUPPORTED), (dispatch->Versi
 @param status The NTSTATUS returning expression
 @return An NTSTATUS representing the evaluation of `val`. */
 template <typename T>
-_Post_satisfies_(return == status) inline long verify_ntstatus(T status)
+_Post_satisfies_(return == status) inline long verify_ntstatus(T status) WI_NOEXCEPT
 {
     // Note: Written in terms of 'long' as NTSTATUS is actually:  typedef _Return_type_success_(return >= 0) long NTSTATUS
     static_assert(wistd::is_same<T, long>::value, "Wrong Type: NTSTATUS expected");
@@ -795,7 +795,7 @@ commonly used when manipulating Win32 error codes.
 @param error The Win32 error code returning expression
 @return An Win32 error code representing the evaluation of `error`. */
 template <typename T>
-_Post_satisfies_(return == error) inline T verify_win32(T error)
+_Post_satisfies_(return == error) inline T verify_win32(T error) WI_NOEXCEPT
 {
     // Note: Win32 error code are defined as 'long' (#define ERROR_SUCCESS 0L), but are more frequently used as DWORD (unsigned
     // long). This accept both types.


### PR DESCRIPTION
The verify functions all use static_assert and should never throw any runtime exceptions. Mark these as `WI_NOEXCEPT` accordingly.