### PR TITLE
`cppwinrt.h`: Improve conversion of error information

### DIFF
--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -121,6 +121,20 @@ inline void MaybeGetExceptionString(
     }
 }
 
+inline HRESULT CppWinRtHResultFromCode(HRESULT hr, PCWSTR debugString)
+{
+    if (FAILED(hr))
+    {
+        // Use winrt::hresult_error::to_abi() to save the debugString so it can later be retrieved by C++/WinRT
+        if (debugString)
+        {
+            return winrt::hresult_error(hr, debugString).to_abi();
+        }
+        return winrt::hresult_error(hr).to_abi();
+    }
+    return hr;
+}
+
 inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
     _Inout_updates_opt_(debugStringChars) PWSTR debugString,
     _When_(debugString != nullptr, _Pre_satisfies_(debugStringChars > 0)) size_t debugStringChars,
@@ -136,34 +150,34 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         {
             *isNormalized = true;
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(exception.GetErrorCode(), debugString).to_abi();
+            return CppWinRtHResultFromCode(exception.GetErrorCode(), debugString);
         }
         catch (const winrt::hresult_error& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return exception.to_abi();
+            return CppWinRtHResultFromCode(exception.code(), debugString);
         }
         catch (const std::bad_alloc& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_OUTOFMEMORY, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_OUTOFMEMORY, debugString);
         }
         catch (const std::out_of_range& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_BOUNDS, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_BOUNDS, debugString);
         }
         catch (const std::invalid_argument& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_INVALIDARG, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_INVALIDARG, debugString);
         }
         catch (...)
         {
             auto hr = RecognizeCaughtExceptionFromCallback(debugString, debugStringChars);
             if (FAILED(hr))
             {
-                return hr;
+                return CppWinRtHResultFromCode(hr, debugString);
             }
         }
     }
@@ -177,32 +191,32 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         {
             *isNormalized = true;
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(exception.GetErrorCode(), debugString).to_abi();
+            return CppWinRtHResultFromCode(exception.GetErrorCode(), debugString);
         }
         catch (const winrt::hresult_error& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return exception.to_abi();
+            return CppWinRtHResultFromCode(exception.code(), debugString);
         }
         catch (const std::bad_alloc& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_OUTOFMEMORY, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_OUTOFMEMORY, debugString);
         }
         catch (const std::out_of_range& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_BOUNDS, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_BOUNDS, debugString);
         }
         catch (const std::invalid_argument& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(E_INVALIDARG, debugString).to_abi();
+            return CppWinRtHResultFromCode(E_INVALIDARG, debugString);
         }
         catch (const std::exception& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return winrt::hresult_error(ERROR_UNHANDLED_EXCEPTION, debugString).to_abi();
+            return CppWinRtHResultFromCode(ERROR_UNHANDLED_EXCEPTION, debugString);
         }
         catch (...)
         {

--- a/include/wil/cppwinrt.h
+++ b/include/wil/cppwinrt.h
@@ -136,7 +136,7 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         {
             *isNormalized = true;
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return exception.GetErrorCode();
+            return winrt::hresult_error(exception.GetErrorCode(), debugString).to_abi();
         }
         catch (const winrt::hresult_error& exception)
         {
@@ -146,17 +146,17 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         catch (const std::bad_alloc& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_OUTOFMEMORY;
+            return winrt::hresult_error(E_OUTOFMEMORY, debugString).to_abi();
         }
         catch (const std::out_of_range& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_BOUNDS;
+            return winrt::hresult_error(E_BOUNDS, debugString).to_abi();
         }
         catch (const std::invalid_argument& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_INVALIDARG;
+            return winrt::hresult_error(E_INVALIDARG, debugString).to_abi();
         }
         catch (...)
         {
@@ -177,7 +177,7 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         {
             *isNormalized = true;
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return exception.GetErrorCode();
+            return winrt::hresult_error(exception.GetErrorCode(), debugString).to_abi();
         }
         catch (const winrt::hresult_error& exception)
         {
@@ -187,22 +187,22 @@ inline HRESULT __stdcall ResultFromCaughtException_CppWinRt(
         catch (const std::bad_alloc& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_OUTOFMEMORY;
+            return winrt::hresult_error(E_OUTOFMEMORY, debugString).to_abi();
         }
         catch (const std::out_of_range& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_BOUNDS;
+            return winrt::hresult_error(E_BOUNDS, debugString).to_abi();
         }
         catch (const std::invalid_argument& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return E_INVALIDARG;
+            return winrt::hresult_error(E_INVALIDARG, debugString).to_abi();
         }
         catch (const std::exception& exception)
         {
             MaybeGetExceptionString(exception, debugString, debugStringChars);
-            return HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION);
+            return winrt::hresult_error(ERROR_UNHANDLED_EXCEPTION, debugString).to_abi();
         }
         catch (...)
         {


### PR DESCRIPTION
Closes #495

When using WIL with C++/WinRT with the `cppwinrt.h` header, the `winrt_to_hresult_handler` global handler is hooked from WIL directly into the C++/WinRT codebase.

The handler allows WIL exceptions to be understood by C++/WinRT and their HRESULTs extracted, but messages are lost in the way when going over the API boundaries because only the HRESULT is converted in [`winrt::to_hresult()`](https://github.com/microsoft/cppwinrt/blob/a77a2ef2e99059f5d8411bbb08a8299c348f3e73/strings/base_error.h#L429).

C++/WinRT makes use of Get and [SetErrorInfo()](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-seterrorinfo) to recover the messages when re-creating the exceptions on the caller side. The set is done inside `winrt::hresult_error::to_abi()` in `winrt::to_hresult()` on the server side, but only when `winrt_to_hresult_handler` is not hooked. The retrieval happens when re-creating the `winrt::hresult_error` on the caller.

If WIL were to call the `to_abi()` method in the WIL hook for `winrt_to_hresult_handler`, it would properly trigger the storage of the message and later on it could be retrieved when C++/WinRT creates a new `winrt::hresult_error` on the caller side.

That's what this PR is doing.
I also added a test to cover the message being passed.