### PR TITLE
Fix use-after-free bug in registry_watcher

### DIFF
--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -3132,7 +3132,8 @@ namespace details
         void ReleaseFromCallback(bool rearm)
         {
             auto lock = m_lock.lock_exclusive();
-            if (0 == ::InterlockedDecrement(&m_refCount))
+            auto refCount = ::InterlockedDecrement(&m_refCount);
+            if (0 == refCount)
             {
                 // Destroy the thread pool wait now to avoid the wait that would occur in the
                 // destructor. That wait would cause a deadlock since we are doing this from the callback.
@@ -3141,7 +3142,7 @@ namespace details
                 delete this;
                 // Sleep(1); // Enable for testing to find use after free bugs.
             }
-            else if (rearm && m_threadPoolWait.is_valid())
+            else if (rearm && refCount > 0)
             {
                 ::SetThreadpoolWait(m_threadPoolWait.get(), m_eventHandle.get(), nullptr);
             }


### PR DESCRIPTION
Fix the following scenario:

1. (Thread A) registry_watcher_t::callback() starts (before reaching TryAddRef), m_refCount = 1.
2. (Thread B) registry_watcher_state object is deleted (Release() method).
3. (Thread B) m_refCount is destroyed.
4. (Thread A) TryAddRef() is reached and accesses destroyed member m_refCount -> Use-after-free, UNDEFINED BEHAVIOR, can corrupt other members (which happened in production code using WIL).