### PR TITLE
Fix error path on non-throw registry iterator construction

### DIFF
--- a/include/wil/registry_helpers.h
+++ b/include/wil/registry_helpers.h
@@ -1878,6 +1878,11 @@ namespace reg
                 m_data.m_index = 0;
                 m_last_error = m_data.enumerate_current_index();
             }
+
+            if (FAILED(m_last_error))
+            {
+                m_data.make_end_iterator();
+            }
         }
 
         iterator_nothrow_t(const iterator_nothrow_t&) WI_NOEXCEPT = default;

--- a/tests/RegistryTests.cpp
+++ b/tests/RegistryTests.cpp
@@ -5546,6 +5546,13 @@ TEST_CASE("BasicRegistryTests::value_bstr_nothrow_iterator", "[registry]")
         REQUIRE(manual_iterator->at_end());
         REQUIRE(count == 4);
     }
+
+    SECTION("value_bstr_nothrow_iterator with invalid handle")
+    {
+        auto test_iterator = wil::reg::value_bstr_nothrow_iterator{(HKEY)INVALID_HANDLE_VALUE};
+        auto test_end_iterator = wil::reg::value_bstr_nothrow_iterator{};
+        REQUIRE(test_iterator == test_end_iterator);
+    }
 }
 
 TEST_CASE("BasicRegistryTests::key_bstr_nothrow_iterator", "[registry]")
@@ -5833,6 +5840,13 @@ TEST_CASE("BasicRegistryTests::key_bstr_nothrow_iterator", "[registry]")
         REQUIRE_SUCCEEDED(manual_iterator.last_error());
         REQUIRE_SUCCEEDED(manual_iterator.last_error());
         REQUIRE(count == 4);
+    }
+
+    SECTION("key_bstr_nothrow_iterator with invalid handle")
+    {
+        auto test_iterator = wil::reg::key_bstr_nothrow_iterator{(HKEY)INVALID_HANDLE_VALUE};
+        auto test_end_iterator = wil::reg::key_bstr_nothrow_iterator{};
+        REQUIRE(test_iterator == test_end_iterator);
     }
 }
 #endif
@@ -6148,6 +6162,13 @@ TEST_CASE("BasicRegistryTests::value_heap_string_nothrow_iterator", "[registry]"
         REQUIRE(manual_iterator->at_end());
         REQUIRE(count == 4);
     }
+
+    SECTION("value_heap_string_nothrow_iterator with invalid handle")
+    {
+        auto test_iterator = wil::reg::value_heap_string_nothrow_iterator{(HKEY)INVALID_HANDLE_VALUE};
+        auto test_end_iterator = wil::reg::value_heap_string_nothrow_iterator{};
+        REQUIRE(test_iterator == test_end_iterator);
+    }
 }
 
 TEST_CASE("BasicRegistryTests::key_heap_string_nothrow_iterator", "[registry]")
@@ -6432,5 +6453,12 @@ TEST_CASE("BasicRegistryTests::key_heap_string_nothrow_iterator", "[registry]")
         REQUIRE_SUCCEEDED(manual_iterator.last_error());
         REQUIRE_SUCCEEDED(manual_iterator.last_error());
         REQUIRE(count == 4);
+    }
+
+    SECTION("key_heap_string_nothrow_iterator with invalid handle")
+    {
+        auto test_iterator = wil::reg::key_heap_string_nothrow_iterator{(HKEY)INVALID_HANDLE_VALUE};
+        auto test_end_iterator = wil::reg::key_heap_string_nothrow_iterator{};
+        REQUIRE(test_iterator == test_end_iterator);
     }
 }


### PR DESCRIPTION
I'm pretty sure the behaviour I described on #645 is a bug. So this PR should fix it.