### PR TITLE
Improve VS debugging, skipping trivial wil functions by adding wil.natstepfilter

### DIFF
--- a/natvis/wil.natstepfilter
+++ b/natvis/wil.natstepfilter
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StepFilter xmlns="http://schemas.microsoft.com/vstudio/debugger/natstepfilter/2010">
+    <Function><Name>wil::unique_any_t&lt;.*&gt;::get</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wil::unique_any_t&lt;.*&gt;::operator.*</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wistd::unique_ptr&lt;.*&gt;::get</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wistd::forward&lt;.*</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wistd::move&lt;.*</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wistd::unique_ptr&lt;.*&gt;::operator.*</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wil::com_ptr_t&lt;.*&gt;::operator.*</Name><Action>NoStepInto</Action></Function>
+    <Function><Name>wil::com_ptr_t&lt;.*&gt;::get</Name><Action>NoStepInto</Action></Function>
+</StepFilter>

--- a/packaging/nuget/Microsoft.Windows.ImplementationLibrary.nuspec
+++ b/packaging/nuget/Microsoft.Windows.ImplementationLibrary.nuspec
@@ -17,6 +17,7 @@
     <file src="..\..\ThirdPartyNotices.txt"/>
     <file src="..\..\include\**" target="include\" />
     <file src="..\..\natvis\wil.natvis" target="natvis\" />
+    <file src="..\..\natvis\wil.natstepfilter" target="natvis\" />
     <file src="Microsoft.Windows.ImplementationLibrary.targets" target="build\native\" />
   </files>
 </package>

--- a/packaging/nuget/Microsoft.Windows.ImplementationLibrary.targets
+++ b/packaging/nuget/Microsoft.Windows.ImplementationLibrary.targets
@@ -7,5 +7,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis"/>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natstepfilter"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When debugging code that uses wil RAII types, "step in" ends up going into the operators and get functions. 
This change resolves that by
1) adding `wil.natstepfitler`
2) adding that to projects that reference the wil nuget via the targets file `<Natvis>` element.

Learn more [here](https://learn.microsoft.com/en-us/visualstudio/debugger/just-my-code?view=vs-2019#additional-information-on-natstepfilter-and-natjmc-files) and [here](https://learn.microsoft.com/en-us/shows/pure-virtual-cpp-2023/improved-step-filtering-in-the-visual-studio-debugger).

it is annoying that adding wil.natvis/wil.natstepfiler to the project clutters the project with those files. Is there a way to add then by hide them too?