### PR TITLE
Remove com_timeout::timed_out

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3417,7 +3417,7 @@ private:
         // There may not be an in-flight call to a marshaled COM function, so this may fail. We also don't synchronize
         // with other threads, so success/failure can't reliably be communicated to the thread that owns this object, so
         // we just ignore the result.
-        ::CoCancelCall(self->m_threadId, 0);
+        (void)::CoCancelCall(self->m_threadId, 0);
     }
 
     wil::unique_call<decltype(&details::CoDisableCallCancellationNull), details::CoDisableCallCancellationNull, false> m_ensureDisable{};

--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -3394,14 +3394,6 @@ public:
         }
     }
 
-    //! !IMPORTANT! This value is updated concurrently on a separate thread *after* cancellation is requested. Therefore, it is
-    //! not guaranteed that this value is up to date when read immediately after a cancelled call returns.
-    // TODO: This should **at the very least** be updated to use atomic reads and writes
-    bool timed_out() const
-    {
-        return m_timedOut;
-    }
-
     operator bool() const noexcept
     {
         // All construction calls must succeed to provide us with a non-null m_timer value.
@@ -3421,15 +3413,15 @@ private:
     {
         // The timer is waited upon during destruction so it is safe to rely on the this pointer in context.
         com_timeout_t* self = static_cast<com_timeout_t*>(context);
-        if (SUCCEEDED(CoCancelCall(self->m_threadId, 0)))
-        {
-            self->m_timedOut = true;
-        }
+
+        // There may not be an in-flight call to a marshaled COM function, so this may fail. We also don't synchronize
+        // with other threads, so success/failure can't reliably be communicated to the thread that owns this object, so
+        // we just ignore the result.
+        ::CoCancelCall(self->m_threadId, 0);
     }
 
     wil::unique_call<decltype(&details::CoDisableCallCancellationNull), details::CoDisableCallCancellationNull, false> m_ensureDisable{};
     DWORD m_threadId{};
-    bool m_timedOut{};
 
     // The threadpool timer goes last so that it destructs first, waiting until the timer callback has completed.
     wil::unique_threadpool_timer_nocancel m_timer;

--- a/tests/ComTests.cpp
+++ b/tests/ComTests.cpp
@@ -3217,19 +3217,16 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
     {
         wil::com_timeout_nothrow timeout{5000};
         REQUIRE(static_cast<bool>(timeout));
-        REQUIRE(!timeout.timed_out()); // NOTE: *Okay* usage since it should never be set to true
     }
     SECTION("Basic construction throwing")
     {
         wil::com_timeout timeout{5000};
         REQUIRE(static_cast<bool>(timeout));
-        REQUIRE(!timeout.timed_out()); // NOTE: *Okay* usage since it should never be set to true
     }
     SECTION("Basic construction failfast")
     {
         wil::com_timeout_failfast timeout{5000};
         REQUIRE(static_cast<bool>(timeout));
-        REQUIRE(!timeout.timed_out()); // NOTE: *Okay* usage since it should never be set to true
     }
     SECTION("RPC timeout test")
     {
@@ -3242,9 +3239,6 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
         wil::unique_hstring value;
         auto localServerResult = localServer->ToString(&value);
         REQUIRE(static_cast<bool>(localServerResult == RPC_E_CALL_CANCELED));
-        // TODO: This is currently incorrect usage since the internal boolean variable is not guaranteed to be set by the time we
-        // check its value. Hence why this is commented out for now
-        // REQUIRE(timeout.timed_out());
 
         sharedData->hangEvent.SetEvent();
 
@@ -3252,9 +3246,6 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
         // cancel and return.
         localServerResult = localServer->ToString(&value);
         REQUIRE(static_cast<bool>(localServerResult == RPC_E_CALL_CANCELED));
-        // TODO: This is currently incorrect usage since the internal boolean variable is not guaranteed to be set by the time we
-        // check its value. Hence why this is commented out for now
-        // REQUIRE(timeout.timed_out());
 
         sharedData->hangEvent.SetEvent();
 
@@ -3268,7 +3259,6 @@ TEST_CASE("com_timeout", "[com][com_timeout]")
         auto localServer = agileObj.query<ABI::Windows::Foundation::IStringable>();
         wil::unique_hstring value;
         REQUIRE_SUCCEEDED(localServer->ToString(&value));
-        REQUIRE(!timeout.timed_out()); // NOTE: *Okay* usage since it should never be set to true
         REQUIRE(std::wstring_view{L"COMTimeoutTestObject"} == WindowsGetStringRawBuffer(value.get(), nullptr));
     }
 }


### PR DESCRIPTION
There's two issues with the current implementation:
1. Access to the member boolean does not use atomic operations
2. The callback thread does not synchronize with consumers of the `com_timeout` type, so this boolean may not yet be set to `true` even if `CoCancelCall` succeeded.

Since there doesn't appear to be any current consumers, I'm just removing the method. Consumers should instead look at the returned `HRESULT` to figure out if the call was cancelled. 