### PR TITLE
Suppress PREfast false positive (C28167) for RAII lock wrappers

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -22,6 +22,7 @@
 
 #pragma warning(push)
 #pragma warning(disable : 26135 26110) // Missing locking annotation, Caller failing to hold lock
+#pragma warning(disable : 28167) // Prevent false positive by PREfast checker due to inability to detect unlocking in C++ destructors
 #pragma warning(disable : 4714)        // __forceinline not honored
 #pragma warning(disable : 4820)        // padding added after data member
 


### PR DESCRIPTION
PREfast warning C28167 ("The function changes the lock state and does not restore it") fires as a false positive on RAII-based locking patterns in resource.h. PREfast's interprocedural analysis cannot track that the lock is released inside a C++ destructor, causing it to incorrectly report that callers of WIL lock guards leave locks in an inconsistent state.

This change adds C28167 to the existing #pragma warning(disable ...) block that already suppresses the related C26135 and C26110 warnings for the same reason.

Testing:
Verified that the suppression eliminates the false-positive PREfast diagnostics without masking any real lock-state issues. No functional behavior changes.