### PR TITLE
Add `_bstr` user-defined literal for BSTR-shaped wide strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,12 @@ There are a few different ways to format your code:
 
 > **Important!** Git integration with `clang-format` is only available through the LLVM distribution.
 You can install LLVM through their [GibHub releases page](https://github.com/llvm/llvm-project/releases), via `winget install llvm.llvm`, or through the package manager of your choice.
+The `clang-format.exe` that ships with Visual Studio does **not** include the `git-clang-format` wrapper, so a separate LLVM install is required for the `git` integration.
+Make sure the LLVM `bin` directory (e.g., `C:\Program Files\LLVM\bin`) is on your `PATH`; otherwise `git clang-format` fails with `git: 'clang-format' is not a git command`.
 
 > **Important!** The use of `git clang-format` additionally requires Python to be installed and available on your `PATH`.
+The `git-clang-format` script specifically invokes `python3`, so an executable named `python3` (not just `python`) must be resolvable on your `PATH`.
+On Windows, also disable the Microsoft Store `python3` App Execution Alias (Settings > Apps > Advanced app settings > App execution aliases) so that `python3` resolves to your real Python installation.
 
 The simplest way to format just your changes is to use `clang-format`'s `git` integration.
 You have the option to do this continuously as you make changes, or at the very end when you're ready to submit a PR.

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -272,7 +272,7 @@ inline namespace literals
         }
 
         static const std::size_t byte_size = N * sizeof(wchar_t); // includes the trailing L'\0'
-        static const std::size_t length = N - 1; // excludes the trailing L'\0'
+        static const std::size_t length = N - 1;                  // excludes the trailing L'\0'
     };
 
     template <std::size_t N>
@@ -285,9 +285,7 @@ inline namespace literals
         unsigned long m_byte_length;
         wchar_t m_data[N];
 
-        constexpr bstr_literal_t(const wchar_literal_storage<N>& text) WI_NOEXCEPT :
-            m_byte_length(text.byte_size - sizeof(wchar_t)),
-            m_data{}
+        constexpr bstr_literal_t(const wchar_literal_storage<N>& text) WI_NOEXCEPT : m_byte_length(text.byte_size - sizeof(wchar_t)), m_data{}
         {
             static_assert(sizeof(m_byte_length) == 4, "BSTR size must be 32 bits");
             static_assert(offsetof(bstr_literal_t, m_data) == sizeof(m_byte_length), "BSTR data must immediately follow the length prefix");
@@ -312,7 +310,7 @@ inline namespace literals
     {
         return {str, len};
     }
- 
+
     constexpr zwstring_view operator""_zv(const wchar_t* str, std::size_t len) noexcept
     {
         return {str, len};

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -250,24 +250,12 @@ inline auto str_raw_ptr(basic_zstring_view<TChar> str)
     return str.c_str();
 }
 
-inline namespace literals
+namespace details
 {
-#if __WI_LIBCPP_STD_VER >= 20
-    /**
-        A statically-allocated, BSTR-shaped literal: a length-prefixed wide string whose data pointer is a valid
-        BSTR (usable with SysStringLen, SysStringByteLen, wcslen). No heap allocation; size is the literal's exact
-        length. Lifetime is tied to the literal object itself.
-
-        Example:
-            void Use(BSTR);
-            Use(L"foo"_bstr);
-    */
     template <std::size_t N>
     struct wchar_literal_storage
     {
-        static const std::size_t byte_size = N * sizeof(wchar_t); // includes the trailing L'\0'
-        static const std::size_t length = N - 1;                  // excludes the trailing L'\0'
-        uint32_t m_byte_length = static_cast<uint32_t>(byte_size - sizeof(wchar_t));
+        static constexpr const std::size_t size = N;
         wchar_t value[N];
         constexpr wchar_literal_storage(const wchar_t (&str)[N]) WI_NOEXCEPT
         {
@@ -277,15 +265,35 @@ inline namespace literals
 
     template <std::size_t N>
     wchar_literal_storage(const wchar_t (&)[N]) -> wchar_literal_storage<N>;
+}
 
-    template <wchar_literal_storage Lit>
+inline namespace literals
+{
+#if __WI_LIBCPP_STD_VER >= 20
+    template<wil::details::wchar_literal_storage Str> struct bstr_storage_t
+    {
+        uint32_t sizeBytes = static_cast<uint32_t>((Str.size - 1) * sizeof(wchar_t));
+        decltype(Str) string{Str};
+    };
+
+    /**
+        A statically-allocated, BSTR-shaped literal: a length-prefixed wide string whose data pointer is a valid
+        BSTR (usable with SysStringLen, SysStringByteLen, wcslen). No heap allocation; size is the literal's exact
+        length. Lifetime is tied to the literal object itself.
+
+        Example:
+            void Use(BSTR);
+            Use(L"foo"_bstr);
+    */
+    template <wil::details::wchar_literal_storage Lit>
     WI_NODISCARD constexpr auto operator""_bstr() WI_NOEXCEPT
     {
-        static_assert(sizeof(Lit.m_byte_length) == 4);
-        static_assert(offsetof(decltype(Lit), m_byte_length) == 0);
-        static_assert(offsetof(decltype(Lit), value) == sizeof(uint32_t));
-
-        return const_cast<wchar_t*>(Lit.value);
+        constexpr static const bstr_storage_t<Lit> storage{};
+        static_assert(sizeof(storage.sizeBytes) == 4);
+        static_assert(offsetof(decltype(storage), sizeBytes) == 0);
+        static_assert(offsetof(decltype(storage), string) == sizeof(uint32_t));
+        static_assert(offsetof(decltype(storage), string.value) == sizeof(uint32_t));
+        return const_cast<wchar_t*>(storage.string.value);
     }
 
 #endif // __WI_LIBCPP_STD_VER >= 20

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -252,11 +252,67 @@ inline auto str_raw_ptr(basic_zstring_view<TChar> str)
 
 inline namespace literals
 {
+#if __WI_LIBCPP_STD_VER >= 20
+    /**
+        A statically-allocated, BSTR-shaped literal: a length-prefixed wide string whose data pointer is a valid
+        BSTR (usable with SysStringLen, SysStringByteLen, wcslen). No heap allocation; size is the literal's exact
+        length. Lifetime is tied to the literal object itself.
+
+        Example:
+            void Use(BSTR);
+            Use(L"foo"_bst);
+    */
+    template <std::size_t N>
+    struct wchar_literal_storage
+    {
+        wchar_t value[N];
+        constexpr wchar_literal_storage(const wchar_t (&str)[N]) WI_NOEXCEPT
+        {
+            for (std::size_t i = 0; i < N; ++i)
+            {
+                value[i] = str[i];
+            }
+        }
+    };
+
+    template <std::size_t N>
+    wchar_literal_storage(const wchar_t (&)[N]) -> wchar_literal_storage<N>;
+
+    // N includes the trailing L'\0'; the BSTR byte-length prefix excludes it.
+    template <std::size_t N>
+    struct bstr_literal_t
+    {
+        unsigned long m_byte_length;
+        wchar_t m_data[N];
+
+        constexpr bstr_literal_t(const wchar_t (&text)[N]) WI_NOEXCEPT :
+            m_byte_length(static_cast<unsigned long>((N - 1) * sizeof(wchar_t))), m_data{}
+        {
+            for (std::size_t i = 0; i < N; ++i)
+            {
+                m_data[i] = text[i];
+            }
+        }
+
+        WI_NODISCARD constexpr operator BSTR() const WI_NOEXCEPT
+        {
+            return const_cast<wchar_t*>(&m_data[0]);
+        }
+    };
+
+    template <wchar_literal_storage Lit>
+    WI_NODISCARD constexpr auto operator""_bst() WI_NOEXCEPT
+    {
+        return bstr_literal_t<sizeof(Lit.value) / sizeof(wchar_t)>{Lit.value};
+    }
+
+#endif // __WI_LIBCPP_STD_VER >= 20
+
     constexpr zstring_view operator""_zv(const char* str, std::size_t len) noexcept
     {
         return {str, len};
     }
-
+ 
     constexpr zwstring_view operator""_zv(const wchar_t* str, std::size_t len) noexcept
     {
         return {str, len};

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -260,7 +260,7 @@ inline namespace literals
 
         Example:
             void Use(BSTR);
-            Use(L"foo"_bst);
+            Use(L"foo"_bstr);
     */
     template <std::size_t N>
     struct wchar_literal_storage

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -268,11 +268,11 @@ inline namespace literals
         wchar_t value[N];
         constexpr wchar_literal_storage(const wchar_t (&str)[N]) WI_NOEXCEPT
         {
-            for (std::size_t i = 0; i < N; ++i)
-            {
-                value[i] = str[i];
-            }
+            std::copy_n(str, N, value);
         }
+
+        static const std::size_t byte_size = N * sizeof(wchar_t); // includes the trailing L'\0'
+        static const std::size_t length = N - 1; // excludes the trailing L'\0'
     };
 
     template <std::size_t N>
@@ -285,13 +285,13 @@ inline namespace literals
         unsigned long m_byte_length;
         wchar_t m_data[N];
 
-        constexpr bstr_literal_t(const wchar_t (&text)[N]) WI_NOEXCEPT :
-            m_byte_length(static_cast<unsigned long>((N - 1) * sizeof(wchar_t))), m_data{}
+        constexpr bstr_literal_t(const wchar_literal_storage<N>& text) WI_NOEXCEPT :
+            m_byte_length(text.byte_size - sizeof(wchar_t)),
+            m_data{}
         {
-            for (std::size_t i = 0; i < N; ++i)
-            {
-                m_data[i] = text[i];
-            }
+            static_assert(sizeof(m_byte_length) == 4, "BSTR size must be 32 bits");
+            static_assert(offsetof(bstr_literal_t, m_data) == sizeof(m_byte_length), "BSTR data must immediately follow the length prefix");
+            std::copy_n(text.value, N, m_data);
         }
 
         WI_NODISCARD constexpr operator BSTR() const WI_NOEXCEPT
@@ -301,9 +301,9 @@ inline namespace literals
     };
 
     template <wchar_literal_storage Lit>
-    WI_NODISCARD constexpr auto operator""_bst() WI_NOEXCEPT
+    WI_NODISCARD constexpr auto operator""_bstr() WI_NOEXCEPT
     {
-        return bstr_literal_t<sizeof(Lit.value) / sizeof(wchar_t)>{Lit.value};
+        return bstr_literal_t<Lit.length + 1>{Lit};
     }
 
 #endif // __WI_LIBCPP_STD_VER >= 20

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -265,43 +265,27 @@ inline namespace literals
     template <std::size_t N>
     struct wchar_literal_storage
     {
+        static const std::size_t byte_size = N * sizeof(wchar_t); // includes the trailing L'\0'
+        static const std::size_t length = N - 1;                  // excludes the trailing L'\0'
+        uint32_t m_byte_length = static_cast<uint32_t>(byte_size - sizeof(wchar_t));
         wchar_t value[N];
         constexpr wchar_literal_storage(const wchar_t (&str)[N]) WI_NOEXCEPT
         {
             std::copy_n(str, N, value);
         }
-
-        static const std::size_t byte_size = N * sizeof(wchar_t); // includes the trailing L'\0'
-        static const std::size_t length = N - 1;                  // excludes the trailing L'\0'
     };
 
     template <std::size_t N>
     wchar_literal_storage(const wchar_t (&)[N]) -> wchar_literal_storage<N>;
 
-    // N includes the trailing L'\0'; the BSTR byte-length prefix excludes it.
-    template <std::size_t N>
-    struct bstr_literal_t
-    {
-        unsigned long m_byte_length;
-        wchar_t m_data[N];
-
-        constexpr bstr_literal_t(const wchar_literal_storage<N>& text) WI_NOEXCEPT : m_byte_length(text.byte_size - sizeof(wchar_t)), m_data{}
-        {
-            static_assert(sizeof(m_byte_length) == 4, "BSTR size must be 32 bits");
-            static_assert(offsetof(bstr_literal_t, m_data) == sizeof(m_byte_length), "BSTR data must immediately follow the length prefix");
-            std::copy_n(text.value, N, m_data);
-        }
-
-        WI_NODISCARD constexpr operator BSTR() const WI_NOEXCEPT
-        {
-            return const_cast<wchar_t*>(&m_data[0]);
-        }
-    };
-
     template <wchar_literal_storage Lit>
     WI_NODISCARD constexpr auto operator""_bstr() WI_NOEXCEPT
     {
-        return bstr_literal_t<Lit.length + 1>{Lit};
+        static_assert(sizeof(Lit.m_byte_length) == 4);
+        static_assert(offsetof(decltype(Lit), m_byte_length) == 0);
+        static_assert(offsetof(decltype(Lit), value) == sizeof(uint32_t));
+
+        return const_cast<wchar_t*>(Lit.value);
     }
 
 #endif // __WI_LIBCPP_STD_VER >= 20

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -291,12 +291,13 @@ namespace details
 
     template <std::size_t N>
     wchar_literal_storage(const wchar_t (&)[N]) -> wchar_literal_storage<N>;
-}
+} // namespace details
 
 inline namespace literals
 {
 #if __WI_LIBCPP_STD_VER >= 20
-    template<wil::details::wchar_literal_storage Str> struct bstr_storage_t
+    template <wil::details::wchar_literal_storage Str>
+    struct bstr_storage_t
     {
         uint32_t sizeBytes = static_cast<uint32_t>((Str.size - 1) * sizeof(wchar_t));
         decltype(Str) string{Str};

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -143,12 +143,17 @@ TEST_CASE("StlTests::TestBSTR literal", "[stl][bstr]")
 #if __WI_LIBCPP_STD_VER >= 20
     SECTION("Literal creates a valid BSTR")
     {
-        const auto literal = L"foo"_bst;
+        const auto literal = L"foo"_bstr;
         const BSTR value = literal;
         REQUIRE(value != nullptr);
         REQUIRE(SysStringLen(value) == 3);
-        REQUIRE(SysStringLen(L"zot"_bst) == 3);
+        REQUIRE(SysStringLen(L"zot"_bstr) == 3);
         REQUIRE(std::wstring_view(value) == L"foo");
+
+        constexpr auto empty_literal = L""_bstr;
+        REQUIRE(SysStringLen(empty_literal) == 0);
+        REQUIRE(empty_literal != nullptr);
+        REQUIRE(wcslen(empty_literal) == 0);
     }
 #endif
 }

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -128,7 +128,7 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 
 TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]")
 {
- 
+
     SECTION("Literal creates correct zwstring_view")
     {
         auto str = L"Hello, world!"_zv;
@@ -137,7 +137,7 @@ TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]")
         REQUIRE(str[12] == L'!');
     }
 }
- 
+
 TEST_CASE("StlTests::TestBSTR literal", "[stl][bstr]")
 {
 #if __WI_LIBCPP_STD_VER >= 20
@@ -157,7 +157,7 @@ TEST_CASE("StlTests::TestBSTR literal", "[stl][bstr]")
     }
 #endif
 }
- 
+
 TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]")
 {
 

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -128,7 +128,7 @@ TEST_CASE("StlTests::TestZStringView", "[stl][zstring_view]")
 
 TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]")
 {
-
+ 
     SECTION("Literal creates correct zwstring_view")
     {
         auto str = L"Hello, world!"_zv;
@@ -137,7 +137,22 @@ TEST_CASE("StlTests::TestZWStringView literal", "[stl][zwstring_view]")
         REQUIRE(str[12] == L'!');
     }
 }
-
+ 
+TEST_CASE("StlTests::TestBSTR literal", "[stl][bstr]")
+{
+#if __WI_LIBCPP_STD_VER >= 20
+    SECTION("Literal creates a valid BSTR")
+    {
+        const auto literal = L"foo"_bst;
+        const BSTR value = literal;
+        REQUIRE(value != nullptr);
+        REQUIRE(SysStringLen(value) == 3);
+        REQUIRE(SysStringLen(L"zot"_bst) == 3);
+        REQUIRE(std::wstring_view(value) == L"foo");
+    }
+#endif
+}
+ 
 TEST_CASE("StlTests::TestZStringView literal", "[stl][zstring_view]")
 {
 


### PR DESCRIPTION
Reduce global initializers and intermediate allocations with a `BSTR`-compatible string literal.

```c++
// Unnecessary globals - 
const wil::unique_bstr g_bst(SysAllocString(L"kittens"));
const auto g_bst2 { wil::make_bstr_failfast(L"puppies"); };

HRESULT UseBstr(BSTR bst);
void call_bstr_function() {
    UseBstr(g_bst.get());

    // Unnecessary local allocation
    auto propName = wil::make_bstr_failfast(L"waffleCount");
    UseBstr(propName.get());

    // !!super mega ultra danger!! - not passing a real bstr...
    UseBstr(L"kablooie");
}
```

Instead, literals:

```c++
const auto g_bst = L"kittens"_bstr;
const auto g_bst2 = L"puppies"_bstr;

void call_bstr_function() {
    UseBstr(g_bst);
    UseBstr(L"waffleCount"_bstr);
}
```

(Thanks Copilot!)