### PR TITLE
Add noexcept and conversions to zwstring_view

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -161,7 +161,7 @@ namespace details
     class agile_query_policy
     {
     public:
-        inline static HRESULT query(_In_ IAgileReference* ptr, REFIID riid, _COM_Outptr_ void** result)
+        inline static HRESULT query(_In_ IAgileReference* ptr, REFIID riid, _COM_Outptr_ void** result) WI_NOEXCEPT
         {
             WI_ASSERT_MSG(riid != __uuidof(IAgileReference), "Cannot resolve a agile reference to IAgileReference");
             auto hr = ptr->Resolve(riid, result);
@@ -170,7 +170,7 @@ namespace details
         }
 
         template <typename TResult>
-        static HRESULT query(_In_ IAgileReference* ptr, _COM_Outptr_ TResult** result)
+        static HRESULT query(_In_ IAgileReference* ptr, _COM_Outptr_ TResult** result) WI_NOEXCEPT
         {
             static_assert(!wistd::is_same<IAgileReference, TResult>::value, "Cannot resolve a agile reference to IAgileReference");
             return query(ptr, __uuidof(TResult), reinterpret_cast<void**>(result));
@@ -805,7 +805,7 @@ public:
     //!                     not specify the type directly to the template.
     //! @return             A `bool` indicating `true` of the query was successful (the returned parameter is non-null).
     template <class U>
-    _Success_return_ bool try_copy_to(_COM_Outptr_result_maybenull_ U** ptrResult) const
+    _Success_return_ bool try_copy_to(_COM_Outptr_result_maybenull_ U** ptrResult) const WI_NOEXCEPT
     {
         if (m_ptr)
         {
@@ -826,7 +826,7 @@ public:
     //!                     on failure or if the source pointer being queried is null.
     //! @return             A `bool` indicating `true` of the query was successful (the returned parameter is non-null).  Querying
     //!                     a null pointer will return `false` with a null result.
-    _Success_return_ bool try_copy_to(REFIID riid, _COM_Outptr_result_maybenull_ void** ptrResult) const
+    _Success_return_ bool try_copy_to(REFIID riid, _COM_Outptr_result_maybenull_ void** ptrResult) const WI_NOEXCEPT
     {
         if (m_ptr)
         {

--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -1077,7 +1077,7 @@ namespace reg
             reg_view_t& operator=(reg_view_t&&) = delete;
 
             typename err_policy::result open_key(
-                _In_opt_ _In_opt_ PCWSTR subKey, _Out_ HKEY* hkey, ::wil::reg::key_access access = ::wil::reg::key_access::read) const
+                _In_opt_ PCWSTR subKey, _Out_ HKEY* hkey, ::wil::reg::key_access access = ::wil::reg::key_access::read) const
             {
                 constexpr DWORD zero_options{0};
                 return err_policy::HResult(

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -145,6 +145,20 @@ class basic_zstring_view : public std::basic_string_view<TChar>
 {
     using size_type = typename std::basic_string_view<TChar>::size_type;
 
+    template<typename T> struct has_c_str
+    {
+        template<typename U> static auto test(int) -> decltype(std::declval<U>().c_str(), std::true_type());
+        template<typename U> static std::false_type test(...);
+        static constexpr bool value = decltype(test<T>(0))::value;
+    };  
+
+    template<typename T> struct has_size
+    {
+        template<typename U> static auto test(int) -> decltype(std::declval<U>().size() == 1, std::true_type());
+        template<typename U> static std::false_type test(...);
+        static constexpr bool value = decltype(test<T>(0))::value;
+    };
+
 public:
     constexpr basic_zstring_view() noexcept = default;
     constexpr basic_zstring_view(const basic_zstring_view&) noexcept = default;
@@ -174,6 +188,18 @@ public:
 
     constexpr basic_zstring_view(const std::basic_string<TChar>& str) noexcept :
         std::basic_string_view<TChar>(&str[0], str.size())
+    {
+    }
+
+    template<typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && has_size<TSrc>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept :
+        std::basic_string_view<TChar>(src.c_str(), src.size())
+    {
+    }
+
+    template<typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && !has_size<TSrc>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept :
+        std::basic_string_view<TChar>(src.c_str())
     {
     }
 

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -145,17 +145,23 @@ class basic_zstring_view : public std::basic_string_view<TChar>
 {
     using size_type = typename std::basic_string_view<TChar>::size_type;
 
-    template<typename T> struct has_c_str
+    template <typename T>
+    struct has_c_str
     {
-        template<typename U> static auto test(int) -> decltype(std::declval<U>().c_str(), std::true_type());
-        template<typename U> static std::false_type test(...);
+        template <typename U>
+        static auto test(int) -> decltype(std::declval<U>().c_str(), std::true_type());
+        template <typename U>
+        static std::false_type test(...);
         static constexpr bool value = decltype(test<T>(0))::value;
-    };  
+    };
 
-    template<typename T> struct has_size
+    template <typename T>
+    struct has_size
     {
-        template<typename U> static auto test(int) -> decltype(std::declval<U>().size() == 1, std::true_type());
-        template<typename U> static std::false_type test(...);
+        template <typename U>
+        static auto test(int) -> decltype(std::declval<U>().size() == 1, std::true_type());
+        template <typename U>
+        static std::false_type test(...);
         static constexpr bool value = decltype(test<T>(0))::value;
     };
 
@@ -191,15 +197,13 @@ public:
     {
     }
 
-    template<typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && has_size<TSrc>::value>* = nullptr>
-    constexpr basic_zstring_view(TSrc const& src) noexcept :
-        std::basic_string_view<TChar>(src.c_str(), src.size())
+    template <typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && has_size<TSrc>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept : std::basic_string_view<TChar>(src.c_str(), src.size())
     {
     }
 
-    template<typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && !has_size<TSrc>::value>* = nullptr>
-    constexpr basic_zstring_view(TSrc const& src) noexcept :
-        std::basic_string_view<TChar>(src.c_str())
+    template <typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && !has_size<TSrc>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept : std::basic_string_view<TChar>(src.c_str())
     {
     }
 

--- a/tests/CppWinRTTests.cpp
+++ b/tests/CppWinRTTests.cpp
@@ -11,6 +11,7 @@
 #include <wil/cppwinrt_helpers.h>
 #include <winrt/Windows.System.h>
 #include <wil/cppwinrt_helpers.h> // Verify can include a second time to unlock more features
+#include <wil/stl.h>
 
 using namespace winrt::Windows::ApplicationModel::Activation;
 
@@ -758,4 +759,10 @@ TEST_CASE("CppWinRTTests::ThrownExceptionWithMessage", "[cppwinrt]")
         CATCH_RETURN();
     }();
     witest::RequireRestrictedErrorInfo(E_INVALIDARG, L"The parameter is incorrect.\r\n");
+}
+
+TEST_CASE("CppWinRTTests::ZStringViewFromHString", "[cppwinrt]")
+{
+    winrt::hstring hstr = L"Hello";
+    REQUIRE(wil::zwstring_view(hstr) == hstr);
 }

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -211,4 +211,15 @@ TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
     CustomNoncopyableString customString;
     wil::zwstring_view fromCustomString(customString);
     REQUIRE(fromCustomString == (PCWSTR)customString);
+
+    // Test constructing from a type that has a c_str() method only
+    struct string_with_c_str
+    {
+        constexpr PCWSTR c_str() const
+        {
+            return L"hello";
+        }
+    };
+    string_with_c_str fake_path{};
+    REQUIRE(wil::zwstring_view(fake_path) == L"hello");
 }


### PR DESCRIPTION
This fixes #446 and #363.

Resolves warnings about missing noexcept for methods that only operate in HRESULTs.

Adds conversion from `winrt::hstring` and `std::filesystem::path` to `wil::zwstring_view`.  Detects the presence of a `.c_str()` and `.size()` member on the incoming type, using them if present. C++20 Concepts would make this much nicer looking.