### PR TITLE
Yet another clang-format workflow fix

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           REM 'run-clang-format' script needs 'VCINSTALLDIR' env (among maybe others) to be set
           call ./scripts/call-vcvars.cmd x64
-          call ./scripts/run-clang-format.cmd origin/master
+          call ./scripts/format-changes.cmd origin/master
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
In this week's edition, the exit code of `git diff` is preserved and used as the exit code for the script, causing the step to fail