### PR TITLE
feat: add support for 64-bit registry access in key_access enum

### DIFF
--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -112,7 +112,6 @@ namespace reg
             case key_access::readwrite64:
                 return KEY_ALL_ACCESS | KEY_WOW64_64KEY;
             }
-            }
             FAIL_FAST();
             RESULT_NORETURN_RESULT(0);
         }


### PR DESCRIPTION
This PR extends the key_access enum in registry_helpers.h to support 64-bit registry access. The following new values have been added:

- read64: Opens a key for reading from the 64-bit registry.
- readwrite64: Opens a key for reading and writing from the 64-bit registry.

Additionally, the get_access_flags function has been updated to handle these new enum values appropriately.