### PR TITLE
Accept raw REGSAM access masks in open/create key helpers

### DIFF
--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -63,26 +63,29 @@ namespace reg
     }
 
     // Access rights for opening registry keys. See https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-key-security-and-access-rights.
-    enum class key_access
+    // The named values map directly to their corresponding REGSAM access masks, so callers who need an access right not
+    // covered by a named value can supply a raw mask directly, for example key_access{KEY_QUERY_VALUE | KEY_SET_VALUE}.
+    enum class key_access : DWORD
     {
-        // Open key for reading.
-        read,
+        // Open key for reading. Equivalent to KEY_READ.
+        read = KEY_READ,
 
         // Open key for writing. Equivalent to KEY_WRITE.
-        write,
+        write = KEY_WRITE,
 
         // Open key for reading and writing. Equivalent to KEY_ALL_ACCESS.
-        readwrite,
+        readwrite = KEY_ALL_ACCESS,
 
-        // Open key for reading from 64-bit registry.
-        read64,
+        // Open key for reading from 64-bit registry. Equivalent to KEY_READ | KEY_WOW64_64KEY.
+        read64 = KEY_READ | KEY_WOW64_64KEY,
 
         // Open key for writing from 64-bit registry. Equivalent to KEY_WRITE | KEY_WOW64_64KEY.
-        write64,
+        write64 = KEY_WRITE | KEY_WOW64_64KEY,
 
-        // Open key for reading and writing from 64-bit registry. Equivalent to KEY_ALL_ACCESS.
-        readwrite64,
+        // Open key for reading and writing from 64-bit registry. Equivalent to KEY_ALL_ACCESS | KEY_WOW64_64KEY.
+        readwrite64 = KEY_ALL_ACCESS | KEY_WOW64_64KEY,
     };
+    DEFINE_ENUM_FLAG_OPERATORS(key_access);
 
     /// @cond
     namespace reg_view_details
@@ -111,23 +114,7 @@ namespace reg
 
         constexpr DWORD get_access_flags(key_access access) WI_NOEXCEPT
         {
-            switch (access)
-            {
-            case key_access::read:
-                return KEY_READ;
-            case key_access::write:
-                return KEY_WRITE;
-            case key_access::readwrite:
-                return KEY_ALL_ACCESS;
-            case key_access::read64:
-                return KEY_READ | KEY_WOW64_64KEY;
-            case key_access::write64:
-                return KEY_WRITE | KEY_WOW64_64KEY;
-            case key_access::readwrite64:
-                return KEY_ALL_ACCESS | KEY_WOW64_64KEY;
-            }
-            FAIL_FAST();
-            RESULT_NORETURN_RESULT(0);
+            return static_cast<DWORD>(access);
         }
 
         /**

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -6539,3 +6539,55 @@ TEST_CASE("BasicRegistryTests::key_heap_string_nothrow_iterator", "[registry]")
         REQUIRE(test_iterator == test_end_iterator);
     }
 }
+
+TEST_CASE("BasicRegistryTests::raw_regsam_access", "[registry]")
+{
+    const auto deleteHr = HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, testSubkey));
+    if (deleteHr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+    {
+        REQUIRE_SUCCEEDED(deleteHr);
+    }
+
+    // key_access values map directly to their REGSAM masks, and arbitrary masks can be composed with the flag operators.
+    static_assert(static_cast<DWORD>(wil::reg::key_access::read) == KEY_READ, "read must map to KEY_READ");
+    static_assert(static_cast<DWORD>(wil::reg::key_access::write) == KEY_WRITE, "write must map to KEY_WRITE");
+    static_assert(static_cast<DWORD>(wil::reg::key_access::readwrite) == KEY_ALL_ACCESS, "readwrite must map to KEY_ALL_ACCESS");
+    static_assert(static_cast<DWORD>(wil::reg::key_access::read64) == (KEY_READ | KEY_WOW64_64KEY), "read64 must map to KEY_READ | KEY_WOW64_64KEY");
+    static_assert(
+        static_cast<DWORD>(wil::reg::key_access::read | wil::reg::key_access::write) == (KEY_READ | KEY_WRITE),
+        "key_access values must combine with the bitwise OR operator");
+
+    SECTION("create/open with a raw REGSAM mask")
+    {
+        // create with an explicit mask that has no named key_access value
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(
+            wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access{KEY_QUERY_VALUE | KEY_SET_VALUE}));
+        REQUIRE_SUCCEEDED(wil::reg::set_value_dword_nothrow(hkey.get(), dwordValueName, test_dword_two));
+
+        // open with KEY_QUERY_VALUE only - reading works, writing is denied
+        wil::unique_hkey readonly;
+        REQUIRE_SUCCEEDED(
+            wil::reg::open_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, readonly, wil::reg::key_access{KEY_QUERY_VALUE}));
+        DWORD result{};
+        REQUIRE_SUCCEEDED(wil::reg::get_value_dword_nothrow(readonly.get(), dwordValueName, &result));
+        REQUIRE(result == test_dword_two);
+        REQUIRE(wil::reg::set_value_dword_nothrow(readonly.get(), dwordValueName, test_dword_three) == E_ACCESSDENIED);
+    }
+
+    SECTION("named key_access values still work")
+    {
+        wil::unique_hkey hkey;
+        REQUIRE_SUCCEEDED(wil::reg::create_unique_key_nothrow(HKEY_CURRENT_USER, testSubkey, hkey, wil::reg::key_access::readwrite));
+        REQUIRE(hkey.get() != nullptr);
+    }
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    SECTION("throwing open with a raw REGSAM mask")
+    {
+        wil::reg::set_value_dword(HKEY_CURRENT_USER, testSubkey, dwordValueName, test_dword_two);
+        const wil::unique_hkey readonly{wil::reg::open_unique_key(HKEY_CURRENT_USER, testSubkey, wil::reg::key_access{KEY_QUERY_VALUE})};
+        REQUIRE(wil::reg::get_value_dword(readonly.get(), dwordValueName) == test_dword_two);
+    }
+#endif
+}


### PR DESCRIPTION
Adds an `access_mask` type accepted by the open/create key helpers, implicitly constructible from `key_access` or a raw REGSAM, so callers can pass custom access rights. Includes Catch2 `[registry]` tests (and compile-time static_asserts) passing in normal & noexcept configs. Part of enabling WSL to drop its in-house registry helper in favor of wil::reg.