### PR TITLE
Fix registry_helpers.h compilation

### DIFF
--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -1960,4 +1960,3 @@ namespace reg
 } // namespace reg
 } // namespace wil
 #endif // __WIL_REGISTRY_HELPERS_INCLUDED
-


### PR DESCRIPTION
std::fill wasn't included, functional wasn't used
