### PR TITLE
Bump pipeline timeout to 90 min

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
     displayName: 'Check Formatting of Changes'
 
 - job: BuildAndTest
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
 
   variables:
     compilers: 'clang,msvc'


### PR DESCRIPTION
Lately, it seems as though MSVC has been timing out with the 60 min timeout. Bumping up to 90 min.

Not sure why we're getting so many timeouts now; Clang takes ~20 min and I'm pretty sure MSVC used to as well... going to see if this helps at least.