### PR TITLE
[Proposal][WinUI] Easily create dependency properties

### DIFF
--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -330,5 +330,31 @@ private:
  */
 #define INIT_NOTIFYING_PROPERTY(NAME, VALUE) NAME(&m_propertyChanged, *this, L"" #NAME, VALUE)
 
+namespace details
+{
+#ifdef WINRT_Microsoft_UI_Xaml_Data_H
+    using Xaml_DepencyProperty = winrt::Microsoft::UI::Xaml::DependencyProperty;
+#elif defined(WINRT_Windows_UI_Xaml_Data_H)
+    using Xaml_DepencyProperty = winrt::Windows::UI::Xaml::DependencyProperty;
+#endif
+}
+
+#define WIL_DEFINE_DP(type, name) \
+    static wil::details::Xaml_DepencyProperty s_##name##Property; \
+    static wil::details::Xaml_DepencyProperty name##Property() \
+    { \
+        /* You need to initialize (register) this dependency property */ \
+        FAIL_FAST_HR_IF_MSG(E_NOTIMPL, s_##name##Property == nullptr, "##name##"); \
+        return s_##name##Property; \
+    } \
+    auto name() const \
+    { \
+        return winrt::unbox_value<type>(GetValue(s_##name##Property)); \
+    } \
+    void name(type value) const \
+    { \
+        SetValue(s_##name##Property, winrt::box_value(value)); \
+    } \
+
 #endif // !defined(__WIL_CPPWINRT_AUTHORING_INCLUDED_XAML_DATA) && (defined(WINRT_Microsoft_UI_Xaml_Data_H) || defined(WINRT_Windows_UI_Xaml_Data_H))
 } // namespace wil

--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -356,10 +356,10 @@ namespace details
             nullptr);
     }
 
-    template <typename PropertyType, typename OwnerType, typename T = PropertyType>
+    template <typename PropertyType, typename OwnerType, typename DefaultValueType = PropertyType>
     inline Xaml_DependencyProperty register_dependency_property(
         const std::wstring_view& propertyNameString,
-        const T& defaultValue = nullptr,
+        const DefaultValueType& defaultValue,
         const Xaml_PropertyChangedCallback& propertyChangedCallback = nullptr)
     {
         // TODO: assert T and PropertyType are compatible

--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -422,5 +422,25 @@ namespace details
         name##Property(); \
     }
 
+#define WIL_DEFINE_DP_WITH_DEFAULT_VALUE_AND_CALLBACK(baseClass, type, name, defaultValue, propertyChangedCallback) \
+    static wil::details::Xaml_DependencyProperty name##Property() \
+    { \
+        static wil::details::Xaml_DependencyProperty s_##name##Property = \
+            wil::details::register_dependency_property<type, baseClass>(L"" #name, defaultValue, propertyChangedCallback); \
+        return s_##name##Property; \
+    } \
+    auto name() const \
+    { \
+        return winrt::unbox_value<type>(GetValue(name##Property())); \
+    } \
+    void name(type value) const \
+    { \
+        SetValue(name##Property(), winrt::box_value(value)); \
+    } \
+    static void Ensure##name##Property() \
+    { \
+        name##Property(); \
+    }
+
 #endif // !defined(__WIL_CPPWINRT_AUTHORING_INCLUDED_XAML_DATA) && (defined(WINRT_Microsoft_UI_Xaml_Data_H) || defined(WINRT_Windows_UI_Xaml_Data_H))
 } // namespace wil

--- a/include/wil/cppwinrt_authoring.h
+++ b/include/wil/cppwinrt_authoring.h
@@ -333,28 +333,94 @@ private:
 namespace details
 {
 #ifdef WINRT_Microsoft_UI_Xaml_Data_H
-    using Xaml_DepencyProperty = winrt::Microsoft::UI::Xaml::DependencyProperty;
+    using Xaml_DependencyProperty = winrt::Microsoft::UI::Xaml::DependencyProperty;
+    using Xaml_PropertyChangedCallback = winrt::Microsoft::UI::Xaml::PropertyChangedCallback;
+    using Xaml_PropertyMetadata = winrt::Microsoft::UI::Xaml::PropertyMetadata;
 #elif defined(WINRT_Windows_UI_Xaml_Data_H)
-    using Xaml_DepencyProperty = winrt::Windows::UI::Xaml::DependencyProperty;
+    using Xaml_DependencyProperty = winrt::Windows::UI::Xaml::DependencyProperty;
+    using Xaml_PropertyChangedCallback = winrt::Windows::UI::Xaml::PropertyChangedCallback;
+    using Xaml_PropertyMetadata = winrt::Windows::UI::Xaml::PropertyMetadata;
 #endif
+
+    using Xaml_DependencyObject_GetValue = std::function<winrt::Windows::Foundation::IInspectable(Xaml_DependencyProperty const&)>;
+    using Xaml_DependencyObject_SetValue = std::function<void(Xaml_DependencyProperty const&, winrt::Windows::Foundation::IInspectable const&)>;
+
+    template <typename PropertyType, typename OwnerType>
+    inline Xaml_DependencyProperty register_dependency_property(
+        const std::wstring_view& propertyNameString)
+    {
+        return Xaml_DependencyProperty::Register(
+            propertyNameString,
+            winrt::template xaml_typename<PropertyType>(),
+            winrt::template xaml_typename<OwnerType>(),
+            nullptr);
+    }
+
+    template <typename PropertyType, typename OwnerType, typename T = PropertyType>
+    inline Xaml_DependencyProperty register_dependency_property(
+        const std::wstring_view& propertyNameString,
+        const T& defaultValue = nullptr,
+        const Xaml_PropertyChangedCallback& propertyChangedCallback = nullptr)
+    {
+        // TODO: assert T and PropertyType are compatible
+        return Xaml_DependencyProperty::Register(
+            propertyNameString,
+            winrt::template xaml_typename<PropertyType>(),
+            winrt::template xaml_typename<OwnerType>(),
+            Xaml_PropertyMetadata{winrt::box_value(defaultValue), propertyChangedCallback});
+    }
 }
 
-#define WIL_DEFINE_DP(type, name) \
-    static wil::details::Xaml_DepencyProperty s_##name##Property; \
-    static wil::details::Xaml_DepencyProperty name##Property() \
+//template <typename T>
+//struct single_threaded_dependency_property
+//{
+//    using Type = T;
+//
+//    single_threaded_dependency_property(
+//        wil::details::Xaml_DependencyProperty const& dp,
+//        wil::details::Xaml_DependencyObject_GetValue const& getValue,
+//        wil::details::Xaml_DependencyObject_SetValue const& setValue) :
+//        m_dp(dp), m_getValue(getValue), m_setValue(setValue)
+//    {
+//    }
+//
+//    template <typename Q>
+//    auto& operator()(Q&& q)
+//    {
+//        return winrt::unbox_value<Type>(m_getValue(m_dp));
+//    }
+//
+//    template <typename Q>
+//    auto& operator=(Q&& q)
+//    {
+//        m_setValue(m_dp, winrt::box_value(value));
+//    }
+//
+//private:
+//    wil::details::Xaml_DependencyProperty const& m_dp{ nullptr };
+//    wil::details::Xaml_DependencyObject_GetValue m_getValue{nullptr};
+//    wil::details::Xaml_DependencyObject_SetValue m_setValue{nullptr};
+//};
+
+#define WIL_DEFINE_DP(baseClass, type, name) \
+    static wil::details::Xaml_DependencyProperty name##Property() \
     { \
-        /* You need to initialize (register) this dependency property */ \
-        FAIL_FAST_HR_IF_MSG(E_NOTIMPL, s_##name##Property == nullptr, "##name##"); \
+        static wil::details::Xaml_DependencyProperty s_##name##Property = \
+            wil::details::register_dependency_property<type, baseClass>(L"" #name); \
         return s_##name##Property; \
     } \
     auto name() const \
     { \
-        return winrt::unbox_value<type>(GetValue(s_##name##Property)); \
+        return winrt::unbox_value<type>(GetValue(name##Property())); \
     } \
     void name(type value) const \
     { \
-        SetValue(s_##name##Property, winrt::box_value(value)); \
+        SetValue(name##Property(), winrt::box_value(value)); \
     } \
+    static void Ensure##name##Property() \
+    { \
+        name##Property(); \
+    }
 
 #endif // !defined(__WIL_CPPWINRT_AUTHORING_INCLUDED_XAML_DATA) && (defined(WINRT_Microsoft_UI_Xaml_Data_H) || defined(WINRT_Windows_UI_Xaml_Data_H))
 } // namespace wil

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -7,6 +7,7 @@
 #if _MSVC_LANG >= 201703L
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Data.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
 #endif
@@ -172,6 +173,41 @@ TEST_CASE("CppWinRTAuthoringTests::InStruct", "[property]")
     test.Prop2(22)(33);
     REQUIRE(test.Prop2() == 33);
 }
+
+struct my_dependency_properties
+{
+    winrt::Windows::Foundation::IInspectable GetValue(winrt::Windows::UI::Xaml::DependencyProperty const&) const
+    {
+        // Stub
+        return nullptr;
+    }
+    void SetValue(winrt::Windows::UI::Xaml::DependencyProperty const&, winrt::Windows::Foundation::IInspectable const&) const
+    {
+        // Stub
+    }
+
+    WIL_DEFINE_DP(int, MyProperty);
+};
+
+// TODO: export
+#define REQUIRE_FAILFAST_MSG(hr, lambda) \
+    REQUIRE(VerifyResult(__LINE__, EType::FailFastMacro | EType::Msg, hr, [&] { \
+        auto fn = (lambda); \
+        fn(); \
+        return hr; \
+    }))
+
+TEST_CASE("CppWinRTAuthoringTests::DependencyProperties", "[property]")
+{
+    // Throws if not registered
+    auto obj = my_dependency_properties{};
+    //REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyProperty(); });
+    //REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyProperty(42); });
+
+    // Register the dependency property
+
+}
+
 
 #ifdef WINRT_Windows_Foundation_H
 TEST_CASE("CppWinRTAuthoringTests::Events", "[property]")

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -197,6 +197,7 @@ struct my_dependency_properties : mock_dependency_object
 {
     WIL_DEFINE_DP(my_dependency_properties, int32_t, MyProperty);
     WIL_DEFINE_DP_WITH_DEFAULT_VALUE_AND_CALLBACK(my_dependency_properties, int32_t, MyPropertyWithDefault, 42, nullptr);
+    WIL_DEFINE_DP(my_dependency_properties, winrt::hstring, MyStringProperty);
 };
 
 namespace winrt
@@ -217,11 +218,14 @@ TEST_CASE("CppWinRTAuthoringTests::DependencyProperties", "[property]")
     // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyProperty(); });
     // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyProperty(42); });
     // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyPropertyWithDefault(); });
-    //  REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyPropertyWithDefault(42); });
+    // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyPropertyWithDefault(42); });
+    // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyStringProperty(); });
+    // REQUIRE_FAILFAST_MSG(E_NOTIMPL, [&obj] { obj.MyStringProperty(L"foo"); });
 
     // Register the dependency property
     my_dependency_properties::EnsureMyPropertyProperty();
     my_dependency_properties::EnsureMyPropertyWithDefaultProperty();
+    my_dependency_properties::EnsureMyStringPropertyProperty();
 
     // Now it should work
     obj.MyProperty(42);
@@ -231,6 +235,9 @@ TEST_CASE("CppWinRTAuthoringTests::DependencyProperties", "[property]")
     // REQUIRE(obj.MyPropertyWithDefault() == 42);
     obj.MyPropertyWithDefault(43);
     REQUIRE(obj.MyPropertyWithDefault() == 43);
+
+    obj.MyStringProperty(L"foo");
+    REQUIRE(obj.MyStringProperty() == L"foo");
 }
 
 #ifdef WINRT_Windows_Foundation_H


### PR DESCRIPTION
Today, creating a custom dependency property requires a lot of boilerplate. This change gets rid of most of it. With this change, you can add a new dependency property quickly:

```idl
// idl
runtimeclass BgLabelControl : Windows.UI.Xaml.Controls.Control
{
    // ...
    static Windows.UI.Xaml.DependencyProperty LabelProperty{ get; };
    String Label;
}
```

```cpp
// .h
namespace winrt::BgLabelControlApp::implementation
{
    struct BgLabelControl : BgLabelControlT<BgLabelControl>
    {
        // ...

        // At some point in your app initialization, you want to call `BgLabelControl::EnsureLabelProperty`
        WIL_DEFINE_DP(BgLabelControl, Label, winrt::hstring);
    };
}
```

Versus before you'd have to (see [example on MSDN](https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/xaml-cust-ctrl)):

1. (Unchanged) IDL: Declare the IDL
2. .h: Declare a static DP class variable
3. .h: Declare a static DP getter function
4. .cpp: Define memory for the static DP
5. (If you want to be correct) .cpp: In your app, initialize the static DP during startup
6. .h: Declare & define member getter & setter functions

## What changed?

* Introduce new macros `WIL_DEFINE_DP` and `WIL_DEFINE_DP_WITH_DEFAULT_VALUE_AND_CALLBACK` that automatically create idiomatic implementations of the 3 static & member methods needed for a dependency property.
* To avoid any problems with statics, these macros use function-local static storage instead of global static storage.

## How tested?

* [ ] New tests pass
* [ ] TODO: consumed in actual XAML project