### PR TITLE
Suppress warning C26814; Minor renaming and tidy-up.

### DIFF
--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -69,15 +69,14 @@
 
 /// @cond
 #if defined(_MSVC_LANG)
-#define __WI_SUPPRESS_4127_S \
-    __pragma(warning(push)) __pragma(warning(disable : 4127)) __pragma(warning(disable : 26498)) __pragma(warning(disable : 4245))
-#define __WI_SUPPRESS_4127_E __pragma(warning(pop))
-#define __WI_SUPPRESS_NULLPTR_ANALYSIS __pragma(warning(suppress : 28285)) __pragma(warning(suppress : 6504))
+#define __WI_SUPPRESS_BREAKING_WARNINGS_S __pragma(warning(push)) __pragma(warning(disable : 4127 26498 4245 26814))
+#define __WI_SUPPRESS_BREAKING_WARNINGS_E __pragma(warning(pop))
+#define __WI_SUPPRESS_NULLPTR_ANALYSIS __pragma(warning(suppress : 28285 6504))
 #define __WI_SUPPRESS_NONINIT_ANALYSIS __pragma(warning(suppress : 26495))
 #define __WI_SUPPRESS_NOEXCEPT_ANALYSIS __pragma(warning(suppress : 26439))
 #else
-#define __WI_SUPPRESS_4127_S
-#define __WI_SUPPRESS_4127_E
+#define __WI_SUPPRESS_BREAKING_WARNINGS_S
+#define __WI_SUPPRESS_BREAKING_WARNINGS_E
 #define __WI_SUPPRESS_NULLPTR_ANALYSIS
 #define __WI_SUPPRESS_NONINIT_ANALYSIS
 #define __WI_SUPPRESS_NOEXCEPT_ANALYSIS

--- a/include/wil/nt_result_macros.h
+++ b/include/wil/nt_result_macros.h
@@ -19,7 +19,7 @@
 // Helpers for return macros
 /// @cond
 #define __NT_RETURN_NTSTATUS(status, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         NTSTATUS __status = (status); \
         if (FAILED_NTSTATUS(__status)) \
@@ -28,9 +28,9 @@
         } \
         return __status; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __NT_RETURN_NTSTATUS_MSG(status, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         NTSTATUS __status = (status); \
         if (FAILED_NTSTATUS(__status)) \
@@ -39,7 +39,7 @@
         } \
         return __status; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 /// @endcond
 
 //*****************************************************************************
@@ -55,7 +55,7 @@
 
 // Conditionally returns failures (NTSTATUS) - always logs failures
 #define NT_RETURN_IF_NTSTATUS_FAILED(status) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __statusRet = wil::verify_ntstatus(status); \
         if (FAILED_NTSTATUS(__statusRet)) \
@@ -63,11 +63,11 @@
             __NT_RETURN_NTSTATUS(__statusRet, #status); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 // Conditionally returns failures (NTSTATUS) - always logs a var-arg message on failure
 #define NT_RETURN_IF_NTSTATUS_FAILED_MSG(status, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __statusRet = wil::verify_ntstatus(status); \
         if (FAILED_NTSTATUS(__statusRet)) \
@@ -75,7 +75,7 @@
             __NT_RETURN_NTSTATUS_MSG(__statusRet, #status, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 //*****************************************************************************
 // Macros to catch and convert exceptions on failure

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -671,7 +671,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
 
 // Helpers for return macros
 #define __RETURN_HR_MSG(hr, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         if (FAILED(__hr)) \
@@ -680,17 +680,17 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR_MSG_FAIL(hr, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         __R_FN(Return_HrMsg)(__R_INFO(str) __hr, __WI_CHECK_MSG_FMT(fmt, ##__VA_ARGS__)); \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_WIN32_MSG(err, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __err = (err); \
         if (FAILED_WIN32(__err)) \
@@ -699,18 +699,18 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return S_OK; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_WIN32_MSG_FAIL(err, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __err = (err); \
         return __R_FN(Return_Win32Msg)(__R_INFO(str) __err, __WI_CHECK_MSG_FMT(fmt, ##__VA_ARGS__)); \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_GLE_MSG_FAIL(str, fmt, ...) \
     return __R_FN(Return_GetLastErrorMsg)(__R_INFO(str) __WI_CHECK_MSG_FMT(fmt, ##__VA_ARGS__))
 #define __RETURN_NTSTATUS_MSG(status, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __status = (status); \
         if (FAILED_NTSTATUS(__status)) \
@@ -719,16 +719,16 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return S_OK; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_NTSTATUS_MSG_FAIL(status, str, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __status = (status); \
         return __R_FN(Return_NtStatusMsg)(__R_INFO(str) __status, __WI_CHECK_MSG_FMT(fmt, ##__VA_ARGS__)); \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR(hr, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         if (FAILED(__hr)) \
@@ -737,9 +737,9 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR_NOFILE(hr, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         if (FAILED(__hr)) \
@@ -748,33 +748,33 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR_FAIL(hr, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         __R_FN(Return_Hr)(__R_INFO(str) __hr); \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR_FAIL_SUPPRESS_TELEMETRY(hr, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         __R_FN(Return_HrSuppressTelemetry)(__R_INFO(str) __hr); \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_HR_FAIL_NOFILE(hr, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const HRESULT __hr = (hr); \
         __R_FN(Return_Hr)(__R_INFO_NOFILE(str) __hr); \
         return __hr; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_WIN32(err, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __err = (err); \
         if (FAILED_WIN32(__err)) \
@@ -783,18 +783,18 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return S_OK; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_WIN32_FAIL(err, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __err = (err); \
         return __R_FN(Return_Win32)(__R_INFO(str) __err); \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_GLE_FAIL(str) return __R_FN(Return_GetLastError)(__R_INFO_ONLY(str))
 #define __RETURN_GLE_FAIL_NOFILE(str) return __R_FN(Return_GetLastError)(__R_INFO_NOFILE_ONLY(str))
 #define __RETURN_NTSTATUS(status, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __status = (status); \
         if (FAILED_NTSTATUS(__status)) \
@@ -803,14 +803,14 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
         } \
         return S_OK; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __RETURN_NTSTATUS_FAIL(status, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __status = (status); \
         return __R_FN(Return_NtStatus)(__R_INFO(str) __status); \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 /// @endcond
 
 //*****************************************************************************
@@ -825,7 +825,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
 
 // Conditionally returns failures (HRESULT) - always logs failures
 #define RETURN_IF_FAILED(hr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __hrRet = wil::verify_hresult(hr); \
         if (FAILED(__hrRet)) \
@@ -833,9 +833,9 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_HR_FAIL(__hrRet, #hr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_BOOL_FALSE(win32BOOL) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __boolRet = wil::verify_BOOL(win32BOOL); \
         if (!__boolRet) \
@@ -843,9 +843,9 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_GLE_FAIL(#win32BOOL); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_ERROR(win32err) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __errRet = (win32err); \
         if (FAILED_WIN32(__errRet)) \
@@ -853,54 +853,54 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_WIN32_FAIL(__errRet, #win32err); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NULL_ALLOC(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_HR_FAIL(E_OUTOFMEMORY, #ptr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF(hr, condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __RETURN_HR(wil::verify_hresult(hr), #condition); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF_NULL(hr, ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_HR(wil::verify_hresult(hr), #ptr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF(condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __RETURN_GLE_FAIL(#condition); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF_NULL(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_GLE_FAIL(#ptr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NTSTATUS_FAILED(status) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __statusRet = (status); \
         if (FAILED_NTSTATUS(__statusRet)) \
@@ -908,7 +908,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_NTSTATUS_FAIL(__statusRet, #status); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 // Always returns a known failure (HRESULT) - always logs a var-arg message on failure
 #define RETURN_HR_MSG(hr, fmt, ...) __RETURN_HR_MSG(wil::verify_hresult(hr), #hr, fmt, ##__VA_ARGS__)
@@ -918,7 +918,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
 
 // Conditionally returns failures (HRESULT) - always logs a var-arg message on failure
 #define RETURN_IF_FAILED_MSG(hr, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __hrRet = wil::verify_hresult(hr); \
         if (FAILED(__hrRet)) \
@@ -926,18 +926,18 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_HR_MSG_FAIL(__hrRet, #hr, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_BOOL_FALSE_MSG(win32BOOL, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (!wil::verify_BOOL(win32BOOL)) \
         { \
             __RETURN_GLE_MSG_FAIL(#win32BOOL, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_ERROR_MSG(win32err, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __errRet = (win32err); \
         if (FAILED_WIN32(__errRet)) \
@@ -945,54 +945,54 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_WIN32_MSG_FAIL(__errRet, #win32err, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NULL_ALLOC_MSG(ptr, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_HR_MSG_FAIL(E_OUTOFMEMORY, #ptr, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF_MSG(hr, condition, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __RETURN_HR_MSG(wil::verify_hresult(hr), #condition, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF_NULL_MSG(hr, ptr, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_HR_MSG(wil::verify_hresult(hr), #ptr, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF_MSG(condition, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __RETURN_GLE_MSG_FAIL(#condition, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF_NULL_MSG(ptr, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __RETURN_GLE_MSG_FAIL(#ptr, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NTSTATUS_FAILED_MSG(status, fmt, ...) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __statusRet = (status); \
         if (FAILED_NTSTATUS(__statusRet)) \
@@ -1000,11 +1000,11 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             __RETURN_NTSTATUS_MSG_FAIL(__statusRet, #status, fmt, ##__VA_ARGS__); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 // Conditionally returns failures (HRESULT) - use for failures that are expected in common use - failures are not logged - macros are only for control flow pattern
 #define RETURN_IF_FAILED_EXPECTED(hr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __hrRet = wil::verify_hresult(hr); \
         if (FAILED(__hrRet)) \
@@ -1012,18 +1012,18 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             return __hrRet; \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_BOOL_FALSE_EXPECTED(win32BOOL) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (!wil::verify_BOOL(win32BOOL)) \
         { \
             return wil::details::GetLastErrorFailHr(); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_WIN32_ERROR_EXPECTED(win32err) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const DWORD __errRet = (win32err); \
         if (FAILED_WIN32(__errRet)) \
@@ -1031,54 +1031,54 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             return __HRESULT_FROM_WIN32(__errRet); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NULL_ALLOC_EXPECTED(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             return E_OUTOFMEMORY; \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF_EXPECTED(hr, condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             return wil::verify_hresult(hr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_HR_IF_NULL_EXPECTED(hr, ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             return wil::verify_hresult(hr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF_EXPECTED(condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             return wil::details::GetLastErrorFailHr(); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_LAST_ERROR_IF_NULL_EXPECTED(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             return wil::details::GetLastErrorFailHr(); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define RETURN_IF_NTSTATUS_FAILED_EXPECTED(status) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const NTSTATUS __statusRet = (status); \
         if (FAILED_NTSTATUS(__statusRet)) \
@@ -1086,7 +1086,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
             return wil::details::NtStatusToHr(__statusRet); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 /// @cond
 #define __WI_OR_IS_EXPECTED_HRESULT(e) || (__hrRet == wil::verify_hresult(e))
@@ -4590,7 +4590,7 @@ namespace details
             ARRAYSIZE(callContextString),
             FailureFlags::None,
             &failure);
-        __WI_SUPPRESS_4127_S
+        __WI_SUPPRESS_BREAKING_WARNINGS_S
         if ((T == FailureType::FailFast) || WI_IsFlagSet(failure.flags, FailureFlags::RequestFailFast))
         {
             WilFailFast(const_cast<FailureInfo&>(failure));
@@ -4612,7 +4612,7 @@ namespace details
             // Wil was instructed to throw, but doesn't have any capability to do so (global function pointers are not setup)
             WilFailFast(const_cast<FailureInfo&>(failure));
         }
-        __WI_SUPPRESS_4127_E
+        __WI_SUPPRESS_BREAKING_WARNINGS_E
     }
 
     template <>

--- a/include/wil/win32_result_macros.h
+++ b/include/wil/win32_result_macros.h
@@ -19,7 +19,7 @@
 // Helpers for return macros
 /// @cond
 #define __WIN32_RETURN_WIN32(error, str) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __error = (error); \
         if (FAILED_WIN32(__error)) \
@@ -28,7 +28,7 @@
         } \
         return __error; \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define __WIN32_RETURN_GLE_FAIL(str) return __R_FN(Win32_Return_GetLastError)(__R_INFO_ONLY(str))
 
 FORCEINLINE long __WIN32_FROM_HRESULT(HRESULT hr)
@@ -51,7 +51,7 @@ FORCEINLINE long __WIN32_FROM_HRESULT(HRESULT hr)
 
 // Conditionally returns failures (WIN32 error code) - always logs failures
 #define WIN32_RETURN_IF_WIN32_ERROR(error) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __errorRet = wil::verify_win32(error); \
         if (FAILED_WIN32(__errorRet)) \
@@ -59,47 +59,47 @@ FORCEINLINE long __WIN32_FROM_HRESULT(HRESULT hr)
             __WIN32_RETURN_WIN32(__errorRet, #error); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_WIN32_IF(error, condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __WIN32_RETURN_WIN32(wil::verify_win32(error), #condition); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_WIN32_IF_NULL(error, ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __WIN32_RETURN_WIN32(wil::verify_win32(error), #ptr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_LAST_ERROR_IF(condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             __WIN32_RETURN_GLE_FAIL(#condition); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_LAST_ERROR_IF_NULL(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             __WIN32_RETURN_GLE_FAIL(#ptr); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 // Conditionally returns failures (WIN32 error code) - use for failures that are expected in common use - failures are not logged - macros are only for control flow pattern
 #define WIN32_RETURN_IF_WIN32_ERROR_EXPECTED(error) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         const auto __errorRet = wil::verify_win32(error); \
         if (FAILED_WIN32(__errorRet)) \
@@ -107,43 +107,43 @@ FORCEINLINE long __WIN32_FROM_HRESULT(HRESULT hr)
             return __errorRet; \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_WIN32_IF_EXPECTED(error, condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             return wil::verify_win32(error); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_WIN32_IF_NULL_EXPECTED(error, ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             return wil::verify_win32(error); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_LAST_ERROR_IF_EXPECTED(condition) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if (wil::verify_bool(condition)) \
         { \
             return wil::verify_win32(wil::details::GetLastErrorFail()); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 #define WIN32_RETURN_LAST_ERROR_IF_NULL_EXPECTED(ptr) \
-    __WI_SUPPRESS_4127_S do \
+    __WI_SUPPRESS_BREAKING_WARNINGS_S do \
     { \
         if ((ptr) == nullptr) \
         { \
             return wil::verify_win32(wil::details::GetLastErrorFail()); \
         } \
     } \
-    __WI_SUPPRESS_4127_E while ((void)0, 0)
+    __WI_SUPPRESS_BREAKING_WARNINGS_E while ((void)0, 0)
 
 //*****************************************************************************
 // Macros to catch and convert exceptions on failure


### PR DESCRIPTION
The line
 
            `RETURN_WIN32(ERROR_TIMEOUT);`
 
Generates
 
            `warning C26814: The const variable '__err' can be computed at
                                         compile-time. Consider using constexpr (con.5).`
 
This change adds the required suppression and renames __WI_SUPPRESS_4127_E to __WI_SUPPRESS_BREAKING_WARNINGS_S to better reflect its purpose. The existing suppressions and the new one have been consolidated in a single pragma for compactness.

The change was tested with VS2022.