### PR TITLE
Fix set_value template deduction for smart string types

### DIFF
--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -1016,7 +1016,7 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<const ::std::wstring>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<::std::wstring>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }
@@ -1035,13 +1035,13 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<const BSTR>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<BSTR>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }
 
             template <>
-            constexpr DWORD set_value_type<const ::wil::unique_bstr>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<::wil::unique_bstr>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }
@@ -1056,7 +1056,7 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<const ::wil::shared_bstr>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<::wil::shared_bstr>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }
@@ -1070,7 +1070,7 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<const ::wil::unique_cotaskmem_string>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<::wil::unique_cotaskmem_string>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }
@@ -1084,7 +1084,7 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<const ::wil::shared_cotaskmem_string>() WI_NOEXCEPT
+            constexpr DWORD set_value_type<::wil::shared_cotaskmem_string>() WI_NOEXCEPT
             {
                 return REG_SZ;
             }

--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -925,10 +925,17 @@ namespace reg
                 static_assert(!wistd::is_same_v<T, T>, "Unsupported type for get_value_type");
             }
 
-            template <typename T = void>
-            DWORD set_value_type() WI_NOEXCEPT
+            template <typename T>
+            struct set_value_type_t
             {
                 static_assert(!wistd::is_same_v<T, T>, "Unsupported type for set_value_type");
+            };
+
+            // Applies remove_cv_t so callers don't have to strip cv-qualifiers from the deduced type
+            template <typename T = void>
+            constexpr DWORD set_value_type() WI_NOEXCEPT
+            {
+                return set_value_type_t<wistd::remove_cv_t<T>>::value;
             }
 
             template <>
@@ -937,10 +944,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_DWORD);
             }
             template <>
-            constexpr DWORD set_value_type<int32_t>() WI_NOEXCEPT
+            struct set_value_type_t<int32_t>
             {
-                return REG_DWORD;
-            }
+                static constexpr DWORD value = REG_DWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<uint32_t>() WI_NOEXCEPT
@@ -948,10 +955,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_DWORD);
             }
             template <>
-            constexpr DWORD set_value_type<uint32_t>() WI_NOEXCEPT
+            struct set_value_type_t<uint32_t>
             {
-                return REG_DWORD;
-            }
+                static constexpr DWORD value = REG_DWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<long>() WI_NOEXCEPT
@@ -959,10 +966,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_DWORD);
             }
             template <>
-            constexpr DWORD set_value_type<long>() WI_NOEXCEPT
+            struct set_value_type_t<long>
             {
-                return REG_DWORD;
-            }
+                static constexpr DWORD value = REG_DWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<unsigned long>() WI_NOEXCEPT
@@ -970,10 +977,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_DWORD);
             }
             template <>
-            constexpr DWORD set_value_type<unsigned long>() WI_NOEXCEPT
+            struct set_value_type_t<unsigned long>
             {
-                return REG_DWORD;
-            }
+                static constexpr DWORD value = REG_DWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<int64_t>() WI_NOEXCEPT
@@ -981,10 +988,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_QWORD);
             }
             template <>
-            constexpr DWORD set_value_type<int64_t>() WI_NOEXCEPT
+            struct set_value_type_t<int64_t>
             {
-                return REG_QWORD;
-            }
+                static constexpr DWORD value = REG_QWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<uint64_t>() WI_NOEXCEPT
@@ -992,10 +999,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_QWORD);
             }
             template <>
-            constexpr DWORD set_value_type<uint64_t>() WI_NOEXCEPT
+            struct set_value_type_t<uint64_t>
             {
-                return REG_QWORD;
-            }
+                static constexpr DWORD value = REG_QWORD;
+            };
 
             template <>
             constexpr DWORD get_value_type<PCWSTR>() WI_NOEXCEPT
@@ -1003,10 +1010,10 @@ namespace reg
                 return get_value_flags_from_value_type(REG_SZ);
             }
             template <>
-            constexpr DWORD set_value_type<PCWSTR>() WI_NOEXCEPT
+            struct set_value_type_t<PCWSTR>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 
 #if (WIL_USE_STL && defined(WIL_ENABLE_EXCEPTIONS)) || defined(WIL_DOXYGEN)
             template <>
@@ -1016,10 +1023,10 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<::std::wstring>() WI_NOEXCEPT
+            struct set_value_type_t<::std::wstring>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 #endif
 
 #if defined(__WIL_OLEAUTO_H_)
@@ -1035,16 +1042,16 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<BSTR>() WI_NOEXCEPT
+            struct set_value_type_t<BSTR>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 
             template <>
-            constexpr DWORD set_value_type<::wil::unique_bstr>() WI_NOEXCEPT
+            struct set_value_type_t<::wil::unique_bstr>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 #endif // #if defined(__WIL_OLEAUTO_H_)
 
 #if defined(__WIL_OLEAUTO_H_STL)
@@ -1056,10 +1063,10 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<::wil::shared_bstr>() WI_NOEXCEPT
+            struct set_value_type_t<::wil::shared_bstr>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 #endif // #if defined(__WIL_OLEAUTO_H_STL)
 
 #if defined(__WIL_OBJBASE_H_)
@@ -1070,10 +1077,10 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<::wil::unique_cotaskmem_string>() WI_NOEXCEPT
+            struct set_value_type_t<::wil::unique_cotaskmem_string>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 #endif // defined(__WIL_OBJBASE_H_)
 
 #if defined(__WIL_OBJBASE_H_STL)
@@ -1084,10 +1091,10 @@ namespace reg
             }
 
             template <>
-            constexpr DWORD set_value_type<::wil::shared_cotaskmem_string>() WI_NOEXCEPT
+            struct set_value_type_t<::wil::shared_cotaskmem_string>
             {
-                return REG_SZ;
-            }
+                static constexpr DWORD value = REG_SZ;
+            };
 #endif // #if defined(__WIL_OBJBASE_H_STL)
         } // namespace reg_value_type_info
 

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -2349,6 +2349,43 @@ TEST_CASE("BasicRegistryTests::string types", "[registry]")
 #endif
     }
 
+    SECTION("strings set_value with std::wstring lvalue: with opened key")
+    {
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite));
+
+        // verify non-const std::wstring lvalue works with set_value (issue #624)
+        std::wstring stringValue{L"wstring lvalue test"};
+        wil::reg::set_value(hkey.get(), stringValueName, stringValue);
+        auto result = wil::reg::get_value<std::wstring>(hkey.get(), stringValueName);
+        REQUIRE(result == stringValue);
+
+        // verify const std::wstring lvalue also works
+        const std::wstring constStringValue{L"const wstring test"};
+        wil::reg::set_value(hkey.get(), stringValueName, constStringValue);
+        result = wil::reg::get_value<std::wstring>(hkey.get(), stringValueName);
+        REQUIRE(result == constStringValue);
+
+        // verify empty std::wstring
+        std::wstring emptyValue;
+        wil::reg::set_value(hkey.get(), stringValueName, emptyValue);
+        result = wil::reg::get_value<std::wstring>(hkey.get(), stringValueName);
+        REQUIRE(result.empty());
+    }
+
+    SECTION("strings set_value with std::wstring lvalue: with string key")
+    {
+        std::wstring stringValue{L"wstring lvalue subkey test"};
+        wil::reg::set_value(HKEY_CURRENT_USER, testSubkey, stringValueName, stringValue);
+        auto result = wil::reg::get_value<std::wstring>(HKEY_CURRENT_USER, testSubkey, stringValueName);
+        REQUIRE(result == stringValue);
+
+        const std::wstring constStringValue{L"const wstring subkey test"};
+        wil::reg::set_value(HKEY_CURRENT_USER, testSubkey, stringValueName, constStringValue);
+        result = wil::reg::get_value<std::wstring>(HKEY_CURRENT_USER, testSubkey, stringValueName);
+        REQUIRE(result == constStringValue);
+    }
+
 #if defined(__cpp_lib_optional)
     SECTION("strings set_value_string/try_get_value_string: with open key")
     {


### PR DESCRIPTION
`set_value_type<>` specializations for `std::wstring`, `BSTR`, `unique_bstr`, `shared_bstr`, `unique_cotaskmem_string`, and `shared_cotaskmem_string` incorrectly used const-qualified template parameters (e.g. `set_value_type<const std::wstring>`).

Since `reg_view_t::set_value` deduces `R` from `const R& value`, the template parameter `R` is always the non-const type. This caused a `static_assert` failure (`Unsupported type for set_value_type`) when calling `set_value` with any of these types:

\\\cpp
std::wstring value{L"Hello"};
wil::reg::set_value(hkey, L"MyValue", value); // static_assert failure
\\\

The fix removes the `const` qualifier from all six affected specializations so the deduced type matches.

Tests added for `std::wstring` lvalues (non-const, const, and empty) with both opened-key and string-key overloads.

Fixes #624