### PR TITLE
<wil/safecast.h> should have a helper that can cast larger with zero-extension of signed types

### DIFF
--- a/include/wil/safecast.h
+++ b/include/wil/safecast.h
@@ -15,7 +15,6 @@
 
 #include "result_macros.h"
 #include <intsafe.h>
-#include <stdint.h>
 #include "wistd_config.h"
 #include "wistd_type_traits.h"
 

--- a/include/wil/safecast.h
+++ b/include/wil/safecast.h
@@ -382,7 +382,6 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
     return S_OK;
 }
 
-#if __cpp_if_constexpr
 // This conversion takes a signed integer value and grows it with the upper bits set to zero.  This is
 // useful when the resulting value is cast to a pointer type as it prevents the upper bits from being fill
 // which would adjust the pointed-to address.
@@ -391,14 +390,13 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 //      wil::safe_zero_extending_cast<ULONG_PTR>(-1)
 // will return 0x00000000`FFFFFFFF on a 64-bit system.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_sign_extending_cast_v<NewT, OldT>, int> = 0>
-NewT safe_zero_extending_cast(OldT var)
+NewT safe_zero_extending_cast(const OldT var)
 {
     // The first cast is to an unsigned type of the same size as the original.  The second cast is to the
     // larger type.  Being an unsigned cast, the upper bits are zeroed out.
     using unsigned_old_t = wistd::make_unsigned_t<OldT>;
     return static_cast<NewT>(static_cast<unsigned_old_t>(var));
 }
-#endif // __cpp_if_constexpr
 } // namespace wil
 
 #endif // __WIL_SAFECAST_INCLUDED

--- a/tests/SafeCastTests.cpp
+++ b/tests/SafeCastTests.cpp
@@ -570,3 +570,34 @@ TEST_CASE("SafeCastTests::SafeCastExpectFailFast", "[safecast]")
     }
 }
 #endif
+
+#if __cpp_if_constexpr
+TEST_CASE("SafeCastTests::ZeroExtendingCast", "[safecast]")
+{
+    constexpr uint32_t c_expected8To32Extension = 0x000000FF;
+    constexpr uint32_t c_expected16To32Extension = 0x0000FFFF;
+    constexpr uint32_t c_expected32To32Extension = 0xFFFFFFFF;
+    constexpr uint64_t c_expected8To64Extension = 0x00000000000000FF;
+    constexpr uint64_t c_expected16To64Extension = 0x000000000000FFFF;
+    constexpr uint64_t c_expected32To64Extension = 0x00000000FFFFFFFF;
+
+    SECTION("int8_t")
+    {
+        int8_t orig = -1;
+        REQUIRE(wil::safe_zero_extending_cast<uint32_t>(orig) == c_expected8To32Extension);
+        REQUIRE(wil::safe_zero_extending_cast<uint64_t>(orig) == c_expected8To64Extension);
+    }
+    SECTION("int16_t")
+    {
+        int16_t orig = -1;
+        REQUIRE(wil::safe_zero_extending_cast<uint32_t>(orig) == c_expected16To32Extension);
+        REQUIRE(wil::safe_zero_extending_cast<uint64_t>(orig) == c_expected16To64Extension);
+    }
+    SECTION("int32_t")
+    {
+        int32_t orig = -1;
+        REQUIRE(wil::safe_zero_extending_cast<uint32_t>(orig) == c_expected32To32Extension);
+        REQUIRE(wil::safe_zero_extending_cast<uint64_t>(orig) == c_expected32To64Extension);
+    }
+}
+#endif // __cpp_if_constexpr

--- a/tests/SafeCastTests.cpp
+++ b/tests/SafeCastTests.cpp
@@ -571,7 +571,6 @@ TEST_CASE("SafeCastTests::SafeCastExpectFailFast", "[safecast]")
 }
 #endif
 
-#if __cpp_if_constexpr
 TEST_CASE("SafeCastTests::ZeroExtendingCast", "[safecast]")
 {
     constexpr uint32_t c_expected8To32Extension = 0x000000FF;
@@ -600,4 +599,3 @@ TEST_CASE("SafeCastTests::ZeroExtendingCast", "[safecast]")
         REQUIRE(wil::safe_zero_extending_cast<uint64_t>(orig) == c_expected32To64Extension);
     }
 }
-#endif // __cpp_if_constexpr


### PR DESCRIPTION
Closes #473

## Why is this change being made?
I am trying to work through some suppressed compiler warnings in one of our code bases.  Many of the suppressed warnings are [C4312](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312?view=msvc-170).  This warning is saying that if a signed integer is cast upwards into a pointer type it may become unsafe if the original value was negative.    The cast will fill in the upper bits with ones, which would change the pointer to some address in the kernel address space.

This new helper aims to help with that by casting upwards with 0s as the upper bits.  That will avoid changing the value to something unsafe if it really is treated as a pointer.

## Briefly summarize what changed
Add a new method (`wil::safe_zero_extending_cast`) that takes an integer type and returns an unsigned integer value that has the upper bits set to zero in all cases.  A naive `static_cast` would have zero in the upper bits for positive values, and ones in the upper bits for negative values.  Using this safe cast the extension will always be zeros.

## How was this change tested?
Added some new test cases.  They all pass.  I ran init-all/build-all/test-all locally.  I also ran clang-format.