### PR TITLE
Add key_options/key_disposition support to create_*_key helpers

### DIFF
--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -55,14 +55,22 @@ namespace reg
      * @param subKey The name of a subkey that this function opens or creates.
      *        Note: this cannot be null (see the above referenced API documentation)
      * @param access The requested access desired for the opened key
+     * @param options Controls whether the created key is volatile - see wil::reg::key_options
+     * @param[out] disposition Optionally receives whether the key was newly created or an existing key was opened.
+     *        Only written on success - see wil::reg::key_disposition
      * @return A wil::unique_hkey or wil::shared_hkey containing the resulting opened HKEY
      * @exception std::exception (including wil::ResultException) will be thrown on all failures
      */
-    inline ::wil::unique_hkey create_unique_key(HKEY key, PCWSTR subKey, ::wil::reg::key_access access = ::wil::reg::key_access::read)
+    inline ::wil::unique_hkey create_unique_key(
+        HKEY key,
+        PCWSTR subKey,
+        ::wil::reg::key_access access = ::wil::reg::key_access::read,
+        ::wil::reg::key_options options = ::wil::reg::key_options::non_volatile,
+        _Out_opt_ ::wil::reg::key_disposition* disposition = nullptr)
     {
         const reg_view_details::reg_view regview{key};
         ::wil::unique_hkey return_value;
-        regview.create_key(subKey, &return_value, access);
+        regview.create_key(subKey, &return_value, access, options, disposition);
         return return_value;
     }
 
@@ -90,14 +98,22 @@ namespace reg
      * @param subKey The name of a subkey that this function opens or creates.
      *        Note: this cannot be null (see the above referenced API documentation)
      * @param access The requested access desired for the opened key
+     * @param options Controls whether the created key is volatile - see wil::reg::key_options
+     * @param[out] disposition Optionally receives whether the key was newly created or an existing key was opened.
+     *        Only written on success - see wil::reg::key_disposition
      * @return A wil::shared_hkey or wil::shared_hkey containing the resulting opened HKEY
      * @exception std::exception (including wil::ResultException) will be thrown on all failures
      */
-    inline ::wil::shared_hkey create_shared_key(HKEY key, PCWSTR subKey, ::wil::reg::key_access access = ::wil::reg::key_access::read)
+    inline ::wil::shared_hkey create_shared_key(
+        HKEY key,
+        PCWSTR subKey,
+        ::wil::reg::key_access access = ::wil::reg::key_access::read,
+        ::wil::reg::key_options options = ::wil::reg::key_options::non_volatile,
+        _Out_opt_ ::wil::reg::key_disposition* disposition = nullptr)
     {
         const reg_view_details::reg_view regview{key};
         ::wil::shared_hkey return_value;
-        regview.create_key(subKey, &return_value, access);
+        regview.create_key(subKey, &return_value, access, options, disposition);
         return return_value;
     }
 #endif // #if defined(__WIL_WINREG_STL)
@@ -126,13 +142,21 @@ namespace reg
      *        Note: this cannot be null (see the above referenced API documentation)
      * @param[out] hkey A reference to a wil::unique_hkey to receive the opened HKEY
      * @param access The requested access desired for the opened key
+     * @param options Controls whether the created key is volatile - see wil::reg::key_options
+     * @param[out] disposition Optionally receives whether the key was newly created or an existing key was opened.
+     *        Only written on success - see wil::reg::key_disposition
      * @return HRESULT error code indicating success or failure (does not throw C++ exceptions)
      */
     inline HRESULT create_unique_key_nothrow(
-        HKEY key, PCWSTR subKey, ::wil::unique_hkey& hkey, ::wil::reg::key_access access = ::wil::reg::key_access::read) WI_NOEXCEPT
+        HKEY key,
+        PCWSTR subKey,
+        ::wil::unique_hkey& hkey,
+        ::wil::reg::key_access access = ::wil::reg::key_access::read,
+        ::wil::reg::key_options options = ::wil::reg::key_options::non_volatile,
+        _Out_opt_ ::wil::reg::key_disposition* disposition = nullptr) WI_NOEXCEPT
     {
         const reg_view_details::reg_view_nothrow regview{key};
-        return regview.create_key(subKey, hkey.put(), access);
+        return regview.create_key(subKey, hkey.put(), access, options, disposition);
     }
 
 #if defined(__WIL_WINREG_STL) || defined(WIL_DOXYGEN)
@@ -162,10 +186,15 @@ namespace reg
      * @return HRESULT error code indicating success or failure (does not throw C++ exceptions)
      */
     inline HRESULT create_shared_key_nothrow(
-        HKEY key, PCWSTR subKey, ::wil::shared_hkey& hkey, ::wil::reg::key_access access = ::wil::reg::key_access::read) WI_NOEXCEPT
+        HKEY key,
+        PCWSTR subKey,
+        ::wil::shared_hkey& hkey,
+        ::wil::reg::key_access access = ::wil::reg::key_access::read,
+        ::wil::reg::key_options options = ::wil::reg::key_options::non_volatile,
+        _Out_opt_ ::wil::reg::key_disposition* disposition = nullptr) WI_NOEXCEPT
     {
         const reg_view_details::reg_view_nothrow regview{key};
-        return regview.create_key(subKey, hkey.put(), access);
+        return regview.create_key(subKey, hkey.put(), access, options, disposition);
     }
 #endif // #define __WIL_WINREG_STL
 

--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -84,6 +84,27 @@ namespace reg
         readwrite64,
     };
 
+    // Options controlling how a key is created. See the dwOptions parameter of RegCreateKeyExW.
+    enum class key_options : DWORD
+    {
+        // The key is preserved when the system is restarted (REG_OPTION_NON_VOLATILE).
+        non_volatile = REG_OPTION_NON_VOLATILE,
+
+        // The key is not preserved when the system is restarted (REG_OPTION_VOLATILE).
+        is_volatile = REG_OPTION_VOLATILE,
+    };
+
+    // Indicates whether a created key was newly created or an existing key was opened. See the lpdwDisposition
+    // out-parameter of RegCreateKeyExW.
+    enum class key_disposition
+    {
+        // The key did not exist and was created (REG_CREATED_NEW_KEY).
+        created_new,
+
+        // The key existed and was opened without being changed (REG_OPENED_EXISTING_KEY).
+        opened_existing,
+    };
+
     /// @cond
     namespace reg_view_details
     {
@@ -128,6 +149,11 @@ namespace reg
             }
             FAIL_FAST();
             RESULT_NORETURN_RESULT(0);
+        }
+
+        constexpr DWORD get_options_flags(key_options options) WI_NOEXCEPT
+        {
+            return static_cast<DWORD>(options);
         }
 
         /**
@@ -1112,17 +1138,36 @@ namespace reg
                     HRESULT_FROM_WIN32(::RegOpenKeyExW(m_key, subKey, zero_options, get_access_flags(access), hkey)));
             }
 
-            typename err_policy::result create_key(PCWSTR subKey, _Out_ HKEY* hkey, ::wil::reg::key_access access = ::wil::reg::key_access::read) const
+            typename err_policy::result create_key(
+                PCWSTR subKey,
+                _Out_ HKEY* hkey,
+                ::wil::reg::key_access access = ::wil::reg::key_access::read,
+                ::wil::reg::key_options options = ::wil::reg::key_options::non_volatile,
+                _Out_opt_ ::wil::reg::key_disposition* disposition = nullptr) const
             {
                 *hkey = nullptr;
 
                 constexpr DWORD zero_reserved{0};
                 constexpr PWSTR null_class{nullptr};
-                constexpr DWORD zero_options{0};
                 constexpr SECURITY_ATTRIBUTES* null_security_attributes{nullptr};
-                DWORD disposition{0};
-                return err_policy::HResult(HRESULT_FROM_WIN32(::RegCreateKeyExW(
-                    m_key, subKey, zero_reserved, null_class, zero_options, get_access_flags(access), null_security_attributes, hkey, &disposition)));
+                DWORD local_disposition{0};
+                const auto hr = HRESULT_FROM_WIN32(
+                    ::RegCreateKeyExW(
+                        m_key,
+                        subKey,
+                        zero_reserved,
+                        null_class,
+                        get_options_flags(options),
+                        get_access_flags(access),
+                        null_security_attributes,
+                        hkey,
+                        &local_disposition));
+                if (disposition && SUCCEEDED(hr))
+                {
+                    *disposition = (local_disposition == REG_CREATED_NEW_KEY) ? ::wil::reg::key_disposition::created_new
+                                                                              : ::wil::reg::key_disposition::opened_existing;
+                }
+                return err_policy::HResult(hr);
             }
 
             typename err_policy::result delete_tree(_In_opt_ PCWSTR sub_key) const

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -6539,3 +6539,65 @@ TEST_CASE("BasicRegistryTests::key_heap_string_nothrow_iterator", "[registry]")
         REQUIRE(test_iterator == test_end_iterator);
     }
 }
+
+TEST_CASE("BasicRegistryTests::create_key_options_disposition", "[registry]")
+{
+    const auto deleteHr = HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, testSubkey));
+    if (deleteHr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+    {
+        REQUIRE_SUCCEEDED(deleteHr);
+    }
+
+    SECTION("create_unique_key_nothrow: disposition reports created vs opened")
+    {
+        wil::unique_hkey hkey;
+        auto disposition = wil::reg::key_disposition::opened_existing;
+        REQUIRE_SUCCEEDED(
+            wil::reg::create_unique_key_nothrow(
+                HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite, wil::reg::key_options::non_volatile, &disposition));
+        REQUIRE(disposition == wil::reg::key_disposition::created_new);
+
+        wil::unique_hkey hkey2;
+        disposition = wil::reg::key_disposition::created_new;
+        REQUIRE_SUCCEEDED(
+            wil::reg::create_unique_key_nothrow(
+                HKEY_CURRENT_USER, testSubkey, hkey2, wil::reg::key_access::readwrite, wil::reg::key_options::non_volatile, &disposition));
+        REQUIRE(disposition == wil::reg::key_disposition::opened_existing);
+    }
+
+    SECTION("create_unique_key_nothrow: volatile key is usable")
+    {
+        wil::unique_hkey hkey;
+        auto disposition = wil::reg::key_disposition::opened_existing;
+        REQUIRE_SUCCEEDED(
+            wil::reg::create_unique_key_nothrow(
+                HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite, wil::reg::key_options::is_volatile, &disposition));
+        REQUIRE(disposition == wil::reg::key_disposition::created_new);
+
+        REQUIRE_SUCCEEDED(wil::reg::set_value_dword_nothrow(hkey.get(), dwordValueName, test_dword_two));
+        DWORD result{};
+        REQUIRE_SUCCEEDED(wil::reg::get_value_dword_nothrow(hkey.get(), dwordValueName, &result));
+        REQUIRE(result == test_dword_two);
+    }
+
+    SECTION("create_unique_key_nothrow: defaults remain backward compatible")
+    {
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite));
+        REQUIRE(hkey.get() != nullptr);
+    }
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    SECTION("create_unique_key: throwing variant with disposition")
+    {
+        auto disposition = wil::reg::key_disposition::opened_existing;
+        const wil::unique_hkey hkey{wil::reg::create_unique_key(
+            HKEY_CURRENT_USER, testSubkey, wil::reg::key_access::readwrite, wil::reg::key_options::non_volatile, &disposition)};
+        REQUIRE(disposition == wil::reg::key_disposition::created_new);
+
+        const wil::unique_hkey hkey2{wil::reg::create_unique_key(
+            HKEY_CURRENT_USER, testSubkey, wil::reg::key_access::readwrite, wil::reg::key_options::non_volatile, &disposition)};
+        REQUIRE(disposition == wil::reg::key_disposition::opened_existing);
+    }
+#endif
+}


### PR DESCRIPTION
Adds `key_options` (volatile) and `key_disposition` (created vs opened-existing) support to the `create_*_key[_nothrow]` helpers. Includes Catch2 `[registry]` tests passing in normal & noexcept configs. Part of enabling WSL to drop its in-house registry helper in favor of wil::reg.