### PR TITLE
Add SAL annotations to safecast.h helper methods

### DIFF
--- a/include/wil/safecast.h
+++ b/include/wil/safecast.h
@@ -265,6 +265,7 @@ namespace details
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast_failfast(const OldT var)
 {
     NewT newVar;
@@ -274,6 +275,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast_failfast(const OldT var)
 {
     NewT newVar;
@@ -283,6 +285,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast_failfast(const OldT var)
 {
     unsigned short newVar;
@@ -292,6 +295,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast_failfast(const OldT var)
 {
     return static_cast<NewT>(var);
@@ -300,6 +304,7 @@ NewT safe_cast_failfast(const OldT var)
 #ifdef WIL_ENABLE_EXCEPTIONS
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast(const OldT var)
 {
     NewT newVar;
@@ -309,6 +314,7 @@ NewT safe_cast(const OldT var)
 
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast(const OldT var)
 {
     NewT newVar;
@@ -318,6 +324,7 @@ NewT safe_cast(const OldT var)
 
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast(const OldT var)
 {
     unsigned short newVar;
@@ -327,6 +334,7 @@ NewT safe_cast(const OldT var)
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast(const OldT var)
 {
     return static_cast<NewT>(var);
@@ -335,6 +343,7 @@ NewT safe_cast(const OldT var)
 
 // This conversion is unsafe, therefore the two parameter version of safe_cast_nothrow must be used
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_v<NewT, OldT>, int> = 0>
+_Out_range_(==, _Param_(1))
 NewT safe_cast_nothrow(const OldT /*var*/)
 {
     static_assert(!wistd::is_same_v<NewT, NewT>, "This cast has the potential to fail, use the two parameter safe_cast_nothrow instead");
@@ -342,6 +351,7 @@ NewT safe_cast_nothrow(const OldT /*var*/)
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_cast_nothrow(const OldT var)
 {
     return static_cast<NewT>(var);
@@ -349,6 +359,7 @@ NewT safe_cast_nothrow(const OldT var)
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
+_At_(*newTResult, _Out_range_(==, var))
 HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<OldT, NewT>(var, newTResult);
@@ -356,6 +367,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
+_At_(*newTResult, _Out_range_(==, var))
 HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<unsigned short, NewT>(static_cast<unsigned short>(var), newTResult);
@@ -363,6 +375,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
+_At_(*newTResult, _Out_range_(==, var))
 HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<OldT, unsigned short>(var, reinterpret_cast<unsigned short*>(newTResult));
@@ -372,6 +385,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 // does not involve a variably sized type, then the compilation will fail and say the single parameter version
 // of safe_cast_nothrow should be used instead.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
+_At_(*newTResult, _Out_range_(==, var))
 HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     static_assert(
@@ -389,6 +403,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 //      wil::safe_zero_extending_cast<ULONG_PTR>(-1)
 // will return 0x00000000`FFFFFFFF on a 64-bit system.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_sign_extending_cast_v<NewT, OldT>, int> = 0>
+_Out_range_(==, var)
 NewT safe_zero_extending_cast(const OldT var)
 {
     // The first cast is to an unsigned type of the same size as the original.  The second cast is to the

--- a/include/wil/safecast.h
+++ b/include/wil/safecast.h
@@ -265,8 +265,7 @@ namespace details
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast_failfast(const OldT var)
+_Out_range_(==, var) NewT safe_cast_failfast(const OldT var)
 {
     NewT newVar;
     FAIL_FAST_IF_FAILED((details::intsafe_conversion<OldT, NewT>(var, &newVar)));
@@ -275,8 +274,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast_failfast(const OldT var)
+_Out_range_(==, var) NewT safe_cast_failfast(const OldT var)
 {
     NewT newVar;
     FAIL_FAST_IF_FAILED((details::intsafe_conversion<unsigned short, NewT>(static_cast<unsigned short>(var), &newVar)));
@@ -285,8 +283,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // Unsafe conversion where failure results in fail fast.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast_failfast(const OldT var)
+_Out_range_(==, var) NewT safe_cast_failfast(const OldT var)
 {
     unsigned short newVar;
     FAIL_FAST_IF_FAILED((details::intsafe_conversion<OldT, unsigned short>(var, &newVar)));
@@ -295,8 +292,7 @@ NewT safe_cast_failfast(const OldT var)
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast_failfast(const OldT var)
+_Out_range_(==, var) NewT safe_cast_failfast(const OldT var)
 {
     return static_cast<NewT>(var);
 }
@@ -304,8 +300,7 @@ NewT safe_cast_failfast(const OldT var)
 #ifdef WIL_ENABLE_EXCEPTIONS
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast(const OldT var)
+_Out_range_(==, var) NewT safe_cast(const OldT var)
 {
     NewT newVar;
     THROW_IF_FAILED((details::intsafe_conversion<OldT, NewT>(var, &newVar)));
@@ -314,8 +309,7 @@ NewT safe_cast(const OldT var)
 
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast(const OldT var)
+_Out_range_(==, var) NewT safe_cast(const OldT var)
 {
     NewT newVar;
     THROW_IF_FAILED((details::intsafe_conversion<unsigned short, NewT>(static_cast<unsigned short>(var), &newVar)));
@@ -324,8 +318,7 @@ NewT safe_cast(const OldT var)
 
 // Unsafe conversion where failure results in a thrown exception.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast(const OldT var)
+_Out_range_(==, var) NewT safe_cast(const OldT var)
 {
     unsigned short newVar;
     THROW_IF_FAILED((details::intsafe_conversion<OldT, unsigned short>(var, &newVar)));
@@ -334,8 +327,7 @@ NewT safe_cast(const OldT var)
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast(const OldT var)
+_Out_range_(==, var) NewT safe_cast(const OldT var)
 {
     return static_cast<NewT>(var);
 }
@@ -343,40 +335,35 @@ NewT safe_cast(const OldT var)
 
 // This conversion is unsafe, therefore the two parameter version of safe_cast_nothrow must be used
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_v<NewT, OldT>, int> = 0>
-_Out_range_(==, _Param_(1))
-NewT safe_cast_nothrow(const OldT /*var*/)
+_Out_range_(==, _Param_(1)) NewT safe_cast_nothrow(const OldT /*var*/)
 {
     static_assert(!wistd::is_same_v<NewT, NewT>, "This cast has the potential to fail, use the two parameter safe_cast_nothrow instead");
 }
 
 // This conversion is always safe, therefore a static_cast is fine.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_cast_nothrow(const OldT var)
+_Out_range_(==, var) NewT safe_cast_nothrow(const OldT var)
 {
     return static_cast<NewT>(var);
 }
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_no_wchar_v<NewT, OldT>, int> = 0>
-_At_(*newTResult, _Out_range_(==, var))
-HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
+_At_(*newTResult, _Out_range_(==, var)) HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<OldT, NewT>(var, newTResult);
 }
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_from_wchar_v<NewT, OldT>, int> = 0>
-_At_(*newTResult, _Out_range_(==, var))
-HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
+_At_(*newTResult, _Out_range_(==, var)) HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<unsigned short, NewT>(static_cast<unsigned short>(var), newTResult);
 }
 
 // Unsafe conversion where an HRESULT is returned. It is up to the callee to check and handle the HRESULT
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_unsafe_cast_to_wchar_v<NewT, OldT>, int> = 0>
-_At_(*newTResult, _Out_range_(==, var))
-HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
+_At_(*newTResult, _Out_range_(==, var)) HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     return details::intsafe_conversion<OldT, unsigned short>(var, reinterpret_cast<unsigned short*>(newTResult));
 }
@@ -385,8 +372,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 // does not involve a variably sized type, then the compilation will fail and say the single parameter version
 // of safe_cast_nothrow should be used instead.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_supported_safe_static_cast_v<NewT, OldT>, int> = 0>
-_At_(*newTResult, _Out_range_(==, var))
-HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
+_At_(*newTResult, _Out_range_(==, var)) HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 {
     static_assert(
         details::is_potentially_variably_sized_cast_v<OldT, NewT>,
@@ -403,8 +389,7 @@ HRESULT safe_cast_nothrow(const OldT var, NewT* newTResult)
 //      wil::safe_zero_extending_cast<ULONG_PTR>(-1)
 // will return 0x00000000`FFFFFFFF on a 64-bit system.
 template <typename NewT, typename OldT, wistd::enable_if_t<details::is_sign_extending_cast_v<NewT, OldT>, int> = 0>
-_Out_range_(==, var)
-NewT safe_zero_extending_cast(const OldT var)
+_Out_range_(==, var) NewT safe_zero_extending_cast(const OldT var)
 {
     // The first cast is to an unsigned type of the same size as the original.  The second cast is to the
     // larger type.  Being an unsigned cast, the upper bits are zeroed out.


### PR DESCRIPTION
## Why is this change being made?
After adding some usage of these helpers in the OS we received a static analysis bug that was a false positive.  The underlying problem is that these methods lack annotations on the result so the static analysis tooling had to assume the worst.

## Briefly summarize what changed
Add SAL annotations so that static analysis understands that upon success the input and output values are unchanged.

## How was this change tested?
As part of the OS.  This is a port to GitHub after the fact.