### PR TITLE
Guard bit_cast use with WIL_USE_STL

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -38,7 +38,7 @@
 #endif
 
 /// @cond
-#if __cpp_lib_bit_cast >= 201806L
+#if WIL_USE_STL && (__cpp_lib_bit_cast >= 201806L)
 #define __WI_CONSTEXPR_BIT_CAST constexpr
 #else
 #define __WI_CONSTEXPR_BIT_CAST inline
@@ -209,7 +209,7 @@ namespace filetime
 {
     constexpr unsigned long long to_int64(const FILETIME& ft) WI_NOEXCEPT
     {
-#if __cpp_lib_bit_cast >= 201806L
+#if WIL_USE_STL && (__cpp_lib_bit_cast >= 201806L)
         return std::bit_cast<unsigned long long>(ft);
 #else
         // Cannot reinterpret_cast FILETIME* to unsigned long long*
@@ -220,7 +220,7 @@ namespace filetime
 
     __WI_CONSTEXPR_BIT_CAST FILETIME from_int64(unsigned long long i64) WI_NOEXCEPT
     {
-#if __cpp_lib_bit_cast >= 201806L
+#if WIL_USE_STL && (__cpp_lib_bit_cast >= 201806L)
         return std::bit_cast<FILETIME>(i64);
 #else
         static_assert(sizeof(i64) == sizeof(FILETIME), "sizes don't match");


### PR DESCRIPTION
This usage was missed. Perhaps I thought that `__cpp_lib_bit_cast` was only defined in `<bit>` for some reason... who knows.

Fixes #512