### PR TITLE
Add ArgvToCommandLine, the reverse of CommandLineToArgvW

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -50,10 +50,6 @@
 #include "wistd_functional.h"
 #include "wistd_type_traits.h"
 
-#if defined(WIL_ENABLE_EXCEPTIONS) && (__cpp_lib_string_view >= 201606L)
-#include <string>
-#endif
-
 /// @cond
 namespace wistd
 {

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -1012,7 +1012,7 @@ inline std::basic_string<CharT> ArgvToCommandLine(RangeT&& range, ArgvToCommandL
                 // NOTE: By updating the search string here, we don't need to worry about manually inserting the
                 // character later since we'll just include it in our next iteration
                 WI_ASSERT(!forceQuotes);               // Otherwise, shouldn't be part of our search string
-                searchString = search_string_no_space; // We're already adding a space; don't do it again
+                searchString = search_string_no_space; // We're already adding a quote; don't do it again
                 result.insert(startPos, 1, '"');
                 terminateWithQuotes = true;
             }

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -4114,6 +4114,10 @@ static void DoArgvToCommandLineTest(std::initializer_list<const char*> argv, con
 
 TEST_CASE("WindowsInternalTests::ArgvToCommandLine", "[win32_helpers]")
 {
+    // NOTE: CommandLineToArgvW makes the assumption that the first argument is an executable name, and thefefore must
+    // be a valid NTFS path. This enables special handling when the first argument is a quoted string since NTFS paths
+    // cannot contain embedded quotation characters.
+
     DoArgvToCommandLineTest({"SingleNoSpaces"}, "SingleNoSpaces", R"("SingleNoSpaces")");
     DoArgvToCommandLineTest({"multiple", "no", "spaces"}, "multiple no spaces", R"("multiple" "no" "spaces")");
     DoArgvToCommandLineTest({"single with spaces"}, R"("single with spaces")", R"("single with spaces")");

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -1,15 +1,5 @@
 #include "pch.h"
 
-#include <wil/common.h>
-
-#ifdef WIL_ENABLE_EXCEPTIONS
-#include <memory>
-#include <set>
-#include <string_view>
-#include <thread>
-#include <unordered_set>
-#endif
-
 #include <wil/result.h>
 #include <wil/resource.h>
 #include <wil/win32_helpers.h>
@@ -18,6 +8,13 @@
 #include <wil/wrl.h>
 #endif
 #include <wil/com.h>
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+#include <memory>
+#include <set>
+#include <thread>
+#include <unordered_set>
+#endif
 
 // Do not include most headers until after the WIL headers to ensure that we're not inadvertently adding any unnecessary
 // dependencies to STL, WRL, or indirectly retrieved headers


### PR DESCRIPTION
A separate project I was working on required this functionality; thought I'd copy it here. The general gist behind its purpose is that `CreateProcess*` requires a string for the command line as opposed to an `argv` array; when you're in a scenario where you have an `argv` array and need to call `CreateProcess*`, this function is useful. The documentation for the function mentions two specific scenarios in which this is useful, but I'm copying it here for quick reference:

1. When implementing a "driver" application. That is, an application that consumes some command line arguments, translates others into new arguments, and preserves the rest, "forwarding" the resulting command line to a separate application.
2. When reading command line arguments from some data storage, e.g. from a JSON array, which then need to get compiled into a command line string that's used for creating a new process.

Note that the [documentation for `CommandLineToArgvW`](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw) describes how arguments are parsed; this just does the reverse. The goal of this function is to ensure that the target application's `argv` array is identical to the one passed into this function. This is potentially problematic if the target application does not use its `argv` array (e.g. if it gets the command line string directly, e.g. with `GetCommandLineW`) and instead attempts to perform its own command line processing, which may not handle quotes, etc. identically to `CommandLineToArgvW`. One notable example is `cmd.exe` which does not handle some quoted arguments as one would logically expect. For example, `cmd.exe "/c" "echo foo"` does not behave as you would expect it to:
```cmd
>cmd "/c" "echo foo"
'"echo foo' is not recognized as an internal or external command,
operable program or batch file.
```
This is the motivating factor behind `ArgvToCommandLineFlags::ForceQuotes`. Ideally, we would always surround all arguments with quotes as that's the more efficient thing to do, however as you can see from the above, this is not always safe to do.