### PR TITLE
Fix incompatibility with C++14.

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -8322,7 +8322,7 @@ namespace details
     {
     };
 
-#ifdef __cpp_lib_scoped_lock
+#if __cpp_lib_scoped_lock >= 201703L
     template <typename TMutex>
     struct lock_proof_traits<std::scoped_lock<TMutex>> : exclusive_lock_proof
     {


### PR DESCRIPTION
`std::scoped_lock` is available in C++17. Using it without a feature guard causes compile errors on earlier C++ versions.

One affected case is the conda-forge distribution of the Azure SDK for C++.