### PR TITLE
Add registry delete_value and delete_tree helpers

### DIFF
--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -169,6 +169,92 @@ namespace reg
     }
 #endif // #define __WIL_WINREG_STL
 
+#if defined(WIL_ENABLE_EXCEPTIONS)
+    /**
+     * @brief Deletes the specified value from under an open or well-known registry key - see RegDeleteKeyValueW
+     * @param key An open or well-known registry key
+     * @param subKey The name of the subkey to append to `key`.
+     *        If `nullptr`, then the value is deleted from `key` directly.
+     * @param value_name The name of the registry value to delete.
+     *        Can be nullptr to delete the unnamed default registry value.
+     * @exception std::exception (including wil::ResultException) will be thrown on all failures
+     */
+    inline void delete_value(HKEY key, _In_opt_ PCWSTR subKey, _In_opt_ PCWSTR value_name)
+    {
+        const reg_view_details::reg_view regview{key};
+        regview.delete_value(subKey, value_name);
+    }
+
+    /**
+     * @brief Deletes the specified value from under an open or well-known registry key - see RegDeleteValueW
+     * @param key An open or well-known registry key
+     * @param value_name The name of the registry value to delete.
+     *        Can be nullptr to delete the unnamed default registry value.
+     * @exception std::exception (including wil::ResultException) will be thrown on all failures
+     */
+    inline void delete_value(HKEY key, _In_opt_ PCWSTR value_name)
+    {
+        const reg_view_details::reg_view regview{key};
+        regview.delete_value(value_name);
+    }
+
+    /**
+     * @brief Recursively deletes the specified subkey, its values, and all of its descendant subkeys - see RegDeleteTreeW
+     * @param key An open or well-known registry key
+     * @param subKey The name of the subkey to delete (relative to `key`).
+     *        If `nullptr`, then the subkeys and values of `key` are deleted, but `key` itself is not.
+     * @remark Succeeds (does nothing) if the specified subkey does not exist - see wil::reg::is_registry_not_found
+     * @exception std::exception (including wil::ResultException) will be thrown on all failures
+     */
+    inline void delete_tree(HKEY key, _In_opt_ PCWSTR subKey)
+    {
+        const reg_view_details::reg_view regview{key};
+        regview.delete_tree(subKey);
+    }
+#endif // #if defined(WIL_ENABLE_EXCEPTIONS)
+
+    /**
+     * @brief Deletes the specified value from under an open or well-known registry key - see RegDeleteKeyValueW
+     * @param key An open or well-known registry key
+     * @param subKey The name of the subkey to append to `key`.
+     *        If `nullptr`, then the value is deleted from `key` directly.
+     * @param value_name The name of the registry value to delete.
+     *        Can be nullptr to delete the unnamed default registry value.
+     * @return HRESULT error code indicating success or failure (does not throw C++ exceptions)
+     */
+    inline HRESULT delete_value_nothrow(HKEY key, _In_opt_ PCWSTR subKey, _In_opt_ PCWSTR value_name) WI_NOEXCEPT
+    {
+        const reg_view_details::reg_view_nothrow regview{key};
+        return regview.delete_value(subKey, value_name);
+    }
+
+    /**
+     * @brief Deletes the specified value from under an open or well-known registry key - see RegDeleteValueW
+     * @param key An open or well-known registry key
+     * @param value_name The name of the registry value to delete.
+     *        Can be nullptr to delete the unnamed default registry value.
+     * @return HRESULT error code indicating success or failure (does not throw C++ exceptions)
+     */
+    inline HRESULT delete_value_nothrow(HKEY key, _In_opt_ PCWSTR value_name) WI_NOEXCEPT
+    {
+        const reg_view_details::reg_view_nothrow regview{key};
+        return regview.delete_value(value_name);
+    }
+
+    /**
+     * @brief Recursively deletes the specified subkey, its values, and all of its descendant subkeys - see RegDeleteTreeW
+     * @param key An open or well-known registry key
+     * @param subKey The name of the subkey to delete (relative to `key`).
+     *        If `nullptr`, then the subkeys and values of `key` are deleted, but `key` itself is not.
+     * @remark Succeeds (does nothing) if the specified subkey does not exist - see wil::reg::is_registry_not_found
+     * @return HRESULT error code indicating success or failure (does not throw C++ exceptions)
+     */
+    inline HRESULT delete_tree_nothrow(HKEY key, _In_opt_ PCWSTR subKey) WI_NOEXCEPT
+    {
+        const reg_view_details::reg_view_nothrow regview{key};
+        return regview.delete_tree(subKey);
+    }
+
     //
     //  wil::key_iterator and wil::value_iterator objects enable enumerating registry keys and values.
     //

--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -1140,6 +1140,11 @@ namespace reg
                 return err_policy::HResult(HRESULT_FROM_WIN32(::RegDeleteValueW(m_key, value_name)));
             }
 
+            typename err_policy::result delete_value(_In_opt_ PCWSTR subKey, _In_opt_ PCWSTR value_name) const
+            {
+                return err_policy::HResult(HRESULT_FROM_WIN32(::RegDeleteKeyValueW(m_key, subKey, value_name)));
+            }
+
             template <typename R>
             typename err_policy::result get_value(
                 _In_opt_ PCWSTR subkey, _In_opt_ PCWSTR value_name, R& return_value, DWORD type = reg_value_type_info::get_value_type<R>()) const

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -1328,6 +1328,83 @@ using ThrowingTypesToTest = std::tuple<DwordFns, GenericDwordFns, QwordFns, Gene
 #endif // defined(WIL_ENABLE_EXCEPTIONS)
 } // namespace
 
+TEST_CASE("BasicRegistryTests::delete_value_and_tree", "[registry]")
+{
+    const auto deleteHr = HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, testSubkey));
+    if (deleteHr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+    {
+        REQUIRE_SUCCEEDED(deleteHr);
+    }
+
+    SECTION("delete_value_nothrow: from an open key")
+    {
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite));
+        REQUIRE_SUCCEEDED(wil::reg::set_value_dword_nothrow(hkey.get(), dwordValueName, test_dword_two));
+
+        DWORD result{};
+        REQUIRE_SUCCEEDED(wil::reg::get_value_dword_nothrow(hkey.get(), dwordValueName, &result));
+        REQUIRE(result == test_dword_two);
+
+        REQUIRE_SUCCEEDED(wil::reg::delete_value_nothrow(hkey.get(), dwordValueName));
+        // the value should now be gone
+        REQUIRE(wil::reg::get_value_dword_nothrow(hkey.get(), dwordValueName, &result) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+        // deleting a value that doesn't exist returns not-found
+        REQUIRE(wil::reg::delete_value_nothrow(hkey.get(), dwordValueName) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+    }
+
+    SECTION("delete_value_nothrow: via subkey path")
+    {
+        REQUIRE_SUCCEEDED(wil::reg::set_value_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, test_dword_two));
+
+        DWORD result{};
+        REQUIRE_SUCCEEDED(wil::reg::get_value_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, &result));
+        REQUIRE(result == test_dword_two);
+
+        REQUIRE_SUCCEEDED(wil::reg::delete_value_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName));
+        REQUIRE(
+            wil::reg::get_value_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, &result) ==
+            HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+    }
+
+    SECTION("delete_tree_nothrow: removes subkeys and values")
+    {
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite));
+        wil::unique_hkey subkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(hkey.get(), L"child", subkey, wil::reg::key_access::readwrite));
+        REQUIRE_SUCCEEDED(wil::reg::set_value_dword_nothrow(subkey.get(), dwordValueName, test_dword_two));
+
+        REQUIRE_SUCCEEDED(wil::reg::delete_tree_nothrow(HKEY_CURRENT_USER, testSubkey));
+        wil::unique_hkey opened;
+        REQUIRE(wil::reg::open_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, opened) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+
+        // deleting a tree that doesn't exist succeeds (is_registry_not_found is swallowed)
+        REQUIRE_SUCCEEDED(wil::reg::delete_tree_nothrow(HKEY_CURRENT_USER, testSubkey));
+    }
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    SECTION("delete_value/delete_tree: throwing variants")
+    {
+        wil::unique_hkey hkey{wil::reg::create_unique_key(HKEY_CURRENT_USER, testSubkey, wil::reg::key_access::readwrite)};
+        wil::reg::set_value_dword(hkey.get(), dwordValueName, test_dword_two);
+        wil::reg::set_value_dword(HKEY_CURRENT_USER, testSubkey, stringValueName, test_dword_three);
+
+        wil::reg::delete_value(hkey.get(), dwordValueName);
+        REQUIRE(!wil::reg::try_get_value_dword(hkey.get(), dwordValueName).has_value());
+
+        wil::reg::delete_value(HKEY_CURRENT_USER, testSubkey, stringValueName);
+        REQUIRE(!wil::reg::try_get_value_dword(HKEY_CURRENT_USER, testSubkey, stringValueName).has_value());
+
+        wil::reg::delete_tree(HKEY_CURRENT_USER, testSubkey);
+        wil::unique_hkey opened;
+        REQUIRE(wil::reg::open_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, opened) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+        // deleting a non-existent tree does not throw
+        wil::reg::delete_tree(HKEY_CURRENT_USER, testSubkey);
+    }
+#endif
+}
+
 TEMPLATE_LIST_TEST_CASE("BasicRegistryTests::simple types typed nothrow gets/sets", "[registry]", NoThrowTypesToTest)
 {
     const auto deleteHr = HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, testSubkey));


### PR DESCRIPTION
Adds `wil::reg::delete_value[_nothrow]` (RegDeleteValueW + RegDeleteKeyValueW subkey overloads) and `delete_tree[_nothrow]` (RegDeleteTreeW, swallowing not-found). Includes Catch2 `[registry]` tests passing in normal & noexcept configs. Part of enabling WSL to drop its in-house registry helper in favor of wil::reg.