### PR TITLE
wil::WaitForDebuggerPresent only supports exceptional callers

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -668,28 +668,28 @@ namespace details
         {
             const auto fileName = lastSlash + 1;
             wil::unique_cotaskmem_string keyPath;
-            RETURN_IF_FAILED(wil::str_concat_nothrow<wil::unique_cotaskmem_string>(keyPath,
-                LR"(SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\)", fileName));
+            RETURN_IF_FAILED(wil::str_concat_nothrow<wil::unique_cotaskmem_string>(
+                keyPath, LR"(SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\)", fileName));
             DWORD value{}, sizeofValue = sizeof(value);
             if (::RegGetValueW(
-                HKEY_LOCAL_MACHINE,
-                keyPath.get(),
-                valueName,
+                    HKEY_LOCAL_MACHINE,
+                    keyPath.get(),
+                    valueName,
 #ifdef RRF_SUBKEY_WOW6464KEY
-                RRF_RT_REG_DWORD | RRF_SUBKEY_WOW6464KEY,
+                    RRF_RT_REG_DWORD | RRF_SUBKEY_WOW6464KEY,
 #else
-                RRF_RT_REG_DWORD,
+                    RRF_RT_REG_DWORD,
 #endif
-                nullptr,
-                &value,
-                &sizeofValue) == ERROR_SUCCESS)
+                    nullptr,
+                    &value,
+                    &sizeofValue) == ERROR_SUCCESS)
             {
                 *result = value;
             }
         }
         return S_OK;
     }
-}
+} // namespace details
 
 #ifdef WIL_ENABLE_EXCEPTIONS
 inline DWORD GetCurrentProcessExecutionOption(PCWSTR valueName, DWORD defaultValue = 0)
@@ -710,7 +710,6 @@ inline DWORD GetCurrentProcessExecutionOptionNoThrow(PCWSTR valueName, DWORD def
     }
     return result;
 }
-
 
 inline DWORD GetCurrentProcessExecutionOptionFailFast(PCWSTR valueName, DWORD defaultValue = 0)
 {
@@ -763,7 +762,7 @@ namespace details
             Sleep(500);
         }
     }
-}
+} // namespace details
 
 #ifdef WIL_ENABLE_EXCEPTIONS
 inline void WaitForDebuggerPresent(bool checkRegistryConfig = true)

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -739,11 +739,9 @@ namespace details
             DWORD configValue{1};
             if (checkRegistryConfig)
             {
-                DWORD registryConfigValue{};
                 // err_returncode_policy will continue running after this line on failure.  The default value of zero
                 // will apply in that case so we will still behave reasonably.
-                error_policy::HResult(details::GetCurrentProcessExecutionOptionNoThrow(L"WaitForDebuggerPresent", 0, &registryConfigValue));
-                configValue = registryConfigValue;
+                error_policy::HResult(details::GetCurrentProcessExecutionOptionNoThrow(L"WaitForDebuggerPresent", 0, &configValue));
             }
 
             if (configValue == 0)

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -4221,7 +4221,6 @@ TEST_CASE("WindowsInternalTests::ArgvToCommandLine", "[win32_helpers]")
 }
 #endif
 
-
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 TEST_CASE("wil::WaitForDebuggerPresent", "[win32_helpers]")
 {

--- a/tests/wiTest.cpp
+++ b/tests/wiTest.cpp
@@ -4221,4 +4221,16 @@ TEST_CASE("WindowsInternalTests::ArgvToCommandLine", "[win32_helpers]")
 }
 #endif
 
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+TEST_CASE("wil::WaitForDebuggerPresent", "[win32_helpers]")
+{
+#ifdef WIL_ENABLE_EXCEPTIONS
+    wil::WaitForDebuggerPresent();
+#endif // WIL_ENABLE_EXCEPTIONS
+    wil::WaitForDebuggerPresentFailFast();
+    wil::WaitForDebuggerPresentNoThrow();
+}
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+
 #pragma warning(pop)


### PR DESCRIPTION
## Why is this change being made?
I want to use WaitForDebuggerPresent from a component that compiles with exceptions disabled.  I was (unpleasantly) surprised that it is totally unusable without exceptions enabled.

## Briefly summarize what changed
`WaitForDebuggerPresent` and its dependency `GetCurrentProcessExecutionOption` now have throwing+failfasting+returning variants.  They are present outside the exception ifdef in this file.  The logic has been tweaked slightly so that the base methods are nothrow (GetCurrentProcessExecutionOption) or use a templated error policy (WaitForDebuggerPresent).  

## How was this change tested?
There are now some unit test cases.  Nobody sets the regkey for the test binary so it will always return immediately.  This provides coverage that all three variants compile without any build breaks.

I also used the debugger to insert fake failures and confirmed how all three variants behave.  The nothrow uses the default value (do not wait).  The failfast and throw variants do what they should too.

Ran init_all, build_all, and runtests.  Everything is green.  Clang-format was also run.