### PR TITLE
 max_extended_path_length off by 1 fix

### DIFF
--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -147,10 +147,10 @@ constexpr size_t max_path_segment_length = 255;
 //! Character length not including the null, MAX_PATH (260) includes the null.
 constexpr size_t max_path_length = 259;
 
-//! 32743 Character length not including the null. This is a system defined limit.
-//! The 24 is for the expansion of the roots from "C:" to "\Device\HarddiskVolume4"
-//! It will be 25 when there are more than 9 disks.
-constexpr size_t max_extended_path_length = 0x7FFF - 24;
+//! 32744 Character length not including the null. This is a system defined limit.
+//! The 23 is for the expansion of the roots from "C:" to "\Device\HarddiskVolume4"
+//! It will be 24 when there are more than 9 disks.
+constexpr size_t max_extended_path_length = 0x7FFF - 23;
 
 //! For {guid} string form. Includes space for the null terminator.
 constexpr size_t guid_string_buffer_length = 39;


### PR DESCRIPTION
length of "\Device\HarddiskVolume4" is 23.

<details>
<summary>verification code</summary>

```cpp
#include <windows.h>
#include <winternl.h>
#include <wil/filesystem.h>
#include <wil/resource.h>
#include <wil/result.h>
#include <wil/win32_helpers.h>
#include <clocale>
#include <cstdio>
#include <memory>
#include <string>
#pragma comment(lib, "ntdll")

int main() try
{
	setlocale(LC_CTYPE, "");

	const auto root = wil::open_file(L"F:\\", FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, FILE_FLAG_BACKUP_SEMANTICS);
	const std::wstring d_name(wil::max_path_segment_length, L'd');
	wil::unique_hfile parent;
	OBJECT_ATTRIBUTES obj;
	UNICODE_STRING str;
	IO_STATUS_BLOCK iob;
	RtlInitUnicodeString(&str, d_name.c_str());
	InitializeObjectAttributes(&obj, &str, 0, root.get(), nullptr);
	for (;;)
	{
		wil::unique_hfile dir;
		if (NT_ERROR(NtCreateFile(&dir, FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, &obj, &iob, nullptr, FILE_ATTRIBUTE_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, FILE_OPEN_IF, FILE_DIRECTORY_FILE, nullptr, 0)))
		{
			break;
		}
		parent = std::move(dir);
		obj.RootDirectory = parent.get();
	}
	// In fact, can go up to 254 here.
	// However, if do that, finally NT pathname length will exceed USHRT_MAX, and UNICODE_STRING will be corrupted.
	const std::wstring f_name(231, L'f');
	RtlInitUnicodeString(&str, f_name.c_str());
	obj.ObjectName = &str;
	wil::unique_hfile file;
	THROW_IF_NTSTATUS_FAILED(NtCreateFile(&file, FILE_GENERIC_READ, &obj, &iob, nullptr, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, FILE_OPEN_IF, FILE_NON_DIRECTORY_FILE, nullptr, 0));
#if 0
	constexpr OBJECT_INFORMATION_CLASS ObjectNameInformation = static_cast<OBJECT_INFORMATION_CLASS>(1);
	struct OBJECT_NAME_INFORMATION
	{
		UNICODE_STRING          Name;
		WCHAR                   NameBuffer[ANYSIZE_ARRAY];
	};
	ULONG size;
	NtQueryObject(file.get(), ObjectNameInformation, nullptr, 0, &size);
	wil::unique_process_heap_ptr<OBJECT_NAME_INFORMATION> obj_name(THROW_IF_NULL_ALLOC(static_cast<OBJECT_NAME_INFORMATION*>(HeapAlloc(GetProcessHeap(), 0, size))));
	THROW_IF_NTSTATUS_FAILED(NtQueryObject(file.get(), ObjectNameInformation, obj_name.get(), size, &size));
	printf("%zu\n", wcslen(obj_name->NameBuffer));
#endif
	const auto path = std::make_unique_for_overwrite<WCHAR[]>(PATHCCH_MAX_CCH);
	THROW_LAST_ERROR_IF(!GetFinalPathNameByHandleW(file.get(), path.get(), PATHCCH_MAX_CCH, VOLUME_NAME_NT));
	printf("%zu\n", wcslen(path.get()));
	THROW_LAST_ERROR_IF(!GetFinalPathNameByHandleW(file.get(), path.get(), PATHCCH_MAX_CCH, VOLUME_NAME_NONE));
	printf("%zu\n", wcslen(path.get()));
}
catch (wil::ResultException e)
{
	puts(e.what());
}
```
</details>