### PR TITLE
LLVM MinGW compatibility improvements

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -2892,6 +2892,7 @@ typedef unique_any_t<event_t<details::unique_storage<details::handle_resource_po
 typedef unique_any_t<event_t<details::unique_storage<details::handle_resource_policy>, err_exception_policy>> unique_event;
 #endif
 
+#ifndef WIL_NO_SLIM_EVENT
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && \
     ((_WIN32_WINNT >= _WIN32_WINNT_WIN8) || (__WIL_RESOURCE_ENABLE_QUIRKS && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)))
 enum class SlimEventType
@@ -3060,6 +3061,7 @@ using slim_event_manual_reset = slim_event_t<SlimEventType::ManualReset>;
 using slim_event = slim_event_auto_reset;
 
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+#endif // WIL_NO_SLIM_EVENT
 
 typedef unique_any<HANDLE, decltype(&details::ReleaseMutex), details::ReleaseMutex, details::pointer_access_none> mutex_release_scope_exit;
 

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -27,10 +27,10 @@
 // stdint.h and intsafe.h have conflicting definitions, so it's not safe to include either to pick up our dependencies,
 // so the definitions we need are copied below
 #ifdef _WIN64
-#define __WI_SIZE_MAX 0xffffffffffffffffui64 // UINT64_MAX
-#else                                        /* _WIN64 */
-#define __WI_SIZE_MAX 0xffffffffui32         // UINT32_MAX
-#endif                                       /* _WIN64 */
+#define __WI_SIZE_MAX 0xffffffffffffffffULL // UINT64_MAX
+#else                                       /* _WIN64 */
+#define __WI_SIZE_MAX 0xffffffffUL          // UINT32_MAX
+#endif                                      /* _WIN64 */
 /// @endcond
 
 // Forward declaration

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -2851,7 +2851,7 @@ namespace details
     // NOTE: The following two functions are unfortunate copies of strsafe.h functions that have been copied to reduce the friction associated with using
     // Result.h and ResultException.h in a build that does not have WINAPI_PARTITION_DESKTOP defined (where these are conditionally enabled).
 
-    static STRSAFEAPI WilStringLengthWorkerA(
+    inline HRESULT WilStringLengthWorkerA(
         _In_reads_or_z_(cchMax) STRSAFE_PCNZCH psz,
         _In_ _In_range_(<=, STRSAFE_MAX_CCH) size_t cchMax,
         _Out_opt_ _Deref_out_range_(<, cchMax) _Deref_out_range_(<=, _String_length_(psz)) size_t* pcchLength)
@@ -2883,7 +2883,7 @@ namespace details
     }
 
     _Must_inspect_result_
-    STRSAFEAPI StringCchLengthA(
+    inline HRESULT StringCchLengthA(
         _In_reads_or_z_(cchMax) STRSAFE_PCNZCH psz,
         _In_ _In_range_(1, STRSAFE_MAX_CCH) size_t cchMax,
         _Out_opt_ _Deref_out_range_(<, cchMax) _Deref_out_range_(<=, _String_length_(psz)) size_t* pcchLength)
@@ -2905,7 +2905,7 @@ namespace details
     }
 #pragma warning(pop)
 
-    _Post_satisfies_(cchDest > 0 && cchDest <= cchMax) static STRSAFEAPI
+    _Post_satisfies_(cchDest > 0 && cchDest <= cchMax) inline HRESULT
         WilStringValidateDestA(_In_reads_opt_(cchDest) STRSAFE_PCNZCH /*pszDest*/, _In_ size_t cchDest, _In_ const size_t cchMax)
     {
         HRESULT hr = S_OK;
@@ -2916,7 +2916,7 @@ namespace details
         return hr;
     }
 
-    static STRSAFEAPI WilStringVPrintfWorkerA(
+    inline HRESULT WilStringVPrintfWorkerA(
         _Out_writes_(cchDest) _Always_(_Post_z_) STRSAFE_LPSTR pszDest,
         _In_ _In_range_(1, STRSAFE_MAX_CCH) size_t cchDest,
         _Always_(_Out_opt_ _Deref_out_range_(<=, cchDest - 1)) size_t* pcchNewDestLength,
@@ -2973,7 +2973,7 @@ namespace details
         return hr;
     }
 
-    __inline HRESULT StringCchPrintfA(
+    inline HRESULT StringCchPrintfA(
         _Out_writes_(cchDest) _Always_(_Post_z_) STRSAFE_LPSTR pszDest,
         _In_ size_t cchDest,
         _In_ _Printf_format_string_ STRSAFE_LPCSTR pszFormat,

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -2852,7 +2852,7 @@ namespace details
     // Result.h and ResultException.h in a build that does not have WINAPI_PARTITION_DESKTOP defined (where these are conditionally enabled).
 
     inline HRESULT WilStringLengthWorkerA(
-        _In_reads_or_z_(cchMax) STRSAFE_PCNZCH psz,
+        _In_reads_or_z_(cchMax) PCNZCH psz,
         _In_ _In_range_(<=, STRSAFE_MAX_CCH) size_t cchMax,
         _Out_opt_ _Deref_out_range_(<, cchMax) _Deref_out_range_(<=, _String_length_(psz)) size_t* pcchLength)
     {
@@ -2884,7 +2884,7 @@ namespace details
 
     _Must_inspect_result_
     inline HRESULT StringCchLengthA(
-        _In_reads_or_z_(cchMax) STRSAFE_PCNZCH psz,
+        _In_reads_or_z_(cchMax) PCNZCH psz,
         _In_ _In_range_(1, STRSAFE_MAX_CCH) size_t cchMax,
         _Out_opt_ _Deref_out_range_(<, cchMax) _Deref_out_range_(<=, _String_length_(psz)) size_t* pcchLength)
     {
@@ -2906,7 +2906,7 @@ namespace details
 #pragma warning(pop)
 
     _Post_satisfies_(cchDest > 0 && cchDest <= cchMax) inline HRESULT
-        WilStringValidateDestA(_In_reads_opt_(cchDest) STRSAFE_PCNZCH /*pszDest*/, _In_ size_t cchDest, _In_ const size_t cchMax)
+        WilStringValidateDestA(_In_reads_opt_(cchDest) PCNZCH /*pszDest*/, _In_ size_t cchDest, _In_ const size_t cchMax)
     {
         HRESULT hr = S_OK;
         if ((cchDest == 0) || (cchDest > cchMax))

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -3537,7 +3537,7 @@ void ThreadPoolTimerWorkHelper(SetThreadpoolTimerT const& setThreadpoolTimerFn, 
         // Schedule timer
         myContext.Event.ResetEvent();
         const auto allowedWindow = 0;
-        LONGLONG dueTime = -5 * 10000I64; // 5ms
+        LONGLONG dueTime = -5 * 10000LL; // 5ms
         setThreadpoolTimerFn(timer.get(), reinterpret_cast<DueTimeT*>(&dueTime), 0, allowedWindow);
 
         // Wait until 'myContext.Counter' increments by 1.
@@ -3554,7 +3554,7 @@ void ThreadPoolTimerWorkHelper(SetThreadpoolTimerT const& setThreadpoolTimerFn, 
     // Schedule one last timer.
     myContext.Event.ResetEvent();
     const auto allowedWindow = 0;
-    LONGLONG dueTime = -5 * 10000I64; // 5ms
+    LONGLONG dueTime = -5 * 10000LL; // 5ms
     setThreadpoolTimerFn(timer.get(), reinterpret_cast<DueTimeT*>(&dueTime), 0, allowedWindow);
 
     if (requireExactCallbackCount)


### PR DESCRIPTION
I tried to use WIL with [LLVM MinGW](https://github.com/mstorsjo/llvm-mingw). After the changes in this PR and with the compiler options and definitions below, I'm able to compile the main WIL functionality.

Related issue: https://github.com/microsoft/wil/issues/117.

Compiler options:
```
-fms-extensions
```

Definitions added before including WIL:
```cpp
#define _Frees_ptr_
#define _Frees_ptr_opt_
#define _Post_z_
#define _Pre_maybenull_
#define _Pre_opt_valid_
#define _Pre_valid_
#define _Ret_opt_bytecap_(size)
#define _Translates_last_error_to_HRESULT_
#define _Translates_NTSTATUS_to_HRESULT_(status)
#define _Translates_Win32_to_HRESULT_(err)
#define InterlockedDecrementNoFence InterlockedDecrement
#define InterlockedIncrementNoFence InterlockedIncrement
#define WIL_NO_SLIM_EVENT
```