### PR TITLE
Add make_bstr*(std::wstring_view)

### DIFF
--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -23,8 +23,8 @@
 #pragma warning(push)
 #pragma warning(disable : 26135 26110) // Missing locking annotation, Caller failing to hold lock
 #pragma warning(disable : 28167) // Prevent false positive by PREfast checker due to inability to detect unlocking in C++ destructors
-#pragma warning(disable : 4714) // __forceinline not honored
-#pragma warning(disable : 4820) // padding added after data member
+#pragma warning(disable : 4714)  // __forceinline not honored
+#pragma warning(disable : 4820)  // padding added after data member
 
 #ifndef __WIL_RESOURCE
 #define __WIL_RESOURCE

--- a/include/wil/resource.h
+++ b/include/wil/resource.h
@@ -23,8 +23,8 @@
 #pragma warning(push)
 #pragma warning(disable : 26135 26110) // Missing locking annotation, Caller failing to hold lock
 #pragma warning(disable : 28167) // Prevent false positive by PREfast checker due to inability to detect unlocking in C++ destructors
-#pragma warning(disable : 4714)        // __forceinline not honored
-#pragma warning(disable : 4820)        // padding added after data member
+#pragma warning(disable : 4714) // __forceinline not honored
+#pragma warning(disable : 4820) // padding added after data member
 
 #ifndef __WIL_RESOURCE
 #define __WIL_RESOURCE

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -132,6 +132,28 @@ inline PCWSTR str_raw_ptr(const std::wstring& str)
     return str.c_str();
 }
 
+#if defined(__WIL_OLEAUTO_H_)
+#if defined(_STRING_VIEW_) || defined(__cpp_lib_string_view)
+// Create wil::unique_bstr from std::wstring_view (regardless if not null terminated, or if it contains embedded nulls)
+inline wil::unique_bstr make_bstr_nothrow(std::wstring_view source) noexcept
+{
+    return wil::unique_bstr(::SysAllocStringLen(source.data(), static_cast<UINT>(source.size())));
+}
+inline wil::unique_bstr make_bstr_failfast(std::wstring_view source) noexcept
+{
+    return wil::unique_bstr(FAIL_FAST_IF_NULL_ALLOC(::SysAllocStringLen(source.data(), static_cast<UINT>(source.size()))));
+}
+#ifdef WIL_ENABLE_EXCEPTIONS
+inline wil::unique_bstr make_bstr(std::wstring_view source)
+{
+    wil::unique_bstr result(make_bstr_nothrow(source));
+    THROW_IF_NULL_ALLOC(result);
+    return result;
+}
+#endif // WIL_ENABLE_EXCEPTIONS
+#endif // defined(_STRING_VIEW_) || defined(__cpp_lib_string_view)
+#endif // defined(__WIL_OLEAUTO_H_)
+
 #if __cpp_lib_string_view >= 201606L
 
 /**

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -132,16 +132,23 @@ inline PCWSTR str_raw_ptr(const std::wstring& str)
     return str.c_str();
 }
 
+#if __cpp_lib_string_view >= 201606L
+
 #if defined(__WIL_OLEAUTO_H_)
-#if defined(_STRING_VIEW_) || defined(__cpp_lib_string_view)
 // Create wil::unique_bstr from std::wstring_view (regardless if not null terminated, or if it contains embedded nulls)
 inline wil::unique_bstr make_bstr_nothrow(std::wstring_view source) noexcept
 {
+    if (source.size() > 0xffffffffUL /*UINT32_MAX*/)
+    {
+        return wil::unique_bstr{};
+    }
     return wil::unique_bstr(::SysAllocStringLen(source.data(), static_cast<UINT>(source.size())));
 }
 inline wil::unique_bstr make_bstr_failfast(std::wstring_view source) noexcept
 {
-    return wil::unique_bstr(FAIL_FAST_IF_NULL_ALLOC(::SysAllocStringLen(source.data(), static_cast<UINT>(source.size()))));
+    auto result(make_bstr_nothrow(source));
+    FAIL_FAST_IF_NULL_ALLOC(result);
+    return result;
 }
 #ifdef WIL_ENABLE_EXCEPTIONS
 inline wil::unique_bstr make_bstr(std::wstring_view source)
@@ -151,10 +158,7 @@ inline wil::unique_bstr make_bstr(std::wstring_view source)
     return result;
 }
 #endif // WIL_ENABLE_EXCEPTIONS
-#endif // defined(_STRING_VIEW_) || defined(__cpp_lib_string_view)
 #endif // defined(__WIL_OLEAUTO_H_)
-
-#if __cpp_lib_string_view >= 201606L
 
 /**
     zstring_view. A zstring_view is identical to a std::string_view except it is always nul-terminated (unless empty).

--- a/include/wil/wistd_type_traits.h
+++ b/include/wil/wistd_type_traits.h
@@ -1573,7 +1573,9 @@ struct wi_is_convertible
                    (is_same<typename remove_cv<_T1>::type, typename remove_cv<typename remove_reference<_T2>::type>::type>::value ||
                     is_base_of<typename remove_reference<_T2>::type, _T1>::value))
 #endif
-          >{};
+          >
+{
+};
 
 template <class _T1, class _T2>
 struct wi_is_convertible<_T1, _T2, 0, 1> : public false_type

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -68,7 +68,6 @@ TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 {
     std::string_view stlStringView_empty;
     const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
-    REQUIRE(bstrEmpty.data() == nullptr);
     REQUIRE(bstrEmpty.get() == nullptr);
 
     std::string_view stlStringView_fromLiteral{L"abc"};

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -72,8 +72,6 @@ TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 
     std::string_view stlStringView_fromLiteral{L"abc"};
     const wil::unique_bstr bstrFromLiteral{wil::make_bstr_nothrow(stlStringView_fromLiteral)};
-    REQUIRE(!bstrFromLiteral.empty());
-    REQUIRE(bstrFromLiteral.data() != nullptr);
     REQUIRE(bstrFromLiteral.get() != nullptr);
     REQUIRE(wcslen(bstrFromLiteral.get()) == 3);
     REQUIRE(CompareStringOrdinal(bstrFromLiteral.get(), -1, L"abc", -1, FALSE) == CSTR_EQUAL);

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -67,13 +67,13 @@ struct CustomNoncopyableString
 TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 {
     std::string_view stlStringView_empty;
-    const wil::unique_bstr bstrEmpty{ wil::make_bstr_nothrow(stlStringView_empty) };
+    const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
     REQUIRE(bstrEmpty.empty());
     REQUIRE(bstrEmpty.data() == nullptr);
     REQUIRE(bstrEmpty.get() == nullptr);
 
-    std::string_view stlStringView_fromLiteral{ L"abc" };
-    const wil::unique_bstr bstrFromLiteral{ wil::make_bstr_nothrow(stlStringView_fromLiteral) };
+    std::string_view stlStringView_fromLiteral{L"abc"};
+    const wil::unique_bstr bstrFromLiteral{wil::make_bstr_nothrow(stlStringView_fromLiteral)};
     REQUIRE(!bstrFromLiteral.empty());
     REQUIRE(bstrFromLiteral.data() != nullptr);
     REQUIRE(bstrFromLiteral.get() != nullptr);

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -64,6 +64,23 @@ struct CustomNoncopyableString
     }
 };
 
+TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
+{
+    std::string_view stlStringView_empty;
+    const wil::unique_bstr bstrEmpty{ wil::make_bstr_nothrow(stlStringView_empty) };
+    REQUIRE(bstrEmpty.empty());
+    REQUIRE(bstrEmpty.data() == nullptr);
+    REQUIRE(bstrEmpty.get() == nullptr);
+
+    std::string_view stlStringView_fromLiteral{ L"abc" };
+    const wil::unique_bstr bstrFromLiteral{ wil::make_bstr_nothrow(stlStringView_fromLiteral) };
+    REQUIRE(!bstrFromLiteral.empty());
+    REQUIRE(bstrFromLiteral.data() != nullptr);
+    REQUIRE(bstrFromLiteral.get() != nullptr);
+    REQUIRE(wcslen(bstrFromLiteral.get()) == 3);
+    REQUIRE(CompareStringOrdinal(bstrFromLiteral.get(), -1, L"abc", -1, FALSE) == CSTR_EQUAL);
+};
+
 TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 {
     // Test empty cases

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -66,7 +66,7 @@ struct CustomNoncopyableString
 
 TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 {
-    std::string_view stlStringView_empty;
+    std::wstring_view stlStringView_empty;
     const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
     REQUIRE(bstrEmpty.get() == nullptr);
 

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
     const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
     REQUIRE(bstrEmpty.get() == nullptr);
 
-    std::string_view stlStringView_fromLiteral{L"abc"};
+    std::wstring_view stlStringView_fromLiteral{L"abc"};
     const wil::unique_bstr bstrFromLiteral{wil::make_bstr_nothrow(stlStringView_fromLiteral)};
     REQUIRE(bstrFromLiteral.get() != nullptr);
     REQUIRE(wcslen(bstrFromLiteral.get()) == 3);

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -68,7 +68,6 @@ TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 {
     std::string_view stlStringView_empty;
     const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
-    REQUIRE(bstrEmpty.empty());
     REQUIRE(bstrEmpty.data() == nullptr);
     REQUIRE(bstrEmpty.get() == nullptr);
 

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -68,7 +68,8 @@ TEST_CASE("StlTests::TestBstrAllocator", "[stl][bstr][string_view]")
 {
     std::wstring_view stlStringView_empty;
     const wil::unique_bstr bstrEmpty{wil::make_bstr_nothrow(stlStringView_empty)};
-    REQUIRE(bstrEmpty.get() == nullptr);
+    REQUIRE(bstrEmpty.get() != nullptr);
+    REQUIRE(wcslen(bstrEmpty.get()) == 0);
 
     std::wstring_view stlStringView_fromLiteral{L"abc"};
     const wil::unique_bstr bstrFromLiteral{wil::make_bstr_nothrow(stlStringView_fromLiteral)};


### PR DESCRIPTION
WIL only provides only PCWSTR overloads:

* make_bstr_nothrow(PCWSTR source)
* make_bstr_failfast(PCWSTR source)
* inline wil::unique_bstr make_bstr(PCWSTR source);

This PR adds `wstring_view` overloads calling `SysAllocStringLen` with the view's data and size directly, correctly handling non-null-terminated string views

* make_bstr_nothrow(std::wstring_view source)
* make_bstr_failfast(std::wstring_view source)
* make_bstr(std::wstring_view source)

This works for non-null-terminated views (substrings, slices), avoids unnecessary and dangerous wcslen walk (we know the wstring_view's length), and is a strict superset of the existing API.

NOTE: A `PCWSTR` implicitly converts to `wstring_view`, so these new overloads could replace the existing ones once C++17 is the floor. WIL still supports older standards, so these additional overloads is safer.