### PR TITLE
Avoid Fail fast for registry key path not found during watcher re-arm

### DIFF
--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -3234,6 +3234,8 @@ private:
                 break;
 
             case ERROR_KEY_DELETED:
+            case ERROR_FILE_NOT_FOUND:
+            case ERROR_PATH_NOT_FOUND:
                 // Key deleted, send RegistryChangeKind::Delete, do not re-arm.
                 watcherState->m_callback(RegistryChangeKind::Delete);
                 watcherState->ReleaseFromCallback(false);


### PR DESCRIPTION
During a watcher re-arm attempt after key is deleted, applications using AppV layer, try to recreate the delted registry from cache and often fail with ERROR_FILE_NOT_FOUND, thus cauing wil callback to failfast and crash the user application