### PR TITLE
Update to use feature test macros & other similar changes

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2019,7 +2019,6 @@ PREDEFINED             = WIL_DOXYGEN \
                          _MSVC_LANG=202302L \
                          __WI_CPLUSPLUS=202302L \
                          __WI_LIBCPP_STD_VER=23 \
-                         WIL_HAS_CXX_17=1 \
                          _HAS_CXX17 \
                          _HAS_CXX20 \
                          __declspec(x)= \

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -19,10 +19,10 @@
 #include "win32_helpers.h"
 #include "resource.h" // last to ensure _COMBASEAPI_H_ protected definitions are available
 
-#if __has_include(<tuple>)
+#if WI_HAS_INCLUDE(<tuple>, 1) // Tuple is C++11... assume available
 #include <tuple>
 #endif
-#if __has_include(<type_traits>)
+#if WI_HAS_INCLUDE(<type_traits>, 1) // Type traits is old... assume available
 #include <type_traits>
 #endif
 
@@ -2113,7 +2113,7 @@ wil::com_ptr_nothrow<Interface> CoGetClassObjectNoThrow(DWORD dwClsContext = CLS
     return CoGetClassObjectNoThrow<Interface>(__uuidof(Class), dwClsContext);
 }
 
-#if __cpp_lib_apply && __has_include(<type_traits>)
+#if __cpp_lib_apply && WI_HAS_INCLUDE(<type_traits>, 1)
 /// @cond
 namespace details
 {
@@ -2247,7 +2247,7 @@ auto try_com_multi_query(IUnknown* obj)
 }
 #endif
 
-#endif // __cpp_lib_apply && __has_include(<type_traits>)
+#endif // __cpp_lib_apply && WI_HAS_INCLUDE(<type_traits>, 1)
 
 #pragma endregion
 
@@ -3136,8 +3136,7 @@ void for_each_site(_In_opt_ IUnknown* siteInput, TLambda&& callback)
 
 #endif // __IObjectWithSite_INTERFACE_DEFINED__
 
-// if C++17 or greater
-#if WIL_HAS_CXX_17
+#if __cpp_deduction_guides >= 201703L
 #ifdef WIL_ENABLE_EXCEPTIONS
 /// @cond
 namespace details
@@ -3323,7 +3322,7 @@ WI_NODISCARD auto make_range(IEnumXxx* enumPtr)
     return iterator_range(enumPtr);
 }
 
-#endif // WIL_HAS_CXX_17
+#endif // __cpp_deduction_guides >= 201703L
 #endif // WIL_ENABLE_EXCEPTIONS
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -372,19 +372,19 @@ check fails as opposed to the invalid parameter handler that the STL invokes. Th
 #endif
 
 /// @cond
-#if (__cplusplus >= 201703) || (_MSVC_LANG >= 201703)
-#define WIL_HAS_CXX_17 1
-#else
-#define WIL_HAS_CXX_17 0
-#endif
-
 // Until we'll have C++17 enabled in our code base, we're falling back to SAL
 #define WI_NODISCARD __WI_LIBCPP_NODISCARD_ATTRIBUTE
-/// @endcond
 
-/// @cond
 #define __R_ENABLE_IF_IS_CLASS(ptrType) wistd::enable_if_t<wistd::is_class<ptrType>::value, void*> = nullptr
 #define __R_ENABLE_IF_IS_NOT_CLASS(ptrType) wistd::enable_if_t<!wistd::is_class<ptrType>::value, void*> = nullptr
+
+// Uses the __has_include macro, if available. Otherwise uses a user-provided fallback. E.g. the fallback could always
+// default to true or false, or it could do something like a C++ standard version check
+#ifdef __has_include
+#define WI_HAS_INCLUDE(header, fallback)    __has_include(header)
+#else
+#define WI_HAS_INCLUDE(header, fallback)    (fallback)
+#endif
 /// @endcond
 
 //! @defgroup bitwise Bitwise Inspection and Manipulation

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -381,9 +381,9 @@ check fails as opposed to the invalid parameter handler that the STL invokes. Th
 // Uses the __has_include macro, if available. Otherwise uses a user-provided fallback. E.g. the fallback could always
 // default to true or false, or it could do something like a C++ standard version check
 #ifdef __has_include
-#define WI_HAS_INCLUDE(header, fallback)    __has_include(header)
+#define WI_HAS_INCLUDE(header, fallback) __has_include(header)
 #else
-#define WI_HAS_INCLUDE(header, fallback)    (fallback)
+#define WI_HAS_INCLUDE(header, fallback) (fallback)
 #endif
 /// @endcond
 

--- a/include/wil/result_macros.h
+++ b/include/wil/result_macros.h
@@ -123,7 +123,7 @@ WI_ODR_PRAGMA("WIL_FreeMemory", "0")
 // It would appear as though the C++17 "noexcept is part of the type system" update in MSVC has "infected" the behavior
 // when compiling with C++14 (the default...), however the updated behavior for decltype understanding noexcept is _not_
 // present... So, work around it
-#if __WI_LIBCPP_STD_VER >= 17
+#if __cpp_noexcept_function_type >= 201510L
 #define WI_PFN_NOEXCEPT WI_NOEXCEPT
 #else
 #define WI_PFN_NOEXCEPT

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 #include <utility>
-#if _HAS_CXX17
+#if (__WI_LIBCPP_STD_VER >= 17) && WI_HAS_INCLUDE(<string_view>, 1) // Assume present if C++17
 #include <string_view>
 #endif
 
@@ -132,7 +132,7 @@ inline PCWSTR str_raw_ptr(const std::wstring& str)
     return str.c_str();
 }
 
-#if _HAS_CXX17
+#if __cpp_lib_string_view >= 201606L
 /**
     zstring_view. A zstring_view is identical to a std::string_view except it is always nul-terminated (unless empty).
     * zstring_view can be used for storing string literals without "forgetting" the length or that it is nul-terminated.
@@ -224,7 +224,7 @@ inline namespace literals
     }
 } // namespace literals
 
-#endif // _HAS_CXX17
+#endif // __cpp_lib_string_view >= 201606L
 
 } // namespace wil
 

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -20,11 +20,11 @@
 #include <winreg.h>
 #include <objbase.h>
 
+#include "common.h"
+
 // detect std::bit_cast
-#ifdef __has_include
-#if (__cplusplus >= 202002L || _MSVC_LANG >= 202002L) && __has_include(<bit>)
+#if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<bit>, 1) // Assume present if C++20
 #include <bit>
-#endif
 #endif
 
 /// @cond
@@ -41,10 +41,10 @@
 #include "wistd_type_traits.h"
 
 /// @cond
-#if _HAS_CXX20 && defined(_STRING_VIEW_) && defined(_COMPARE_)
+#if (__WI_LIBCPP_STD_VER >= 20) && defined(_STRING_VIEW_) && defined(_COMPARE_)
 // If we're using c++20, then <compare> must be included to use the string ordinal functions
 #define __WI_DEFINE_STRING_ORDINAL_FUNCTIONS
-#elif !_HAS_CXX20 && defined(_STRING_VIEW_)
+#elif (__WI_LIBCPP_STD_VER < 20) && defined(_STRING_VIEW_)
 #define __WI_DEFINE_STRING_ORDINAL_FUNCTIONS
 #endif
 /// @endcond
@@ -54,11 +54,11 @@ namespace wistd
 {
 #if defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS)
 
-#if _HAS_CXX20
+#if __WI_LIBCPP_STD_VER >= 20
 
 using weak_ordering = std::weak_ordering;
 
-#else // _HAS_CXX20
+#else // __WI_LIBCPP_STD_VER >= 20
 
 struct weak_ordering
 {
@@ -133,7 +133,7 @@ inline constexpr weak_ordering weak_ordering::less{static_cast<signed char>(-1)}
 inline constexpr weak_ordering weak_ordering::equivalent{static_cast<signed char>(0)};
 inline constexpr weak_ordering weak_ordering::greater{static_cast<signed char>(1)};
 
-#endif // !_HAS_CXX20
+#endif // __WI_LIBCPP_STD_VER < 20
 
 #endif // defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS)
 } // namespace wistd

--- a/include/wil/windowing.h
+++ b/include/wil/windowing.h
@@ -14,6 +14,8 @@
 #include <WinUser.h>
 #include <exception>
 
+#include "common.h"
+
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 namespace wil
 {
@@ -28,7 +30,7 @@ namespace details
     BOOL __stdcall EnumWindowsCallbackNoThrow(HWND hwnd, LPARAM lParam)
     {
         auto pCallback = reinterpret_cast<TCallback*>(lParam);
-#ifdef __cpp_if_constexpr
+#if __cpp_if_constexpr >= 201606L
         using result_t = decltype((*pCallback)(hwnd));
         if constexpr (wistd::is_void_v<result_t>)
         {
@@ -74,7 +76,7 @@ namespace details
         try
         {
             auto pCallback = pCallbackData->pCallback;
-#ifdef __cpp_if_constexpr
+#if __cpp_if_constexpr >= 201606L
             using result_t = decltype((*pCallback)(hwnd));
             if constexpr (std::is_void_v<result_t>)
             {

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -30,14 +30,11 @@
 
 /// @cond
 #if defined(WIL_ENABLE_EXCEPTIONS) && !defined(__WI_HAS_STD_LESS)
-#ifdef __has_include
-#if __has_include(<functional>)
 #define __WI_HAS_STD_LESS 1
+#if WI_HAS_INCLUDE(<functional>, 1) // Functional header available since C++11... fall back to assume present
 #include <functional>
-#endif // Otherwise, not using STL; don't specialize std::less
 #else
 // Fall back to the old way of forward declaring std::less
-#define __WI_HAS_STD_LESS 1
 #pragma warning(push)
 #pragma warning(disable : 4643) // Forward declaring '...' in namespace std is not permitted by the C++ Standard.
 namespace std
@@ -48,11 +45,10 @@ struct less;
 #pragma warning(pop)
 #endif
 #endif
-#if defined(WIL_ENABLE_EXCEPTIONS) && defined(__has_include)
-#if __has_include(<vector>)
+
+#if defined(WIL_ENABLE_EXCEPTIONS) && WI_HAS_INCLUDE(<vector>, 1) // Vector has been around forever... fall back to assume present
 #define __WI_HAS_STD_VECTOR 1
 #include <vector>
-#endif
 #endif
 /// @endcond
 

--- a/include/wil/wistd_config.h
+++ b/include/wil/wistd_config.h
@@ -76,8 +76,12 @@
 #define __WI_LIBCPP_STD_VER 14
 #elif __WI_CPLUSPLUS <= 201703L
 #define __WI_LIBCPP_STD_VER 17
+#elif __WI_CPLUSPLUS <= 202002L
+#define __WI_LIBCPP_STD_VER 20
+#elif __WI_CPLUSPLUS <= 202302L
+#define __WI_LIBCPP_STD_VER 23
 #else
-#define __WI_LIBCPP_STD_VER 18 // current year, or date of c++2a ratification
+#define __WI_LIBCPP_STD_VER 24 // Newer standard or prerelease standard
 #endif
 #endif // __WI_LIBCPP_STD_VER
 

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -2272,7 +2272,7 @@ TEST_CASE("ComTests::VerifyCoGetClassObject", "[com][CoGetClassObject]")
 }
 #endif
 
-#if defined(__IBackgroundCopyManager_INTERFACE_DEFINED__) && (__WI_LIBCPP_STD_VER >= 17)
+#if defined(__IBackgroundCopyManager_INTERFACE_DEFINED__)
 TEST_CASE("ComTests::VerifyCoCreateEx", "[com][CoCreateInstance]")
 {
     auto init = wil::CoInitializeEx_failfast();
@@ -2839,7 +2839,7 @@ TEST_CASE("StreamTests::Saver", "[com][IStream]")
         REQUIRE(250ULL == second.Position);
     }
 }
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && WIL_HAS_CXX_17
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
 template <typename T>
 struct EnumT : IUnknown
@@ -3058,7 +3058,7 @@ TEST_CASE("COMEnumerator", "[com][enumerator]")
     }
 }
 #pragma warning(pop)
-#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && WIL_HAS_CXX_17
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 #if (NTDDI_VERSION >= NTDDI_WINBLUE)

--- a/tests/CppWinRTAuthoringTests.cpp
+++ b/tests/CppWinRTAuthoringTests.cpp
@@ -3,13 +3,11 @@
 #define WINAPI_PARTITION_DESKTOP 1 // for RO_INIT_SINGLETHREADED
 #include "common.h"
 #undef GetCurrentTime
-// check if at least C++17
-#if _MSVC_LANG >= 201703L
+
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Data.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
-#endif
 
 #include <wil/cppwinrt_authoring.h>
 #include <wil/winrt.h>
@@ -173,7 +171,6 @@ TEST_CASE("CppWinRTAuthoringTests::InStruct", "[property]")
     REQUIRE(test.Prop2() == 33);
 }
 
-#ifdef WINRT_Windows_Foundation_H
 TEST_CASE("CppWinRTAuthoringTests::Events", "[property]")
 {
     struct Test
@@ -222,9 +219,7 @@ TEST_CASE("CppWinRTAuthoringTests::EventsAndCppWinRt", "[property]")
     REQUIRE(invoked == true);
     test.Closed(token);
 }
-#endif // WINRT_Windows_Foundation_H
 
-#if defined(WINRT_Windows_UI_Xaml_Data_H)
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 
@@ -321,4 +316,3 @@ TEST_CASE("CppWinRTAuthoringTests::NotifyPropertyChanged", "[property]")
     }
 #endif
 }
-#endif // msvc

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -3,9 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#if _HAS_CXX17
 #include <optional>
-#endif
 #include <array>
 
 #include <windows.h>

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -13,9 +13,7 @@ struct dummy
     char value;
 };
 
-#if _HAS_CXX17
 using namespace wil::literals;
-#endif // _HAS_CXX17
 
 // Specialize std::allocator<> so that we don't actually allocate/deallocate memory
 dummy g_memoryBuffer[256];
@@ -50,8 +48,6 @@ TEST_CASE("StlTests::TestSecureAllocator", "[stl][secure_allocator]")
         wil::secure_vector<dummy> sensitiveBytes(32, dummy{'a'});
     }
 }
-
-#if __WI_LIBCPP_STD_VER >= 17
 
 struct CustomNoncopyableString
 {
@@ -216,4 +212,3 @@ TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
     wil::zwstring_view fromCustomString(customString);
     REQUIRE(fromCustomString == (PCWSTR)customString);
 }
-#endif

--- a/tests/WinRTTests.cpp
+++ b/tests/WinRTTests.cpp
@@ -8,13 +8,7 @@
 #include <vector>
 #endif
 
-// detect std::wstring_view
-#ifdef __has_include
-#if (__cplusplus >= 201606L || _MSVC_LANG >= 201606L) && __has_include(<string_view>)
-#define __WI_HAS_STD_WSTRING_VIEW
 #include <string_view>
-#endif
-#endif
 
 // Required for pinterface template specializations that we depend on in this test
 #include <Windows.ApplicationModel.Chat.h>
@@ -179,7 +173,7 @@ void DoHStringSameValueComparisonTest(const wchar_t (&lhs)[Size], const wchar_t 
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstr, rhsHstr, 0);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstr, rhsUniqueStr, 0);
 #endif
-#ifdef __WI_HAS_STD_WSTRING_VIEW
+
     std::wstring_view lhsWstrview(lhs, Size - 1);
     std::wstring_view rhsWstrview(rhs, Size - 1);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsWstrview, 0);
@@ -190,7 +184,6 @@ void DoHStringSameValueComparisonTest(const wchar_t (&lhs)[Size], const wchar_t 
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsStr, 0);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsHstr, 0);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsUniqueStr, 0);
-#endif
 }
 
 // It's expected that the first argument (lhs) compares greater than the second argument (rhs)
@@ -273,7 +266,7 @@ void DoHStringDifferentValueComparisonTest(const wchar_t (&lhs)[LhsSize], const 
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstr, rhsHstr, 1);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstr, rhsUniqueStr, 1);
 #endif
-#ifdef __WI_HAS_STD_WSTRING_VIEW
+
     std::wstring_view lhsWstrview(lhs, LhsSize - 1);
     std::wstring_view rhsWstrview(rhs, RhsSize - 1);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsWstrview, 1);
@@ -284,7 +277,6 @@ void DoHStringDifferentValueComparisonTest(const wchar_t (&lhs)[LhsSize], const 
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsStr, 1);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsHstr, 1);
     DoHStringComparisonTest<InhibitArrayReferences, IgnoreCase>(lhsWstrview, rhsUniqueStr, 1);
-#endif
 }
 
 TEST_CASE("WinRTTests::HStringComparison", "[winrt][hstring_compare]")
@@ -362,7 +354,7 @@ TEST_CASE("WinRTTests::HStringComparison", "[winrt][hstring_compare]")
         DoHStringComparisonTest<false, false>(wstr, str.Get(), 0);
         DoHStringComparisonTest<false, false>(wstr, nullHstr, 0);
 #endif
-#ifdef __WI_HAS_STD_WSTRING_VIEW
+
         std::wstring_view wstrview;
         DoHStringComparisonTest<false, false>(wstrview, wstrview, 0);
         DoHStringComparisonTest<false, false>(wstrview, constArray, 0);
@@ -371,7 +363,6 @@ TEST_CASE("WinRTTests::HStringComparison", "[winrt][hstring_compare]")
         DoHStringComparisonTest<false, false>(wstrview, nullCstr, 0);
         DoHStringComparisonTest<false, false>(wstrview, str.Get(), 0);
         DoHStringComparisonTest<false, false>(wstrview, nullHstr, 0);
-#endif
     }
 }
 
@@ -426,9 +417,7 @@ TEST_CASE("WinRTTests::HStringMapTest", "[winrt][hstring_compare]")
 
     HStringReference ref(constArray);
     std::wstring wstr(constArray, 7);
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     std::wstring_view wstrview(wstr);
-#endif
 
     auto verifyFunc = [&](int expectedValue, auto&& keyValue) {
         auto itr = hstringMap.find(std::forward<decltype(keyValue)>(keyValue));
@@ -443,9 +432,7 @@ TEST_CASE("WinRTTests::HStringMapTest", "[winrt][hstring_compare]")
     verifyFunc(expectedValue, key.Get());
     verifyFunc(expectedValue, ref);
     verifyFunc(expectedValue, wstr);
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     verifyFunc(expectedValue, wstrview);
-#endif
 
     // Arrays/strings should not deduce length and should therefore find "foo"
     expectedValue = wstringMap[L"foo"];
@@ -466,9 +453,7 @@ TEST_CASE("WinRTTests::HStringMapTest", "[winrt][hstring_compare]")
     HSTRING nullHstr = nullptr;
 
     std::wstring emptyWstr;
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     std::wstring_view emptywstrview;
-#endif
 
     expectedValue = wstringMap[L""];
     verifyFunc(expectedValue, constEmptyArray);
@@ -478,9 +463,7 @@ TEST_CASE("WinRTTests::HStringMapTest", "[winrt][hstring_compare]")
     verifyFunc(expectedValue, emptyStr);
     verifyFunc(expectedValue, nullHstr);
     verifyFunc(expectedValue, emptyWstr);
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     verifyFunc(expectedValue, emptywstrview);
-#endif
 }
 
 TEST_CASE("WinRTTests::HStringCaseInsensitiveMapTest", "[winrt][hstring_compare]")
@@ -519,9 +502,7 @@ TEST_CASE("WinRTTests::HStringCaseInsensitiveMapTest", "[winrt][hstring_compare]
 
     HStringReference ref(constArray);
     std::wstring wstr(constArray, 7);
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     std::wstring_view wstrview(wstr);
-#endif
 
     auto verifyFunc = [&](int expectedValue, auto&& key) {
         auto itr = hstringMap.find(std::forward<decltype(key)>(key));
@@ -535,9 +516,7 @@ TEST_CASE("WinRTTests::HStringCaseInsensitiveMapTest", "[winrt][hstring_compare]
     verifyFunc(foobarValue, key.Get());
     verifyFunc(foobarValue, ref);
     verifyFunc(foobarValue, wstr);
-#ifdef __WI_HAS_STD_WSTRING_VIEW
     verifyFunc(foobarValue, wstrview);
-#endif
 
     // Arrays/strings should not deduce length and should therefore find "foo"
     verifyFunc(fooValue, constArray);

--- a/tests/WindowingTests.cpp
+++ b/tests/WindowingTests.cpp
@@ -1,7 +1,7 @@
 #include "common.h"
 #include <wil/windowing.h>
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && WIL_HAS_CXX_17
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 TEST_CASE("EnumWindows", "[windowing]")
 {
     // lambda can return a bool


### PR DESCRIPTION
This has the following changes:

* Where possible, prefer the use of feature test macros (as opposed to C++ version checks, etc.) as this is the more supported and reliable way for determining feature support. The only real legitimate remaining use of C++ version checks is for guarding includes (which should also include a `__has_include` check), which might warn when compiling with a standard version less than when the header was introduced.
* Remove reliances in code on MSVC specific version macros (e.g. `_HAS_CXX##`) to remove the reliance on the MSVC-specific define and the reliance on the necessary header from being included first.
* Introduced a new `WI_HAS_INCLUDE` macro to avoid the need to surround all `__has_include` checks with an `#ifdef` check. This macro takes both a header name and a fallback for when `__has_include` is not defined.
* Remove guards in tests for C++17 features as that's now the minimum version we compile the tests with.