### PR TITLE
Inline `winrt::get_module_lock` definition

### DIFF
--- a/include/wil/cppwinrt_notifiable_server_lock.h
+++ b/include/wil/cppwinrt_notifiable_server_lock.h
@@ -72,7 +72,7 @@ private:
 
 namespace winrt
 {
-auto& get_module_lock() noexcept
+inline auto& get_module_lock() noexcept
 {
     return wil::notifiable_server_lock::instance();
 }


### PR DESCRIPTION
Since the definition of `winrt::get_module_lock` has to come before any WinRT includes, there's currently no way to precompile WinRT headers while using notifiable_server_lock. Nothing can be processed before the pch.h include, and adding `wil/cppwinrt_notifiable_module_lock.h` to pch.h results in an ODR violation.

This PR solves the ODR violation by inlining `winrt::get_module_lock`, and since it's a a simple wrapper around another function call this doesn't change behavior.