### PR TITLE
Update the workflow for running clang-format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,20 +6,27 @@ on:
     types: [ created ]
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
-  run-clang-format:
+  # Job 1: Run formatting in sandbox with no write permissions
+  format-code:
     if: >
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '!run-clang-format') &&
       (
         github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.user.login == github.event.issue.user.login
+        github.event.comment.author_association == 'MEMBER'
       )
     runs-on: windows-latest
+    permissions:
+      pull-requests: read
+      contents: read
+
+    outputs:
+      pr-ref: ${{ steps.pr.outputs.ref }}
+      pr-sha: ${{ steps.pr.outputs.sha }}
+      has-changes: ${{ steps.check-changes.outputs.has-changes }}
 
     steps:
       - name: Get PR info
@@ -36,11 +43,16 @@ jobs:
             core.setOutput('sha', pr.data.head.sha);
             return pr.data.head.ref;
 
-      - name: Checkout PR branch
+      - name: Checkout base repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.ref }}
           fetch-depth: 0
+
+      - name: Fetch PR branch
+        shell: cmd
+        run: |
+          git fetch origin ${{ steps.pr.outputs.ref }}:pr-branch
+          git checkout pr-branch
 
       - name: Run clang-format
         id: format
@@ -50,31 +62,93 @@ jobs:
           ./scripts/call-vcvars.cmd x64
           ./scripts/run-clang-format.cmd origin/master
 
-      - name: Commit changes
-        id: commit
+      - name: Check for changes
+        id: check-changes
+        shell: cmd
+        run: |
+          git diff --quiet && echo has-changes=false >> %GITHUB_OUTPUT% || echo has-changes=true >> %GITHUB_OUTPUT%
+
+      - name: Create patch
+        if: steps.check-changes.outputs.has-changes == 'true'
+        shell: cmd
+        run: |
+          git diff > format-changes.patch
+
+      - name: Upload patch
+        if: steps.check-changes.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: format-patch
+          path: format-changes.patch
+          retention-days: 1
+
+  # Job 2: Apply changes with write permissions (runs trusted code only)
+  apply-changes:
+    needs: format-code
+    if: needs.format-code.outputs.has-changes == 'true'
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch PR branch
+        shell: cmd
+        run: |
+          git fetch origin ${{ needs.format-code.outputs.pr-ref }}:pr-branch
+          git checkout pr-branch
+
+      - name: Download patch
+        uses: actions/download-artifact@v4
+        with:
+          name: format-patch
+
+      - name: Apply patch
+        shell: cmd
+        run: |
+          git apply format-changes.patch
+
+      - name: Commit and push changes
         shell: cmd
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "Run clang-format on PR changes"
-          git push
+          git push origin pr-branch
 
+  # Job 3: Comment on PR with results
+  comment-result:
+    needs: [format-code, apply-changes]
+    if: always() && needs.format-code.result != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
       - name: Comment success
-        if: success()
+        if: needs.format-code.result == 'success' && (needs.apply-changes.result == 'success' || needs.format-code.outputs.has-changes == 'false')
         uses: actions/github-script@v7
         with:
           script: |
+            const hasChanges = '${{ needs.format-code.outputs.has-changes }}' === 'true';
+            const message = hasChanges 
+              ? '✅ clang-format completed successfully! Code formatting has been applied and committed to this PR.'
+              : '✅ clang-format completed successfully! No formatting changes were needed.';
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '✅ clang-format completed successfully! Code formatting has been applied and committed to this PR.'
+              body: message
             });
 
       - name: Comment failure
-        if: failure()
+        if: needs.format-code.result == 'failure' || needs.apply-changes.result == 'failure'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Since this type of action only runs off what's in master, I can't fully test this before committing... Hopefully Claude Sonnet did a good job this time. Specifically this:

* Updates scripts to preserve new lines instead of concatenating everything (yay YAML)
* Comments success/failure since previously there was no indication of it even running on the PR (depending on how slow this is, we may want a "started running" comment, but I'll hold off for now)
* Some other changes Claude felt were necessary and they seem reasonable...