### PR TITLE
Add zwstring_view support for formatting, and fix bucketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Use "Build > Build All" to compile all targets.
 Microsoft's [CMake Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) make working
 in VSCode easy.
 
-1. Open the repo's folder in VS Code.
+1. Start a "Native Tools Command Prompt" (see below)
+1. Launch VS Code from the prompt, giving it the path to this repo (like `code c:\wil`)
 3. Use "CMake: Select Configure Preset" to pick `clang`, then "CMake: Select Build Preset" to pick `clang Debug`, then "CMake: Select Build Target" and pick `all`
 4. Use "CMake: Build" to compile all targets
 

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -403,7 +403,7 @@ namespace details_abi
         T* GetLocal(bool shouldAllocate = false) WI_NOEXCEPT
         {
             DWORD const threadId = ::GetCurrentThreadId();
-            size_t const index = (threadId % ARRAYSIZE(m_hashArray));
+            size_t const index = ((threadId >> 2) % ARRAYSIZE(m_hashArray));
             for (auto pNode = m_hashArray[index]; pNode != nullptr; pNode = pNode->pNext)
             {
                 if (pNode->threadId == threadId)

--- a/include/wil/result.h
+++ b/include/wil/result.h
@@ -403,7 +403,7 @@ namespace details_abi
         T* GetLocal(bool shouldAllocate = false) WI_NOEXCEPT
         {
             DWORD const threadId = ::GetCurrentThreadId();
-            size_t const index = ((threadId >> 2) % ARRAYSIZE(m_hashArray));
+            size_t const index = ((threadId >> 2) % ARRAYSIZE(m_hashArray)); // Reduce hash collisions; thread IDs are even.
             for (auto pNode = m_hashArray[index]; pNode != nullptr; pNode = pNode->pNext)
             {
                 if (pNode->threadId == threadId)

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -258,6 +258,13 @@ inline namespace literals
 
 } // namespace wil
 
+#if defined(_FORMAT_)
+template <typename TChar>
+struct std::formatter<wil::basic_zstring_view<TChar>, TChar> : std::formatter<std::basic_string_view<TChar>, TChar>
+{
+};
+#endif
+
 #endif // WIL_ENABLE_EXCEPTIONS
 
 #endif // __WIL_STL_INCLUDED

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -258,7 +258,8 @@ inline namespace literals
 
 } // namespace wil
 
-#if defined(_FORMAT_)
+#if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<format>, 1) // Assume present if C++20
+#include <format>
 template <typename TChar>
 struct std::formatter<wil::basic_zstring_view<TChar>, TChar> : std::formatter<std::basic_string_view<TChar>, TChar>
 {

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -1,11 +1,5 @@
 #include "pch.h"
 
-#include <wil/common.h>
-
-#if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<format>, 1) // Assume present if C++20
-#include <format>
-#endif
-
 #include <wil/stl.h>
 
 #include "common.h"

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -157,7 +157,7 @@ TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]")
     }
 }
 
-#if defined(__cpp_lib_format) && (__cpp_lib_format > 201907L)
+#if __cpp_lib_format >= 201907L
 
 TEST_CASE("StlTests::TestZStringView formatting", "[stl][zstring_view]")
 {

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -176,7 +176,7 @@ TEST_CASE("StlTests::TestZStringView formatting", "[stl][zstring_view]")
     }
 }
 
-#endif // __WI_LIBCPP_STD_VER >= 20
+#endif
 
 TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
 {

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -1,5 +1,11 @@
 #include "pch.h"
 
+#include <wil/common.h>
+
+#if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<format>, 1) // Assume present if C++20
+#include <format>
+#endif
+
 #include <wil/stl.h>
 
 #include "common.h"
@@ -150,6 +156,27 @@ TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]")
         REQUIRE(str[12] == '!');
     }
 }
+
+#if defined(__cpp_lib_format) && (__cpp_lib_format > 201907L)
+
+TEST_CASE("StlTests::TestZStringView formatting", "[stl][zstring_view]")
+{
+    SECTION("zstring_view can be used with std::format(wchar_t const*)")
+    {
+        auto str = L"kittens"_zv;
+        auto f = std::format(L"Hello {}", str);
+        REQUIRE(f == L"Hello kittens");
+    }
+
+    SECTION("zstring_view can be used with std::format(char const*)")
+    {
+        auto str = "kittens"_zv;
+        auto f = std::format("Hello {}", str);
+        REQUIRE(f == "Hello kittens");
+    }
+}
+
+#endif // __WI_LIBCPP_STD_VER >= 20
 
 TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
 {


### PR DESCRIPTION
Some loose livers on this...

Adds a std::formatter<> specialization for wil::zwstring_view.

Fixes thread local bucketing to use all the buckets instead of only even values.