### PR TITLE
Use Windows SDK header define instead of C standard header define

### DIFF
--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -435,7 +435,7 @@ namespace details_abi
     private:
         struct Node
         {
-            DWORD threadId = ULONG_MAX;
+            DWORD threadId = MAXDWORD;
             Node* pNext = nullptr;
             T value{};
         };


### PR DESCRIPTION
When WIN32_LEAN_AND_MEAN and WIL_SUPPRESS_EXCEPTIONS are defined, limits.h is not included.