### PR TITLE
Deduce STL availability

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -19,10 +19,10 @@
 #include "win32_helpers.h"
 #include "resource.h" // last to ensure _COMBASEAPI_H_ protected definitions are available
 
-#if WI_HAS_INCLUDE(<tuple>, 1) // Tuple is C++11... assume available
+#if WIL_USE_STL && WI_HAS_INCLUDE(<tuple>, 1) // Tuple is C++11... assume available
 #include <tuple>
 #endif
-#if WI_HAS_INCLUDE(<type_traits>, 1) // Type traits is old... assume available
+#if WIL_USE_STL && WI_HAS_INCLUDE(<type_traits>, 1) // Type traits is old... assume available
 #include <type_traits>
 #endif
 
@@ -2113,7 +2113,7 @@ wil::com_ptr_nothrow<Interface> CoGetClassObjectNoThrow(DWORD dwClsContext = CLS
     return CoGetClassObjectNoThrow<Interface>(__uuidof(Class), dwClsContext);
 }
 
-#if __cpp_lib_apply && WI_HAS_INCLUDE(<type_traits>, 1)
+#if __cpp_lib_apply && WIL_USE_STL && WI_HAS_INCLUDE(<type_traits>, 1)
 /// @cond
 namespace details
 {

--- a/include/wil/common.h
+++ b/include/wil/common.h
@@ -305,6 +305,29 @@ static_assert(WIL_EXCEPTION_MODE <= 2, "Invalid exception mode");
 #error Must enable exceptions when WIL_EXCEPTION_MODE == 1
 #endif
 
+#ifdef WIL_DOXYGEN
+/** This define is used to control whether or not WIL assumes safe access to the STL.
+This define can be set manually (1 to enable, 0 to disable), otherwise heuristics will be applied in an attempt to
+deduce whether or not the STL is available and can be safely used.
+ */
+#define WIL_USE_STL 1
+#elif !defined(WIL_USE_STL)
+#if !defined(WIL_ENABLE_EXCEPTIONS) || !defined(__has_include)
+// Assume it's not safe to use the STL when:
+//      * Exceptions are not enabled, OR
+//      * We can't check for header presence
+#define WIL_USE_STL 0
+#else
+// Check for several STL headers that have been around since the dawn of time
+#if __has_include(<algorithm>) && __has_include(<exception>) && __has_include(<iterator>) && __has_include(<new>) && \
+    __has_include(<string>) && __has_include(<utility>) && __has_include(<vector>)
+#define WIL_USE_STL 1
+#else
+#define WIL_USE_STL 0
+#endif
+#endif
+#endif
+
 /// @cond
 #ifndef WIL_ITERATOR_DEBUG_LEVEL
 // NOTE: See the definition of 'RESULT_DEBUG' for commentary on the use of 'WIL_KERNEL_MODE' below

--- a/include/wil/filesystem.h
+++ b/include/wil/filesystem.h
@@ -26,6 +26,10 @@
 #include "win32_helpers.h"
 #include "resource.h"
 
+#if WIL_USE_STL
+#include <iterator>
+#endif
+
 namespace wil
 {
 //! Determines if a path is an extended length path that can be used to access paths longer than MAX_PATH.
@@ -403,7 +407,7 @@ struct next_entry_offset_iterator
     using value_type = T;
     using pointer = const T*;
     using reference = const T&;
-#ifdef _XUTILITY_
+#if WIL_USE_STL
     using iterator_category = ::std::forward_iterator_tag;
 #endif
 

--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -223,7 +223,7 @@ namespace reg
     //
 #if defined(WIL_ENABLE_EXCEPTIONS)
 
-#if defined(_STRING_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     using key_iterator = ::wil::reg::iterator_t<::wil::reg::key_iterator_data<::std::wstring>>;
     using value_iterator = ::wil::reg::iterator_t<::wil::reg::value_iterator_data<::std::wstring>>;
 #endif
@@ -583,7 +583,7 @@ namespace reg
         ::wil::reg::set_value_expanded_string(key, nullptr, value_name, data);
     }
 
-#if (defined(_VECTOR_) && defined(_STRING_)) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief The generic set_value template function to write a REG_MULTI_SZ value from a std::vector<std::wstring>
      * @param key An open or well-known registry key
@@ -645,9 +645,9 @@ namespace reg
     {
         ::wil::reg::set_value(key, nullptr, value_name, data);
     }
-#endif // #if defined(_VECTOR_) && defined(_STRING_)
+#endif
 
-#if defined(_VECTOR_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Writes a registry value of the specified type from a `std::vector<uint8_t>`/`std::vector<BYTE>`
      * @param key An open or well-known registry key
@@ -680,8 +680,8 @@ namespace reg
     {
         ::wil::reg::set_value_binary(key, nullptr, value_name, type, data);
     }
-#endif // #if defined(_VECTOR_)
-#endif // #if defined(WIL_ENABLE_EXCEPTIONS)
+#endif
+#endif
 
     //
     // template <typename T>
@@ -1087,7 +1087,7 @@ namespace reg
         return ::wil::reg::get_value<uint64_t>(key, nullptr, value_name);
     }
 
-#if defined(_STRING_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Reads a REG_SZ value, returning a std::wstring
      * @param key An open or well-known registry key
@@ -1210,7 +1210,7 @@ namespace reg
     {
         return ::wil::reg::get_value_expanded_string(key, nullptr, value_name);
     }
-#endif // #if defined(_STRING_)
+#endif
 
 #if defined(__WIL_OLEAUTO_H_) || defined(WIL_DOXYGEN)
     /**
@@ -1482,7 +1482,7 @@ namespace reg
 #endif // #if defined(__WIL_OBJBASE_H_STL)
 #endif // defined(__WIL_OBJBASE_H_)
 
-#if defined(_VECTOR_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Reads a registry value of the specified type, returning a std::vector<BYTE>
      * @param key An open or well-known registry key
@@ -1515,9 +1515,9 @@ namespace reg
     {
         return ::wil::reg::get_value_binary(key, nullptr, value_name, type);
     }
-#endif // #if defined(_VECTOR_)
+#endif
 
-#if (defined(_VECTOR_) && defined(_STRING_)) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Reads a REG_MULTI_SZ value, returning a std::vector<std::wstring>
      * @param key An open or well-known registry key
@@ -1600,9 +1600,9 @@ namespace reg
     {
         return ::wil::reg::get_value<::std::vector<::std::wstring>>(key, nullptr, value_name);
     }
-#endif // #if defined(_VECTOR_) && defined(_STRING_)
+#endif
 
-#if (defined(_OPTIONAL_) && defined(__cpp_lib_optional)) || defined(WIL_DOXYGEN)
+#if (WIL_USE_STL && (__cpp_lib_optional >= 201606L)) || defined(WIL_DOXYGEN)
     //
     // template <typename T>
     // void try_get_value(...)
@@ -1819,7 +1819,7 @@ namespace reg
         return ::wil::reg::try_get_value<uint64_t>(key, nullptr, value_name);
     }
 
-#if defined(_VECTOR_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Attempts to read a value under a specified key requiring the specified type, returning the raw bytes in a
      *        std::optional
@@ -1854,9 +1854,9 @@ namespace reg
     {
         return ::wil::reg::try_get_value_binary(key, nullptr, value_name, type);
     }
-#endif // #if defined(_VECTOR_)
+#endif
 
-#if defined(_STRING_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Attempts to read a REG_SZ value under a specified key, returning the value in a std::optional
      * @param key An open or well-known registry key
@@ -1986,7 +1986,7 @@ namespace reg
     {
         return ::wil::reg::try_get_value_expanded_string(key, nullptr, value_name);
     }
-#endif // #if defined(_STRING_)
+#endif
 
 #if defined(__WIL_OLEAUTO_H_STL) || defined(WIL_DOXYGEN)
     /**
@@ -2132,7 +2132,7 @@ namespace reg
     }
 #endif // defined(__WIL_OBJBASE_H_STL)
 
-#if (defined(_VECTOR_) && defined(_STRING_)) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
     /**
      * @brief Attempts to read a REG_MULTI_SZ value under a specified key, returning the value in a std::optional
      * @param key An open or well-known registry key
@@ -2209,9 +2209,9 @@ namespace reg
     {
         return ::wil::reg::try_get_value<::std::vector<::std::wstring>>(key, nullptr, value_name);
     }
-#endif // #if defined (_VECTOR_) && defined (_STRING_)
-#endif // #if defined (_OPTIONAL_) && defined(__cpp_lib_optional)
-#endif // #if defined(WIL_ENABLE_EXCEPTIONS)
+#endif
+#endif
+#endif
 
     //
     // template <typename T>

--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -13,9 +13,17 @@
 #ifndef __WIL_REGISTRY_HELPERS_INCLUDED
 #define __WIL_REGISTRY_HELPERS_INCLUDED
 
-#if defined(_STRING_) || defined(_VECTOR_) || (defined(__cpp_lib_optional) && defined(_OPTIONAL_)) || defined(WIL_DOXYGEN)
+#include "common.h"
+
+#if WIL_USE_STL
 #include <functional>
 #include <iterator>
+#include <string>
+#include <vector>
+
+#if (__WI_LIBCPP_STD_VER >= 17) && WI_HAS_INCLUDE(<optional>, 1) // Assume present if C++17 or later
+#include <optional>
+#endif
 #endif
 
 #include <stdint.h>
@@ -142,7 +150,7 @@ namespace reg
             }
         }
 
-#if defined(_VECTOR_) && defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
         /**
          * @brief A translation function taking iterators referencing std::wstring objects and returns a corresponding
          *        std::vector<wchar_t> to be written to a MULTI_SZ registry value. The translation follows the rules for how
@@ -203,7 +211,7 @@ namespace reg
             });
             return strings;
         }
-#endif // #if defined(_VECTOR_) && defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#endif
 
 #if defined(__WIL_OBJBASE_H_)
         template <size_t C>
@@ -442,7 +450,7 @@ namespace reg
                 return static_cast<DWORD>((::wcslen(value) + 1) * sizeof(wchar_t));
             }
 
-#if defined(_VECTOR_) && defined(WIL_ENABLE_EXCEPTIONS)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
             inline void* get_buffer(const ::std::vector<uint8_t>& buffer) WI_NOEXCEPT
             {
                 return const_cast<uint8_t*>(buffer.data());
@@ -517,9 +525,9 @@ namespace reg
                 }
                 return S_OK;
             }
-#endif // #if defined(_VECTOR_) && defined(WIL_ENABLE_EXCEPTIONS)
+#endif
 
-#if defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
             inline void* get_buffer(const ::std::wstring& string) WI_NOEXCEPT
             {
                 return const_cast<wchar_t*>(string.data());
@@ -575,7 +583,7 @@ namespace reg
                 }
                 return buffer.size();
             }
-#endif // #if defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#endif
 
 #if defined(__WIL_OLEAUTO_H_)
             inline void* get_buffer(const BSTR& value) WI_NOEXCEPT
@@ -972,7 +980,7 @@ namespace reg
                 return REG_SZ;
             }
 
-#if defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
             template <>
             constexpr DWORD get_value_type<::std::wstring>() WI_NOEXCEPT
             {
@@ -984,7 +992,7 @@ namespace reg
             {
                 return REG_SZ;
             }
-#endif // #if defined(_STRING_) && defined(WIL_ENABLE_EXCEPTIONS)
+#endif
 
 #if defined(__WIL_OLEAUTO_H_)
             template <>
@@ -1129,7 +1137,7 @@ namespace reg
                 return err_policy::HResult(hr);
             }
 
-#if defined(_OPTIONAL_) && defined(__cpp_lib_optional)
+#if (WIL_USE_STL && (__cpp_lib_optional >= 201606L)) || defined(WIL_DOXYGEN)
             // intended for err_exception_policy as err_returncode_policy will not get an error code
             template <typename R>
             ::std::optional<R> try_get_value(
@@ -1151,7 +1159,7 @@ namespace reg
                 err_policy::HResult(hr);
                 return ::std::nullopt;
             }
-#endif // #if defined (_OPTIONAL_) && defined(__cpp_lib_optional)
+#endif
 
             template <typename R>
             typename err_policy::result set_value(
@@ -1313,7 +1321,7 @@ namespace reg
         }
 #endif // #if defined(__WIL_WINREG_STL)
 
-#if defined(WIL_ENABLE_EXCEPTIONS) && defined(_STRING_)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
         // overloads for some of the below string functions - specific for std::wstring
         // these overloads must be declared before the template functions below, as some of those template functions
         // reference these overload functions
@@ -1340,7 +1348,7 @@ namespace reg
         {
             return !name.empty();
         }
-#endif // #if defined(WIL_ENABLE_EXCEPTIONS) && defined(_STRING_)
+#endif
 
         // string manipulation functions needed for iterator functions
         template <typename T>
@@ -1730,7 +1738,7 @@ namespace reg
         // Notice this is a forward_iterator
         // - does not support random-access (e.g. vector::iterator)
         // - does not support bidirectional access (e.g. list::iterator)
-#if defined(_ITERATOR_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
         using iterator_category = ::std::forward_iterator_tag;
 #endif
         using value_type = T;

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -16,6 +16,10 @@
 #include "wistd_functional.h"
 #include "wistd_memory.h"
 
+#if WIL_USE_STL
+#include <iterator>
+#endif
+
 #pragma warning(push)
 #pragma warning(disable : 26135 26110) // Missing locking annotation, Caller failing to hold lock
 #pragma warning(disable : 4714)        // __forceinline not honored
@@ -7346,7 +7350,7 @@ namespace details
 
         struct iterator
         {
-#if defined(_XUTILITY_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
             // muse be input_iterator_tag as use of one instance invalidates the other.
             typedef ::std::input_iterator_tag iterator_category;
 #endif

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -22,9 +22,18 @@
 
 #include "common.h"
 
-// detect std::bit_cast
-#if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<bit>, 1) // Assume present if C++20
+#if WIL_USE_STL
+#if (__WI_LIBCPP_STD_VER >= 17) && WI_HAS_INCLUDE(<string_view>, 1) // Assume present if C++17
+#include <string_view>
+#endif
+#if (__WI_LIBCPP_STD_VER >= 20)
+#if WI_HAS_INCLUDE(<bit>, 1) // Assume present if C++20
 #include <bit>
+#endif
+#if WI_HAS_INCLUDE(<compare>, 1) // Assume present if C++20
+#include <compare>
+#endif
+#endif
 #endif
 
 /// @cond
@@ -41,24 +50,13 @@
 #include "wistd_type_traits.h"
 
 /// @cond
-#if (__WI_LIBCPP_STD_VER >= 20) && defined(_STRING_VIEW_) && defined(_COMPARE_)
-// If we're using c++20, then <compare> must be included to use the string ordinal functions
-#define __WI_DEFINE_STRING_ORDINAL_FUNCTIONS
-#elif (__WI_LIBCPP_STD_VER < 20) && defined(_STRING_VIEW_)
-#define __WI_DEFINE_STRING_ORDINAL_FUNCTIONS
-#endif
-/// @endcond
-
-/// @cond
 namespace wistd
 {
-#if defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS)
-
-#if __WI_LIBCPP_STD_VER >= 20
+#if WIL_USE_STL && (__cpp_lib_three_way_comparison >= 201907L)
 
 using weak_ordering = std::weak_ordering;
 
-#else // __WI_LIBCPP_STD_VER >= 20
+#else
 
 struct weak_ordering
 {
@@ -133,9 +131,7 @@ inline constexpr weak_ordering weak_ordering::less{static_cast<signed char>(-1)}
 inline constexpr weak_ordering weak_ordering::equivalent{static_cast<signed char>(0)};
 inline constexpr weak_ordering weak_ordering::greater{static_cast<signed char>(1)};
 
-#endif // __WI_LIBCPP_STD_VER < 20
-
-#endif // defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS)
+#endif
 } // namespace wistd
 /// @endcond
 
@@ -165,8 +161,7 @@ constexpr size_t guid_string_length = 38;
 // Indentifiers require a locale-less (ordinal), and often case-insensitive, comparison (filenames, registry keys, XML node names,
 // etc). DO NOT use locale-sensitive (lexical) comparisons for resource identifiers (e.g.wcs*() functions in the CRT).
 
-#if defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS) || defined(WIL_DOXYGEN)
-
+#if WIL_USE_STL && (__cpp_lib_string_view >= 201606L)
 /// @cond
 namespace details
 {
@@ -192,8 +187,7 @@ namespace details
         return wistd::weak_ordering::equivalent;
     }
 }
-
-#endif // defined(__WI_DEFINE_STRING_ORDINAL_FUNCTIONS)
+#endif
 
 #pragma endregion
 

--- a/include/wil/winrt.h
+++ b/include/wil/winrt.h
@@ -29,25 +29,9 @@
 #endif
 
 /// @cond
-#if defined(WIL_ENABLE_EXCEPTIONS) && !defined(__WI_HAS_STD_LESS)
-#define __WI_HAS_STD_LESS 1
-#if WI_HAS_INCLUDE(<functional>, 1) // Functional header available since C++11... fall back to assume present
+#if WIL_USE_STL
 #include <functional>
-#else
-// Fall back to the old way of forward declaring std::less
-#pragma warning(push)
-#pragma warning(disable : 4643) // Forward declaring '...' in namespace std is not permitted by the C++ Standard.
-namespace std
-{
-template <class _Ty>
-struct less;
-}
-#pragma warning(pop)
-#endif
-#endif
-
-#if defined(WIL_ENABLE_EXCEPTIONS) && WI_HAS_INCLUDE(<vector>, 1) // Vector has been around forever... fall back to assume present
-#define __WI_HAS_STD_VECTOR 1
+#include <iterator>
 #include <vector>
 #endif
 /// @endcond
@@ -604,7 +588,7 @@ public:
     class vector_iterator
     {
     public:
-#if defined(_XUTILITY_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
         // could be random_access_iterator_tag but missing some features
         typedef ::std::bidirectional_iterator_tag iterator_category;
 #endif
@@ -795,7 +779,7 @@ public:
     class vector_iterator_nothrow
     {
     public:
-#if defined(_XUTILITY_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
         // must be input_iterator_tag as use (via ++, --, etc.) of one invalidates the other.
         typedef ::std::input_iterator_tag iterator_category;
 #endif
@@ -965,7 +949,7 @@ public:
     class iterable_iterator
     {
     public:
-#if defined(_XUTILITY_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
         typedef ::std::forward_iterator_tag iterator_category;
 #endif
         typedef TSmart value_type;
@@ -1075,7 +1059,7 @@ private:
 };
 #pragma endregion
 
-#if defined(__WI_HAS_STD_VECTOR) || defined(WIL_DOXYGEN)
+#if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
 /** Converts WinRT vectors to std::vector by requesting the collection's data in a single
 operation. This can be more efficient in terms of IPC cost than iteratively processing it.
 @code
@@ -1170,7 +1154,7 @@ public:
     class iterable_iterator_nothrow
     {
     public:
-#if defined(_XUTILITY_) || defined(WIL_DOXYGEN)
+#if WIL_USE_STL || defined(WIL_DOXYGEN)
         // muse be input_iterator_tag as use of one instance invalidates the other.
         typedef ::std::input_iterator_tag iterator_category;
 #endif
@@ -2492,7 +2476,7 @@ struct ABI::Windows::Foundation::IAsyncOperationWithProgressCompletedHandler<ABI
 #pragma pop_macro("ABI")
 #endif
 
-#if __WI_HAS_STD_LESS
+#if WIL_USE_STL
 
 namespace std
 {

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -1484,7 +1484,6 @@ TEST_CASE("BasicRegistryTests::wstrings", "[registry]")
         REQUIRE_SUCCEEDED(deleteHr);
     }
 
-#if defined(_VECTOR_)
     SECTION("get_value_nothrow with non-null-terminated string: with opened key")
     {
         wil::unique_hkey hkey;
@@ -1554,7 +1553,6 @@ TEST_CASE("BasicRegistryTests::wstrings", "[registry]")
         const std::wstring result{wil::reg::get_value_string(HKEY_CURRENT_USER, testSubkey, stringValueName)};
         REQUIRE(result.empty());
     }
-#endif
 
     SECTION("set_value_nothrow/get_value_string_nothrow: into buffers with open key")
     {
@@ -3082,7 +3080,7 @@ void verify_cotaskmem_array_nothrow(
 }
 #endif
 
-#if defined(_VECTOR_) && defined(WIL_ENABLE_EXCEPTIONS)
+#ifdef WIL_ENABLE_EXCEPTIONS
 namespace
 {
 // Test byte vectors/binary getters. These tests are very similar to the
@@ -3309,7 +3307,7 @@ TEST_CASE("BasicRegistryTests::vector-bytes", "[registry]")
     }
 #endif // #if defined(__cpp_lib_optional)
 }
-#endif // #if defined(_VECTOR_) && defined(WIL_ENABLE_EXCEPTIONS)
+#endif
 
 #if defined(__WIL_OBJBASE_H_)
 TEST_CASE("BasicRegistryTests::cotaskmem_array-bytes", "[registry]")
@@ -3353,7 +3351,6 @@ TEST_CASE("BasicRegistryTests::cotaskmem_array-bytes", "[registry]")
 #endif // #if defined(__WIL_OBJBASE_H_)
 
 #if defined(WIL_ENABLE_EXCEPTIONS)
-#if defined(_STRING_)
 TEST_CASE("BasicRegistryTests::value_iterator", "[registry]")
 {
     const auto deleteHr = HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, testSubkey));
@@ -3938,7 +3935,6 @@ TEST_CASE("BasicRegistryTests::key_iterator", "[registry]")
         }
     }
 }
-#endif // #if !defined(_STRING_)
 
 #if defined(__WIL_OLEAUTO_H_)
 TEST_CASE("BasicRegistryTests::value_bstr_iterator", "[registry]")

--- a/tests/noexcept/CMakeLists.txt
+++ b/tests/noexcept/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 target_compile_definitions(witest.noexcept PRIVATE
     -DCATCH_CONFIG_DISABLE_EXCEPTIONS
+    # No exceptions means we will deduce STL usage to false, however the tests still want to test things that use the STL
+    -DWIL_USE_STL=1
     )
 
 # Catch2 has a no exceptions mode (configured above), however still includes STL headers which contain try...catch

--- a/tests/sanitize-address/CMakeLists.txt
+++ b/tests/sanitize-address/CMakeLists.txt
@@ -23,6 +23,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         target_compile_options(witest.asan PRIVATE -fno-exceptions)
     endif()
 
+    # Since we're disabling exceptions, we also need to explicitly enable use of the STL since some tests rely on it
+    target_compile_definitions(witest.asan PRIVATE
+        -DWIL_USE_STL=1
+        )
+
     if ($ENV{Platform} STREQUAL "x86")
         target_link_libraries(witest.asan PRIVATE
             clang_rt.asan_dynamic-i386.lib


### PR DESCRIPTION
There's a pattern that's existed in WIL for a while that's only gotten worse over time. A lot of the code is sprinkled with things like:
```c++
#ifdef SOME_HEADER_INCLUDED
// Some functionality
#endif
```
Some headers do this in a "safe" way such that they can be re-included to pick up new definitions (e.g. `resource.h`), however many do not. In the best case scenario, this creates header include order dependencies that can cause builds to sporadically break when include orders change (such as a dependency including new headers). In the worst case scenario, this introduces the possibility for ODR violations when one translation unit defines something different than another that can result in security or reliability issues.

The change here tries to determine if it's "safe" to use the STL so that code doesn't need to check to see if a dependent STL header has been included and can instead include that header itself. This heuristic can be seen in `common.h` and can be overridden by defining `WIL_USE_STL`, ideally on the command line to ensure all translation units get the same definition. This isn't perfect and won't avoid _all_ ODR violations - in particular linking to other libraries is one place where it can be easy to accidentally introduce violations - however it should improve things a fair bit. In theory we could detect those violations with a `detect_mismatch` pragma, however that's likely to flag too many places where no realistic issue exists.