### PR TITLE
Define SAL annotations as empty macros in CMake `WIL::WIL` target for MinGW and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,27 @@ file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+# If MinGW and Clang, define SAL annotations as macros with empty definitions.
+if(MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_definitions(${PROJECT_NAME} INTERFACE
+        _Frees_ptr_=
+        _Frees_ptr_opt_=
+        _Post_z_=
+        _Pre_maybenull_=
+        _Pre_opt_valid_=
+        _Pre_valid_=
+        _Translates_last_error_to_HRESULT_=
+        InterlockedDecrementNoFence=InterlockedDecrement
+        InterlockedIncrementNoFence=InterlockedIncrement
+        WIL_NO_SLIM_EVENT=
+    )
+    target_compile_options(${PROJECT_NAME} INTERFACE
+        "-D_Ret_opt_bytecap_(size)="
+        "-D_Translates_NTSTATUS_to_HRESULT_(status)="
+        "-D_Translates_Win32_to_HRESULT_(err)="
+    )
+endif()
+
 # The interface's include directory.
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>


### PR DESCRIPTION
Relevant to #117 and #454 (the latter of which I feel is incomplete). In that PR users had to `#define` away SAL annotations used by WIL as macros with empty definitions. 

When consumers (e.g. [Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp)) use WIL with CMake and compile with Clang targeting MinGW, they will have to continuously re-define these macros which is repetitive and unintuitive.

This PR resolves this, especially in the CMake case. 

Now, consumers may simply use `target_link_libraries(my_target PRIVATE WIL::WIL), and when CMake builds, these macros will be appended to every command-line invocation of the consumer's `my_target`, which considerably simplifies matters. 

The function-like macros are added with `target_compile_options` because `target_compile_definitions` does [not support function-like macros](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Help/prop_tgt/COMPILE_DEFINITIONS.rst?ref_type=heads&plain=1#L8).

