### PR TITLE
More attempts to get the run-clang-format script working

### DIFF
--- a/include/wil/com.h
+++ b/include/wil/com.h
@@ -52,7 +52,7 @@ namespace details
     //          the added complexity.
     template <class TFrom, class TTo>
     struct is_com_convertible
-    : wistd::bool_constant<__is_convertible_to(TFrom, TTo) && (__is_abstract(TFrom) || wistd::is_same<TFrom, TTo>::value)>
+        : wistd::bool_constant<__is_convertible_to(TFrom, TTo) && (__is_abstract(TFrom) || wistd::is_same<TFrom, TTo>::value)>
     {
     };
 


### PR DESCRIPTION
Peeling the onion... Using `call` to invoke scripts (which I just forgot to do initially) and ensuring that the `has-changes` variable's value does not have any trailing space (idk if this is the issue, but it's consistent with my failure to test the workflow).