### PR TITLE
Feature: Add an RAII wrapper to support RPC timeouts when making blocking COM calls #458

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3344,8 +3344,7 @@ Include wil/win32_helpers.h before wil/com.h to use this.
 class rpc_timeout
 {
 public:
-    rpc_timeout(DWORD timeoutInMilliseconds):
-        m_threadId(GetCurrentThreadId())
+    rpc_timeout(DWORD timeoutInMilliseconds) : m_threadId(GetCurrentThreadId())
     {
         m_cancelEnablementResult = CoEnableCallCancellation(nullptr);
         if (SUCCEEDED(m_cancelEnablementResult))
@@ -3378,8 +3377,8 @@ public:
 
 private:
     // Disable use of new as this class should only be declared on the stack, never the heap.
-    void *operator new(size_t) = delete;
-    void *operator new[](size_t) = delete;
+    void* operator new(size_t) = delete;
+    void* operator new[](size_t) = delete;
 
     static void timer_callback(PTP_CALLBACK_INSTANCE /*instance*/, PVOID context, PTP_TIMER /*timer*/)
     {

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3327,6 +3327,20 @@ WI_NODISCARD auto make_range(IEnumXxx* enumPtr)
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 #ifdef __WIL_WIN32_HELPERS_INCLUDED
+
+/** RAII support for making cross-apartment (or cross process) COM calls with a timeout applied to them.
+ * When this is active any timed out calls will fail with an RPC error code such as RPC_E_CALL_CANCELED.
+ * This is a shared timeout that applies to all calls made on the current thread for the lifetime of
+ * the wil::rpc_timeout object.
+~~~
+{
+  auto timeout = wil::rpc_timeout(5000);
+  remote_object->BlockingCOMCall();
+  remote_object->AnotherBlockingCOMCall();
+}
+~~~
+Include wil/win32_helpers.h before wil/com.h to use this.
+*/
 class rpc_timeout
 {
 public:

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3411,14 +3411,14 @@ private:
 // Error-policy driven forms of com_timeout
 
 #ifdef WIL_ENABLE_EXCEPTIONS
-//! COM pointer, errors throw exceptions (see @ref com_ptr_t for details)
+//! COM timeout, errors throw exceptions (see @ref com_timeout_t for details)
 using com_timeout = com_timeout_t<err_exception_policy>;
 #endif
 
-//! COM pointer, errors return error codes (see @ref com_ptr_t for details)
+//! COM timeout, errors return error codes (see @ref com_timeout_t for details)
 using com_timeout_nothrow = com_timeout_t<err_returncode_policy>;
 
-//! COM pointer, errors fail-fast (see @ref com_ptr_t for details)
+//! COM timeout, errors fail-fast (see @ref com_timeout_t for details)
 using com_timeout_failfast = com_timeout_t<err_failfast_policy>;
 
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3380,7 +3380,7 @@ private:
     void* operator new(size_t) = delete;
     void* operator new[](size_t) = delete;
 
-    static void timer_callback(PTP_CALLBACK_INSTANCE /*instance*/, PVOID context, PTP_TIMER /*timer*/)
+    static void __stdcall timer_callback(PTP_CALLBACK_INSTANCE /*instance*/, PVOID context, PTP_TIMER /*timer*/)
     {
         // The timer is waited upon during destruction so it is safe to rely on the this pointer in context.
         rpc_timeout* self = static_cast<rpc_timeout*>(context);

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3357,7 +3357,7 @@ public:
             if (m_timer)
             {
                 FILETIME ft = filetime::get_system_time();
-                filetime::add(ft, filetime::convert_msec_to_100ns(timeoutInMilliseconds));
+                ft = filetime::add(ft, filetime::convert_msec_to_100ns(timeoutInMilliseconds));
                 SetThreadpoolTimer(m_timer.get(), &ft, timeoutInMilliseconds, 0);
             }
         }

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3071,7 +3071,7 @@ const winrt::guid CLSID_RPCTimeoutTestServer{L"CED2F47C-200B-476F-BFDC-D0D79B052
 HANDLE g_hangHandle{nullptr};
 HANDLE g_doneHangingHandle{nullptr};
 
-TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
+TEST_CASE("com_timeout", "[com][com_timeout]")
 {
     auto init = wil::CoInitializeEx_failfast();
 
@@ -3144,7 +3144,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
 
     SECTION("Basic construction")
     {
-        wil::rpc_timeout timeout{5000};
+        wil::com_timeout timeout{5000};
         REQUIRE(!timeout.timed_out());
     }
     SECTION("RPC timeout test")
@@ -3160,7 +3160,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
         doneHangingHandle.create();
         g_doneHangingHandle = doneHangingHandle.get();
 
-        wil::rpc_timeout timeout{100};
+        wil::com_timeout timeout{100};
 
         // The timeout is now in place.  The blocking call should cancel in a timely manner and fail with RPC_E_CALL_CANCELED.
         wil::com_ptr<ABI::Windows::Foundation::IStringable> localServer;
@@ -3175,7 +3175,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
 
         hangHandle.ResetEvent();
 
-        // Make a second blocking call within the lifetime of the same rpc_timeout instance.  This second call should also
+        // Make a second blocking call within the lifetime of the same com_timeout instance.  This second call should also
         // cancel and return.
         const auto result = localServer->ToString(&value);
         REQUIRE(result == RPC_E_CALL_CANCELED);
@@ -3189,7 +3189,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
     }
     SECTION("Non-timeout unaffected test")
     {
-        wil::rpc_timeout timeout{100};
+        wil::com_timeout timeout{100};
 
         // g_hangHandle is not set so this call will not block.  It should not be affected by the timeout.
         wil::com_ptr<ABI::Windows::Foundation::IStringable> localServer;

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3060,7 +3060,6 @@ TEST_CASE("COMEnumerator", "[com][enumerator]")
 #pragma warning(pop)
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && WIL_HAS_CXX_17
 
-
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 #if (NTDDI_VERSION >= NTDDI_WINBLUE)
 TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
@@ -3081,7 +3080,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
         initialized.create();
         wil::shared_event blocker;
         blocker.create();
-        
+
         wil::com_agile_ref_failfast agileDesktop;
 
         auto staThread = std::thread([initialized, blocker, &agileDesktop] {
@@ -3092,7 +3091,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
             agileDesktop = wil::com_agile_query(desktop);
 
             initialized.SetEvent(); // Tell the original thread that agileDesktop is ready
-            blocker.wait(5000); // And then block so that calls will hang.
+            blocker.wait(5000);     // And then block so that calls will hang.
         });
 
         REQUIRE(initialized.wait(5000));
@@ -3120,7 +3119,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
         initialized.create();
         wil::shared_event blocker;
         blocker.create();
-        
+
         wil::com_agile_ref_failfast agileDesktop;
 
         auto staThread = std::thread([initialized, blocker, &agileDesktop] {
@@ -3131,11 +3130,11 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
             agileDesktop = wil::com_agile_query(desktop);
 
             initialized.SetEvent(); // Tell the original thread that agileDesktop is ready
-            
+
             // Pump messages so this STA thread is healthy.
             HANDLE handles[1] = {blocker.get()};
             DWORD index;
-            CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS  | CWMO_DISPATCH_WINDOW_MESSAGES, 5000, ARRAYSIZE(handles), handles, &index);
+            CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS | CWMO_DISPATCH_WINDOW_MESSAGES, 5000, ARRAYSIZE(handles), handles, &index);
         });
 
         REQUIRE(initialized.wait(5000));

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3139,7 +3139,7 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
 
         REQUIRE(initialized.wait(5000));
 
-        auto timeout = wil::rpc_timeout(100);
+        auto timeout = wil::rpc_timeout(1000);
 
         // Perform a cross-apartment call to the STA that is pumping.  The specific call doesn't matter
         // as long as it is a blocking call.

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3148,9 +3148,22 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
         Sleep(50);
     }
 
-    SECTION("Basic construction")
+    SECTION("Basic construction nothrow")
+    {
+        wil::com_timeout_nothrow timeout{5000};
+        REQUIRE(static_cast<bool>(timeout));
+        REQUIRE(!timeout.timed_out());
+    }
+    SECTION("Basic construction throwing")
     {
         wil::com_timeout timeout{5000};
+        REQUIRE(static_cast<bool>(timeout));
+        REQUIRE(!timeout.timed_out());
+    }
+    SECTION("Basic construction failfast")
+    {
+        wil::com_timeout_failfast timeout{5000};
+        REQUIRE(static_cast<bool>(timeout));
         REQUIRE(!timeout.timed_out());
     }
     SECTION("RPC timeout test")

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3067,9 +3067,9 @@ TEST_CASE("COMEnumerator", "[com][enumerator]")
 #include <winrt/windows.foundation.h>
 #include <windows.foundation.h>
 
-const winrt::guid CLSID_RPCTimeoutTestServer{ L"CED2F47C-200B-476F-BFDC-D0D79B052AC6" };
-HANDLE g_hangHandle{ nullptr };
-HANDLE g_doneHangingHandle{ nullptr };
+const winrt::guid CLSID_RPCTimeoutTestServer{L"CED2F47C-200B-476F-BFDC-D0D79B052AC6"};
+HANDLE g_hangHandle{nullptr};
+HANDLE g_doneHangingHandle{nullptr};
 
 TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
 {
@@ -3092,9 +3092,10 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
             {
                 // Pump messages so this STA thread is healthy while we wait.  If this wait fails that means
                 // the cancel did not work.
-                HANDLE handles[1] = { g_hangHandle };
+                HANDLE handles[1] = {g_hangHandle};
                 DWORD index;
-                REQUIRE_SUCCEEDED(CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS | CWMO_DISPATCH_WINDOW_MESSAGES, 10000, ARRAYSIZE(handles), handles, &index));
+                REQUIRE_SUCCEEDED(CoWaitForMultipleObjects(
+                    CWMO_DISPATCH_CALLS | CWMO_DISPATCH_WINDOW_MESSAGES, 10000, ARRAYSIZE(handles), handles, &index));
 
                 if (g_doneHangingHandle)
                 {
@@ -3118,15 +3119,20 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
 
         DWORD registration{};
         REQUIRE_SUCCEEDED(CoRegisterClassObject(
-            winrt::guid{ CLSID_RPCTimeoutTestServer }, winrt::make<wil::details::CppWinRTClassFactory<RPCTimeoutTestServer>>().get(), CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &registration));
-        wil::unique_com_class_object_cookie revoker{ registration };
+            winrt::guid{CLSID_RPCTimeoutTestServer},
+            winrt::make<wil::details::CppWinRTClassFactory<RPCTimeoutTestServer>>().get(),
+            CLSCTX_LOCAL_SERVER,
+            REGCLS_MULTIPLEUSE,
+            &registration));
+        wil::unique_com_class_object_cookie revoker{registration};
 
         comServerInitializedEvent.SetEvent();
 
         // Pump messages so this STA thread is healthy.
-        HANDLE handles[1] = { comServerEvent.get() };
+        HANDLE handles[1] = {comServerEvent.get()};
         DWORD index;
-        REQUIRE_SUCCEEDED(CoWaitForMultipleObjects(CWMO_DISPATCH_CALLS | CWMO_DISPATCH_WINDOW_MESSAGES, 10000, ARRAYSIZE(handles), handles, &index));
+        REQUIRE_SUCCEEDED(CoWaitForMultipleObjects(
+            CWMO_DISPATCH_CALLS | CWMO_DISPATCH_WINDOW_MESSAGES, 10000, ARRAYSIZE(handles), handles, &index));
     });
 
     REQUIRE(comServerInitializedEvent.wait(5000));
@@ -3154,11 +3160,12 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
         doneHangingHandle.create();
         g_doneHangingHandle = doneHangingHandle.get();
 
-        wil::rpc_timeout timeout{ 100 };
+        wil::rpc_timeout timeout{100};
 
         // The timeout is now in place.  The blocking call should cancel in a timely manner and fail with RPC_E_CALL_CANCELED.
         wil::com_ptr<ABI::Windows::Foundation::IStringable> localServer;
-        REQUIRE_SUCCEEDED(CoCreateInstance(winrt::guid{ CLSID_RPCTimeoutTestServer }, nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&localServer)));
+        REQUIRE_SUCCEEDED(
+            CoCreateInstance(winrt::guid{CLSID_RPCTimeoutTestServer}, nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&localServer)));
         wil::unique_hstring value;
         REQUIRE(localServer->ToString(&value) == RPC_E_CALL_CANCELED);
         REQUIRE(timeout.timed_out());
@@ -3182,11 +3189,12 @@ TEST_CASE("rpc_timeout", "[com][rpc_timeout]")
     }
     SECTION("Non-timeout unaffected test")
     {
-        wil::rpc_timeout timeout{ 100 };
+        wil::rpc_timeout timeout{100};
 
         // g_hangHandle is not set so this call will not block.  It should not be affected by the timeout.
         wil::com_ptr<ABI::Windows::Foundation::IStringable> localServer;
-        REQUIRE_SUCCEEDED(CoCreateInstance(winrt::guid{ CLSID_RPCTimeoutTestServer }, nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&localServer)));
+        REQUIRE_SUCCEEDED(
+            CoCreateInstance(winrt::guid{CLSID_RPCTimeoutTestServer}, nullptr, CLSCTX_LOCAL_SERVER, IID_PPV_ARGS(&localServer)));
         wil::unique_hstring value;
         REQUIRE_SUCCEEDED(localServer->ToString(&value));
         REQUIRE(!timeout.timed_out());

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3062,6 +3062,7 @@ TEST_CASE("COMEnumerator", "[com][enumerator]")
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 #if (NTDDI_VERSION >= NTDDI_WINBLUE)
+#if defined(__cpp_impl_coroutine) || defined(__cpp_coroutines) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 
 #include <wil/cppwinrt_register_com_server.h>
 #include <winrt/windows.foundation.h>
@@ -3208,6 +3209,7 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
     g_hangHandle = nullptr;
     g_doneHangingHandle = nullptr;
 }
+#endif // defined(__cpp_impl_coroutine) || defined(__cpp_coroutines) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #endif // (NTDDI_VERSION >= NTDDI_WINBLUE)
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 


### PR DESCRIPTION
Closes #458

## Why is this change being made?
We have a project where we want to make blocking COM calls to another COM server process, but we want protection from the calls taking an infinite amount of time.  There is an existing, but very old, wrapper that provides this functionality.  Instead of using the old wrapper I am porting it to WIL so that we can use it in a different repo than the original and to share it more broadly because it is useful.

## Briefly summarize what changed
Add a new `wil::rpc_timeout` class to <wil/com.h> along with a few test cases for it.  This class uses a combination of `CoEnableCallCancellation`, `CoDisableCallCancellation`, and `CoCancelCall` to provide the COM functionality.  `CreateThreadpoolTimer` is used to provide a timed callback that will not block on the same thread as the blocking COM call.

This object is intended to live on the stack and have a short lifetime.  It is single-use and applies to all RPC calls made while it is alive.

## How was this change tested?
New test cases in ComTests.cpp.