### PR TITLE
Update cppwinrt used by WIL tests to the latest released version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT DEFINED WIL_BUILD_VERSION)
 endif()
 
 if (NOT DEFINED CPPWINRT_VERSION)
-    set(CPPWINRT_VERSION "2.0.221121.5")
+    set(CPPWINRT_VERSION "2.0.240405.15")
 endif()
 
 # Detect the Windows SDK version. If we're using the Visual Studio generator, this will be provided for us. Otherwise

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT DEFINED WIL_BUILD_VERSION)
 endif()
 
 if (NOT DEFINED CPPWINRT_VERSION)
-    set(CPPWINRT_VERSION "2.0.240405.15") 
+    set(CPPWINRT_VERSION "2.0.240405.15")
 endif()
 
 # Detect the Windows SDK version. If we're using the Visual Studio generator, this will be provided for us. Otherwise

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT DEFINED WIL_BUILD_VERSION)
 endif()
 
 if (NOT DEFINED CPPWINRT_VERSION)
-    set(CPPWINRT_VERSION "2.0.240405.15")
+    set(CPPWINRT_VERSION "2.0.240405.15") 
 endif()
 
 # Detect the Windows SDK version. If we're using the Visual Studio generator, this will be provided for us. Otherwise


### PR DESCRIPTION
Closes #464

## Why is this change being made?
It is nice to keep up to date on dependencies.  Most consumers of WIL have likely moved to a newer version of cppwinrt, so the testing of WIL itself should also move to a newer version.

## Briefly summarize what changed
Update the version defined in cmake from 2.0.221121.5 to 2.0.240405.15 (about a year and a half newer).

## How was this change tested?
1. `scripts\init_all.cmd`
2. `scripts\build_all.cmd`
3. `scripts\runtests.cmd`

No breaks, no test failures.  (Validated x64 of msvc+clang)