### PR TITLE
Use robots to update doc comments

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,46 @@
+# Copilot CLI skills
+
+This directory holds repository-scoped [skills](https://docs.github.com/copilot) for coding agents (GitHub Copilot CLI
+and compatible tools). A *skill* is a folder containing a `SKILL.md` file that gives an agent focused, reusable
+instructions for a specific task in this repository. Agents discover skills here automatically and either surface them
+as `/`-commands or invoke them on their own when a request matches a skill's `description`.
+
+## Layout
+
+    .github/skills/
+      <skill-name>/
+        SKILL.md          # required: YAML frontmatter + Markdown instructions
+        <supporting files> # optional: scripts, templates, examples referenced by SKILL.md
+
+## `SKILL.md` format
+
+Each `SKILL.md` starts with a YAML frontmatter block followed by a Markdown body:
+
+~~~markdown
+---
+name: my-skill
+description: >-
+    One or two sentences describing what the skill does and, importantly, when an agent should use it.
+---
+
+# Human-readable title
+
+Instructions the agent should follow when the skill is active...
+~~~
+
+Recognized frontmatter fields:
+
+| Field            | Required | Purpose                                                                              |
+| ---------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`           | yes      | Unique skill id; should match the folder name.                                       |
+| `description`    | yes      | What the skill does and *when* to use it. Agents match against this to auto-trigger. |
+| `user-invocable` | no       | Set to `false` to hide the skill from manual `/`-command invocation (default: true). |
+| `allowed-tools`  | no       | Comma-separated list of tools to pre-approve while the skill is running.             |
+
+Keep the `description` action-oriented and specific about *when* to apply the skill — that text is the primary signal
+an agent uses to decide whether a skill is relevant.
+
+## Available skills
+
+- [`doxygen-comments`](doxygen-comments/SKILL.md) — write, update, and correct Doxygen documentation comments in WIL's
+  headers so they follow the repo's conventions and generate without warnings.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,9 +1,9 @@
 # Copilot CLI skills
 
-This directory holds repository-scoped [skills](https://docs.github.com/copilot) for coding agents (GitHub Copilot CLI
-and compatible tools). A *skill* is a folder containing a `SKILL.md` file that gives an agent focused, reusable
-instructions for a specific task in this repository. Agents discover skills here automatically and either surface them
-as `/`-commands or invoke them on their own when a request matches a skill's `description`.
+This directory holds repository-scoped [skills](https://docs.github.com/copilot) for coding agents (GitHub Copilot CLI and
+compatible tools). A *skill* is a folder containing a `SKILL.md` file that gives an agent focused, reusable instructions for a
+specific task in this repository. Agents discover skills here automatically and either surface them as `/`-commands or invoke them
+on their own when a request matches a skill's `description`.
 
 ## Layout
 
@@ -37,10 +37,10 @@ Recognized frontmatter fields:
 | `user-invocable` | no       | Set to `false` to hide the skill from manual `/`-command invocation (default: true). |
 | `allowed-tools`  | no       | Comma-separated list of tools to pre-approve while the skill is running.             |
 
-Keep the `description` action-oriented and specific about *when* to apply the skill — that text is the primary signal
-an agent uses to decide whether a skill is relevant.
+Keep the `description` action-oriented and specific about *when* to apply the skill — that text is the primary signal an agent
+uses to decide whether a skill is relevant.
 
 ## Available skills
 
-- [`doxygen-comments`](doxygen-comments/SKILL.md) — write, update, and correct Doxygen documentation comments in WIL's
-  headers so they follow the repo's conventions and generate without warnings.
+- [`doxygen-comments`](doxygen-comments/SKILL.md) — write, update, and correct Doxygen documentation comments in WIL's headers so
+  they follow the repo's conventions and generate without warnings.

--- a/.github/skills/doxygen-comments/SKILL.md
+++ b/.github/skills/doxygen-comments/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: doxygen-comments
 description: >-
-    Conventions and a checklist for writing, updating, and correcting Doxygen documentation comments in WIL's C++
-    headers so they match the repository's style and build without warnings. Use when adding or fixing `//!` or
-    `/** */` doc comments, `@param`/`@tparam`/`@return` tags, `@ref`/`@see` cross-references, or briefs, or when
-    resolving warnings from the Doxygen `docs` build target.
+    Conventions and a checklist for writing, updating, and correcting Doxygen documentation comments in WIL's public C++ headers
+    under `include/` so they match the repository's style and build without warnings. Applies only to headers under `include/` —
+    not `tests/` or other code. Use when adding or fixing `//!` or `/** */` doc comments, `@param`/`@tparam`/`@return` tags,
+    `@ref`/`@see` cross-references, or briefs, or when resolving warnings from the Doxygen `docs` build target.
 ---
 
 # Updating and correcting Doxygen comments in WIL
 
-WIL's public API is documented with Doxygen comments in the headers under `include/wil/`, and the docs are generated
-from `docs/Doxyfile`. Use this skill to add, update, or fix those comments so they stay consistent with the codebase
-and generate cleanly.
+WIL's public API is documented with Doxygen comments in the headers under `include/wil/`, and the docs are generated from
+`docs/Doxyfile`. Use this skill to add, update, or fix those comments so they stay consistent with the codebase and generate
+cleanly.
+
+## Scope
+
+This skill applies **only to WIL's public headers under `include/`** (primarily `include/wil/*.h`). Do **not** apply these
+conventions to test code (`tests/`), documentation sources (`docs/`), packaging, or build scripts — those files are not part of
+the generated API reference. If a request targets files outside `include/`, this skill does not apply.
 
 ## When to use
 
@@ -19,79 +25,83 @@ and generate cleanly.
 - Correcting existing comments after a signature or behavior change.
 - Fixing Doxygen build warnings (mismatched parameters, undocumented members, broken references, etc.).
 
-Do **not** rewrite comments purely for style, and do not document private/internal helpers (see "Public API only"
-below).
+Do **not** rewrite comments purely for style, and do not document private/internal helpers (see "Public API only" below).
 
 ## WIL Doxygen conventions
 
-- **Comment markers.** WIL documents public API with either `//!` line comments or `/** ... */` block comments. Match
-  the style already used in the surrounding file / nearby declarations instead of mixing both. `//!` is common for
-  file banners and member comments; `/** */` is common for free functions and templates.
-- **Tag style is `@`, never `\`.** Use `@param`, `@tparam`, `@return`, `@brief`, `@ingroup`, `@ref`, `@see`, `@note`,
-  `@file`, etc. The codebase uses zero backslash-style tags — keep it that way.
-- **Brief = first sentence.** `JAVADOC_AUTOBRIEF` is enabled, so the first sentence (up to the first period) becomes
-  the brief. Lead with a concise one-line summary and put details in following sentences; an explicit `@brief` is
-  rarely needed.
+- **Comment markers.** WIL documents public API with either `//!` line comments or `/** ... */` block comments. Match the style
+  already used in the surrounding file / nearby declarations instead of mixing both. `//!` is common for file banners and member
+  comments; `/** */` is common for free functions and templates.
+- **Tag style is `@`, never `\`.** Use `@param`, `@tparam`, `@return`, `@brief`, `@ingroup`, `@ref`, `@see`, `@note`, `@file`,
+  etc. The codebase uses zero backslash-style tags — keep it that way.
+- **Brief = first sentence, on its own line.** `JAVADOC_AUTOBRIEF` makes the first sentence (up to the first period) the brief.
+  Keep it on its own physical line; start the detailed description on the next line. An explicit `@brief` is rarely needed.
 - **Wrap at 130 columns.** This matches `.clang-format` (`ColumnLimit: 130`) and applies to comment text too.
-- **Public API only.** `EXTRACT_ALL = NO` and `EXTRACT_PRIVATE = NO`, so private members and undocumented internals
-  are not emitted. Focus documentation on the public surface; don't add Doxygen tags to private helpers expecting them
-  to appear in the output.
-- **Hide internal `details` namespaces.** WIL's implementation details live in namespaces named `details` (and similarly
-  named variants such as `details_abi`). These must not emit documentation — wrap the entire namespace in a
-  `/// @cond` … `/// @endcond` pair (note the `///` marker used for these structural tags) so Doxygen skips its
-  contents. Put `/// @cond` on its own line immediately before the namespace and `/// @endcond` immediately after its
-  closing brace. See the example below.
-- **Code samples use `~~~` fences.** Doxygen fenced code blocks are delimited with `~~~` (see existing headers).
-  Inside `//!` banners, examples are written as indented lines that are each prefixed with `//!`.
-- **Cross-references.** Link to other entities with `@ref <name>` and `@see`, and group related members with
-  `@ingroup <group>` (for example `@ingroup outparam`).
+- **Public API only.** `EXTRACT_ALL = NO` and `EXTRACT_PRIVATE = NO`, so private members and undocumented internals are not
+  emitted. Focus documentation on the public surface; don't add Doxygen tags to private helpers expecting them to appear in the
+  output.
+- **Hide internal `details` namespaces.** WIL's implementation details live in namespaces named `details` (and similarly named
+  variants such as `details_abi`). These must not emit documentation — wrap the entire namespace in a `/// @cond` … `/// @endcond`
+  pair (note the `///` marker used for these structural tags) so Doxygen skips its contents. Put `/// @cond` on its own line
+  immediately before the namespace and `/// @endcond` immediately after its closing brace. See the example below.
+- **Add a usage example when the call pattern is non-obvious.** Include a short `~~~` fenced example for functions whose correct
+  use isn't clear from the signature alone — e.g. callback or functor contracts (what the callback must do and return), paired or
+  multi-step call sequences, RAII helpers whose placement or lifetime matters, round-trip or reverse operations, or subtle
+  buffer/ownership conventions. Skip examples for self-explanatory helpers such as simple getters, predicates, or arithmetic.
+  Doxygen fenced code blocks are delimited with `~~~` (any matching run of three or more tildes); inside `//!` banners, prefix
+  each example line with `//!`.
+- **Cross-references.** Link to other entities with `@ref <name>` and `@see`, and group related members with `@ingroup <group>`
+  (for example `@ingroup outparam`).
 - **Namespaces.** Public entities live under `wil::`; STL-mirroring pieces live under `wistd::`.
-- **Add a `WIL_DOXYGEN` escape to preprocessor guards.** Doxygen predefines `WIL_DOXYGEN` (see `docs/Doxyfile`'s
-  `PREDEFINED`), so a public declaration behind a `#if`/`#ifdef` guard is invisible to the docs unless the escape is
-  OR-ed into the condition. Append `|| defined(WIL_DOXYGEN)` to the guard, converting `#ifdef X` / `#ifndef X` to the
-  `#if defined(X)` form as needed. When the condition wraps, continue it with a trailing `\` and put
-  `defined(WIL_DOXYGEN)` on the next line. A standalone `#ifdef WIL_DOXYGEN` block is used for doc-only constructs
-  that have no real declaration to attach to.
-- **Macros are expanded for docs.** Several macros are expanded when generating documentation (`WI_NOEXCEPT` →
-  `noexcept`, `WI_NODISCARD` → `[[nodiscard]]`, and others in `docs/Doxyfile`'s `PREDEFINED`), so document the logical
-  signature rather than the macro-heavy source.
+- **Prefer a `PREDEFINED` macro over a per-guard escape; use `WIL_DOXYGEN` only when needed.** Doxygen evaluates `#if` guards
+  against `docs/Doxyfile`'s `PREDEFINED` list, which already forces many conditions true in docs — e.g.
+  `WINAPI_FAMILY_PARTITION(partition)=1`, `WIL_USE_STL=1`, `WIL_ENABLE_EXCEPTIONS`, `WIL_RESOURCE_STL`, and many `__cpp_lib_*`
+  feature macros. First check whether the guard is already satisfied there; if so, no escape is needed. If a declaration is
+  gated on a feature macro that is broadly useful, add that macro to `PREDEFINED` rather than sprinkling escapes. Only when the
+  condition can't be satisfied that way — notably the mutually-exclusive `__WIL_*` / `__WIL_*_STL` header-wrapper guards in
+  `resource.h`/`registry.h` — OR `|| defined(WIL_DOXYGEN)` into the condition (convert `#ifdef X` / `#ifndef X` to
+  `#if defined(X)`; when the line wraps, continue with a trailing `\` and put `defined(WIL_DOXYGEN)` on the next line). A
+  standalone `#ifdef WIL_DOXYGEN` block is for doc-only constructs with no real declaration to attach to.
+- **Macros are expanded for docs.** Several macros are expanded when generating documentation (`WI_NOEXCEPT` → `noexcept`,
+  `WI_NODISCARD` → `[[nodiscard]]`, and others in `docs/Doxyfile`'s `PREDEFINED`), so document the logical signature rather than
+  the macro-heavy source.
 
 ## Correction checklist
 
 When adding or fixing comments, verify:
 
-1. **Every `@param`/`@tparam` name matches the signature** — no stale, missing, misspelled, or reordered names. This
-   is the most common source of `WARN_IF_DOC_ERROR` warnings.
+1. **Every `@param`/`@tparam` name matches the signature** — no stale, missing, misspelled, or reordered names. This is the most
+   common source of `WARN_IF_DOC_ERROR` warnings.
 2. **`@return` is present and accurate** for functions that return a meaningful value; omit it for `void`.
-3. **The error-handling flavor is described** where relevant. WIL entities come in neutral, exception-based,
-   `_failfast`, and `_nothrow`/`NoThrow` variants — state how the function reports failure (throws, fail-fasts, or
-   returns an `HRESULT`).
+3. **The error-handling flavor is described** where relevant. WIL entities come in neutral, exception-based, `_failfast`, and
+   `_nothrow`/`NoThrow` variants — state how the function reports failure (throws, fail-fasts, or returns an `HRESULT`).
 4. **Tags use `@`** (convert any `\param`, `\brief`, etc.).
-5. **The brief is a real one-line summary** (the first sentence), not a restatement of the name.
+5. **The brief is a real one-line summary on its own line** (the first sentence), not a restatement of the name.
 6. **Cross-references resolve** — `@ref`/`@see` targets exist and are spelled correctly.
 7. **The description still matches behavior** after any signature or behavior change.
 8. **Lines wrap at 130 columns** and the comment marker style matches the surrounding code.
-9. **No documentation is added to private/internal members** unless they are intentionally part of the documented
-   surface.
-10. **Internal `details`/`details_*` namespaces are wrapped in `/// @cond` … `/// @endcond`** so their contents are
-    excluded from the generated documentation.
-11. **Conditionally-compiled public declarations carry a `WIL_DOXYGEN` escape** — the `#if`/`#ifdef` guard ORs in
-    `|| defined(WIL_DOXYGEN)` so the signature is emitted into the docs.
+9. **No documentation is added to private/internal members** unless they are intentionally part of the documented surface.
+10. **Internal `details`/`details_*` namespaces are wrapped in `/// @cond` … `/// @endcond`** so their contents are excluded from
+    the generated documentation.
+11. **Conditionally-compiled public declarations are visible in docs** — the guard is either already satisfied by `PREDEFINED`
+    or ORs in `|| defined(WIL_DOXYGEN)` (reserved for conditions `PREDEFINED` can't cover, like the header-wrapper guards).
+12. **Non-obvious functions carry a `~~~` usage example** — anything with a callback contract, a paired/multi-step call sequence,
+    or subtle ownership/buffer semantics shows how to call it; trivial helpers do not.
 
 ## Validating changes
 
-Doxygen is configured with `WARN_IF_UNDOCUMENTED = YES` and `WARN_IF_DOC_ERROR = YES`, and formats warnings as
-`$file:$line: $text`, so a docs build points directly at problems. From an already-configured build directory, run the
-`docs` target (it requires Doxygen on `PATH`, and `WIL_BUILD_TESTS = ON`, which is the default):
+Doxygen is configured with `WARN_IF_UNDOCUMENTED = YES` and `WARN_IF_DOC_ERROR = YES`, and formats warnings as `$file:$line:
+$text`, so a docs build points directly at problems. From an already-configured build directory, run the `docs` target (it
+requires Doxygen on `PATH`, and `WIL_BUILD_TESTS = ON`, which is the default):
 
 ```
 ninja docs      # run from the configured build directory, e.g. build/msvc
 ```
 
-The `docs` target just runs Doxygen, so it is independent of the selected configuration. Review its output for new
-warnings referencing the files you touched — mismatched parameters, undocumented public members, and broken
-references all surface there. Generated HTML lands under the build directory. If Doxygen is not installed, at minimum
-re-check each comment against the current signature using the checklist above.
+The `docs` target just runs Doxygen, so it is independent of the selected configuration. Review its output for new warnings
+referencing the files you touched — mismatched parameters, undocumented public members, and broken references all surface there.
+Generated HTML lands under the build directory. If Doxygen is not installed, at minimum re-check each comment against the current
+signature using the checklist above.
 
 ## Example
 
@@ -144,6 +154,6 @@ com_ptr<T> make_com_ptr(T* ptr);
 
 ## Status
 
-This skill is an intentional starting point. The conventions above are grounded in the current headers and
-`docs/Doxyfile`, but the checklist and examples are expected to grow as we refine it. When a rule here disagrees with
-real, nearby code in the file you are editing, prefer matching the surrounding code and flag the discrepancy.
+This skill is an intentional starting point. The conventions above are grounded in the current headers and `docs/Doxyfile`, but
+the checklist and examples are expected to grow as we refine it. When a rule here disagrees with real, nearby code in the file you
+are editing, prefer matching the surrounding code and flag the discrepancy.

--- a/.github/skills/doxygen-comments/SKILL.md
+++ b/.github/skills/doxygen-comments/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: doxygen-comments
+description: >-
+    Conventions and a checklist for writing, updating, and correcting Doxygen documentation comments in WIL's C++
+    headers so they match the repository's style and build without warnings. Use when adding or fixing `//!` or
+    `/** */` doc comments, `@param`/`@tparam`/`@return` tags, `@ref`/`@see` cross-references, or briefs, or when
+    resolving warnings from the Doxygen `docs` build target.
+---
+
+# Updating and correcting Doxygen comments in WIL
+
+WIL's public API is documented with Doxygen comments in the headers under `include/wil/`, and the docs are generated
+from `docs/Doxyfile`. Use this skill to add, update, or fix those comments so they stay consistent with the codebase
+and generate cleanly.
+
+## When to use
+
+- Writing new documentation comments for public functions, classes, templates, or macros.
+- Correcting existing comments after a signature or behavior change.
+- Fixing Doxygen build warnings (mismatched parameters, undocumented members, broken references, etc.).
+
+Do **not** rewrite comments purely for style, and do not document private/internal helpers (see "Public API only"
+below).
+
+## WIL Doxygen conventions
+
+- **Comment markers.** WIL documents public API with either `//!` line comments or `/** ... */` block comments. Match
+  the style already used in the surrounding file / nearby declarations instead of mixing both. `//!` is common for
+  file banners and member comments; `/** */` is common for free functions and templates.
+- **Tag style is `@`, never `\`.** Use `@param`, `@tparam`, `@return`, `@brief`, `@ingroup`, `@ref`, `@see`, `@note`,
+  `@file`, etc. The codebase uses zero backslash-style tags — keep it that way.
+- **Brief = first sentence.** `JAVADOC_AUTOBRIEF` is enabled, so the first sentence (up to the first period) becomes
+  the brief. Lead with a concise one-line summary and put details in following sentences; an explicit `@brief` is
+  rarely needed.
+- **Wrap at 130 columns.** This matches `.clang-format` (`ColumnLimit: 130`) and applies to comment text too.
+- **Public API only.** `EXTRACT_ALL = NO` and `EXTRACT_PRIVATE = NO`, so private members and undocumented internals
+  are not emitted. Focus documentation on the public surface; don't add Doxygen tags to private helpers expecting them
+  to appear in the output.
+- **Hide internal `details` namespaces.** WIL's implementation details live in namespaces named `details` (and similarly
+  named variants such as `details_abi`). These must not emit documentation — wrap the entire namespace in a
+  `/// @cond` … `/// @endcond` pair (note the `///` marker used for these structural tags) so Doxygen skips its
+  contents. Put `/// @cond` on its own line immediately before the namespace and `/// @endcond` immediately after its
+  closing brace. See the example below.
+- **Code samples use `~~~` fences.** Doxygen fenced code blocks are delimited with `~~~` (see existing headers).
+  Inside `//!` banners, examples are written as indented lines that are each prefixed with `//!`.
+- **Cross-references.** Link to other entities with `@ref <name>` and `@see`, and group related members with
+  `@ingroup <group>` (for example `@ingroup outparam`).
+- **Namespaces.** Public entities live under `wil::`; STL-mirroring pieces live under `wistd::`.
+- **Add a `WIL_DOXYGEN` escape to preprocessor guards.** Doxygen predefines `WIL_DOXYGEN` (see `docs/Doxyfile`'s
+  `PREDEFINED`), so a public declaration behind a `#if`/`#ifdef` guard is invisible to the docs unless the escape is
+  OR-ed into the condition. Append `|| defined(WIL_DOXYGEN)` to the guard, converting `#ifdef X` / `#ifndef X` to the
+  `#if defined(X)` form as needed. When the condition wraps, continue it with a trailing `\` and put
+  `defined(WIL_DOXYGEN)` on the next line. A standalone `#ifdef WIL_DOXYGEN` block is used for doc-only constructs
+  that have no real declaration to attach to.
+- **Macros are expanded for docs.** Several macros are expanded when generating documentation (`WI_NOEXCEPT` →
+  `noexcept`, `WI_NODISCARD` → `[[nodiscard]]`, and others in `docs/Doxyfile`'s `PREDEFINED`), so document the logical
+  signature rather than the macro-heavy source.
+
+## Correction checklist
+
+When adding or fixing comments, verify:
+
+1. **Every `@param`/`@tparam` name matches the signature** — no stale, missing, misspelled, or reordered names. This
+   is the most common source of `WARN_IF_DOC_ERROR` warnings.
+2. **`@return` is present and accurate** for functions that return a meaningful value; omit it for `void`.
+3. **The error-handling flavor is described** where relevant. WIL entities come in neutral, exception-based,
+   `_failfast`, and `_nothrow`/`NoThrow` variants — state how the function reports failure (throws, fail-fasts, or
+   returns an `HRESULT`).
+4. **Tags use `@`** (convert any `\param`, `\brief`, etc.).
+5. **The brief is a real one-line summary** (the first sentence), not a restatement of the name.
+6. **Cross-references resolve** — `@ref`/`@see` targets exist and are spelled correctly.
+7. **The description still matches behavior** after any signature or behavior change.
+8. **Lines wrap at 130 columns** and the comment marker style matches the surrounding code.
+9. **No documentation is added to private/internal members** unless they are intentionally part of the documented
+   surface.
+10. **Internal `details`/`details_*` namespaces are wrapped in `/// @cond` … `/// @endcond`** so their contents are
+    excluded from the generated documentation.
+11. **Conditionally-compiled public declarations carry a `WIL_DOXYGEN` escape** — the `#if`/`#ifdef` guard ORs in
+    `|| defined(WIL_DOXYGEN)` so the signature is emitted into the docs.
+
+## Validating changes
+
+Doxygen is configured with `WARN_IF_UNDOCUMENTED = YES` and `WARN_IF_DOC_ERROR = YES`, and formats warnings as
+`$file:$line: $text`, so a docs build points directly at problems. From an already-configured build directory, run the
+`docs` target (it requires Doxygen on `PATH`, and `WIL_BUILD_TESTS = ON`, which is the default):
+
+```
+ninja docs      # run from the configured build directory, e.g. build/msvc
+```
+
+The `docs` target just runs Doxygen, so it is independent of the selected configuration. Review its output for new
+warnings referencing the files you touched — mismatched parameters, undocumented public members, and broken
+references all surface there. Generated HTML lands under the build directory. If Doxygen is not installed, at minimum
+re-check each comment against the current signature using the checklist above.
+
+## Example
+
+Correcting stale parameter names and backslash tags:
+
+```cpp
+// Before — backslash tags, @param name doesn't match the signature, missing @return.
+/** Opens the widget.
+\param widgetName  The name to open.
+*/
+HRESULT open_widget_nothrow(PCWSTR name, wil::unique_hwidget& widget);
+
+// After — @-style tags, names match the signature, failure mode and return documented, wrapped at 130 columns.
+/** Opens the named widget.
+Returns an error code rather than throwing, so it is safe for callers built without exceptions.
+@param name    Name of the widget to open.
+@param widget  Receives the opened widget on success.
+@return `S_OK` on success, or a failure `HRESULT` from the underlying `OpenWidget` call. */
+HRESULT open_widget_nothrow(PCWSTR name, wil::unique_hwidget& widget);
+```
+
+Hiding an internal `details` namespace so Doxygen excludes it from the output:
+
+```cpp
+/// @cond
+namespace details
+{
+    // Internal implementation — intentionally undocumented.
+    template <typename T>
+    using ensure_trivially_destructible_t = typename ensure_trivially_destructible<T>::type;
+} // namespace details
+/// @endcond
+```
+
+Adding a `WIL_DOXYGEN` escape so a guarded public declaration still appears in the docs:
+
+```cpp
+// Before — only compiled when <objbase.h> has been included, so Doxygen never sees this signature.
+#if defined(__WIL_OBJBASE_H_)
+template <typename T>
+com_ptr<T> make_com_ptr(T* ptr);
+#endif
+
+// After — OR in defined(WIL_DOXYGEN) (which Doxygen predefines) so the signature is documented.
+#if defined(__WIL_OBJBASE_H_) || defined(WIL_DOXYGEN)
+template <typename T>
+com_ptr<T> make_com_ptr(T* ptr);
+#endif
+```
+
+## Status
+
+This skill is an intentional starting point. The conventions above are grounded in the current headers and
+`docs/Doxyfile`, but the checklist and examples are expected to grow as we refine it. When a rule here disagrees with
+real, nearby code in the file you are editing, prefer matching the surrounding code and flag the discrepancy.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2034,6 +2034,8 @@ PREDEFINED             = WIL_DOXYGEN \
                          __cpp_lib_coroutine=201902L \
                          __has_include(header)=1 \
                          __cpp_lib_apply=201603L \
+                         WIL_USE_STL=1 \
+                         __cpp_lib_string_view=201803L \
 
 @INCLUDE = nosal2.doxyfile
 

--- a/include/wil/win32_helpers.h
+++ b/include/wil/win32_helpers.h
@@ -50,7 +50,9 @@
 #include "wistd_functional.h"
 #include "wistd_type_traits.h"
 
+/// @cond
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+/// @endcond
 
 /// @cond
 namespace wistd
@@ -178,6 +180,13 @@ namespace details
 } // namespace details
 /// @endcond
 
+/** Performs an ordinal (locale-independent) comparison of two strings and returns their relative order.
+Use ordinal comparisons for resource identifiers such as filenames, registry keys, and XML node names, where a locale-sensitive
+(lexical) comparison would be incorrect. Wraps `CompareStringOrdinal`.
+@param left The first string to compare.
+@param right The second string to compare.
+@param caseInsensitive `true` to compare without regard to case; `false` for a case-sensitive comparison.
+@return A `wistd::weak_ordering` that is `less`, `equivalent`, or `greater` for `left` relative to `right`. */
 [[nodiscard]] inline wistd::weak_ordering compare_string_ordinal(std::wstring_view left, std::wstring_view right, bool caseInsensitive) WI_NOEXCEPT
 {
     switch (wil::details::CompareStringOrdinal(left, right, caseInsensitive))
@@ -195,18 +204,27 @@ namespace details
 #pragma endregion
 
 #pragma region FILETIME helpers
-// FILETIME duration values. FILETIME is in 100 nanosecond units.
+//! Common FILETIME durations, expressed in the 100-nanosecond units that `FILETIME` uses.
 namespace filetime_duration
 {
+    //! One millisecond, in 100-nanosecond units.
     long long const one_millisecond = 10000LL;
+    //! One second, in 100-nanosecond units.
     long long const one_second = 10000000LL;
+    //! One minute, in 100-nanosecond units.
     long long const one_minute = 10000000LL * 60;        // 600000000    or 600000000LL
+    //! One hour, in 100-nanosecond units.
     long long const one_hour = 10000000LL * 60 * 60;     // 36000000000  or 36000000000LL
+    //! One day, in 100-nanosecond units.
     long long const one_day = 10000000LL * 60 * 60 * 24; // 864000000000 or 864000000000LL
 }; // namespace filetime_duration
 
 namespace filetime
 {
+    /// Reinterprets a `FILETIME` as a 64-bit integer count of 100-nanosecond units.
+    /// @tparam Int64 A 64-bit integral type to return the value as; defaults to `unsigned long long`.
+    /// @param val The `FILETIME` to convert.
+    /// @return The `FILETIME` reinterpreted as a single 64-bit integer.
     template <typename Int64 = unsigned long long, wistd::enable_if_t<wistd::is_integral_v<Int64> && (sizeof(Int64) == sizeof(FILETIME)), int> = 0>
     constexpr Int64 to_int64(const FILETIME& val) WI_NOEXCEPT
     {
@@ -218,13 +236,19 @@ namespace filetime
 #endif
     }
 
+    /// @cond
     namespace details
     {
         template <typename Int>
         using select_int64 =
             wistd::conditional_t<sizeof(Int) == 8, Int, wistd::conditional_t<wistd::is_signed_v<Int>, long long, unsigned long long>>;
     }
+    /// @endcond
 
+    /// Converts an integer count of 100-nanosecond units into a `FILETIME`.
+    /// @tparam Int An integral type no larger than `FILETIME` (8 bytes).
+    /// @param val The 100-nanosecond count to convert.
+    /// @return A `FILETIME` representing the given count.
     template <typename Int, wistd::enable_if_t<wistd::is_integral_v<Int> && (sizeof(Int) <= sizeof(FILETIME)), int> = 0>
     __WI_CONSTEXPR_BIT_CAST FILETIME from_int64(Int val) WI_NOEXCEPT
     {
@@ -240,6 +264,11 @@ namespace filetime
 #endif
     }
 
+    /// Adds a 100-nanosecond delta to a `FILETIME` and returns the resulting time.
+    /// @tparam Int An integral type no larger than `FILETIME` (8 bytes).
+    /// @param baseTime The starting time.
+    /// @param delta100ns The number of 100-nanosecond units to add (negative values move backwards in time).
+    /// @return `baseTime` advanced by `delta100ns`, as a new `FILETIME`.
     template <typename Int, wistd::enable_if_t<wistd::is_integral_v<Int> && (sizeof(Int) <= sizeof(FILETIME)), int> = 0>
     __WI_CONSTEXPR_BIT_CAST FILETIME add(FILETIME const& baseTime, Int delta100ns) WI_NOEXCEPT
     {
@@ -247,11 +276,16 @@ namespace filetime
         return from_int64(to_int64<Int64>(baseTime) + delta100ns);
     }
 
+    /// Returns whether a `FILETIME` is zero (both `dwHighDateTime` and `dwLowDateTime` are 0).
+    /// @param val The `FILETIME` to test.
+    /// @return `true` if `val` is all zero, `false` otherwise.
     constexpr bool is_empty(const FILETIME& val) WI_NOEXCEPT
     {
         return (val.dwHighDateTime == 0) && (val.dwLowDateTime == 0);
     }
 
+    /// Returns the current system time (UTC) as a `FILETIME`, via `GetSystemTimeAsFileTime`.
+    /// @return The current system time.
     inline FILETIME get_system_time() WI_NOEXCEPT
     {
         FILETIME now;
@@ -311,30 +345,57 @@ namespace filetime
 #pragma endregion
 
 #pragma region RECT helpers
+/** Returns the width of a rectangle (its `right` minus `left`).
+@tparam rect_type A rectangle type with `left` and `right` members (e.g. `RECT`).
+@param rect The rectangle to measure.
+@return The width, computed as `rect.right - rect.left`. */
 template <typename rect_type>
 constexpr auto rect_width(rect_type const& rect)
 {
     return rect.right - rect.left;
 }
 
+/** Returns the height of a rectangle (its `bottom` minus `top`).
+@tparam rect_type A rectangle type with `top` and `bottom` members (e.g. `RECT`).
+@param rect The rectangle to measure.
+@return The height, computed as `rect.bottom - rect.top`. */
 template <typename rect_type>
 constexpr auto rect_height(rect_type const& rect)
 {
     return rect.bottom - rect.top;
 }
 
+/** Returns whether a rectangle is empty (encloses no area).
+@tparam rect_type A rectangle type with `left`, `top`, `right`, and `bottom` members (e.g. `RECT`).
+@param rect The rectangle to test.
+@return `true` if the rectangle is empty (`left >= right` or `top >= bottom`), `false` otherwise. */
 template <typename rect_type>
 constexpr auto rect_is_empty(rect_type const& rect)
 {
     return (rect.left >= rect.right) || (rect.top >= rect.bottom);
 }
 
+/** Returns whether a point lies within a rectangle, treating the rectangle as half-open.
+The `left` and `top` edges are inclusive while the `right` and `bottom` edges are exclusive.
+@tparam rect_type A rectangle type with `left`, `top`, `right`, and `bottom` members (e.g. `RECT`).
+@tparam point_type A point type with `x` and `y` members (e.g. `POINT`).
+@param rect The rectangle to test against.
+@param point The point to test.
+@return `true` if `point` is inside `rect`, `false` otherwise. */
 template <typename rect_type, typename point_type>
 constexpr auto rect_contains_point(rect_type const& rect, point_type const& point)
 {
     return (point.x >= rect.left) && (point.x < rect.right) && (point.y >= rect.top) && (point.y < rect.bottom);
 }
 
+/** Builds a rectangle from an origin and a size.
+@tparam rect_type A rectangle type with `left`, `top`, `right`, and `bottom` members (e.g. `RECT`).
+@tparam length_type The integral type of the coordinate and size values.
+@param x The left coordinate of the rectangle.
+@param y The top coordinate of the rectangle.
+@param width The width of the rectangle; `right` is set to `x + width`.
+@param height The height of the rectangle; `bottom` is set to `y + height`.
+@return A `rect_type` with the given origin and size. */
 template <typename rect_type, typename length_type>
 constexpr rect_type rect_from_size(length_type x, length_type y, length_type width, length_type height)
 {
@@ -347,11 +408,33 @@ constexpr rect_type rect_from_size(length_type x, length_type y, length_type wid
 }
 #pragma endregion
 
-// Use to adapt Win32 APIs that take a fixed size buffer into forms that return
-// an allocated buffer. Supports many types of string representation.
-// See comments below on the expected behavior of the callback.
-// Adjust stackBufferLength based on typical result sizes to optimize use and
-// to test the boundary cases.
+/** Adapts a Win32 API that fills a fixed-size, caller-provided buffer into one that returns an allocated string.
+Many Win32 APIs write into a fixed-size buffer and report how much space is required. This helper first tries a stack buffer of
+`stackBufferLength` characters and, if that is too small, allocates a buffer of the required size, retrying if the required size
+changes between calls. Supports any `string_type` understood by the internal `string_maker` (e.g. `wil::unique_cotaskmem_string`
+or `std::wstring`).
+~~~
+// Wrap a fixed-size Win32 API (here ::GetSystemDirectoryW) into one that returns an allocated string.
+wil::unique_cotaskmem_string dir;
+RETURN_IF_FAILED(wil::AdaptFixedSizeToAllocatedResult(dir,
+    [](PWSTR value, size_t valueLength, size_t* valueLengthNeededWithNul) -> HRESULT
+    {
+        *valueLengthNeededWithNul = ::GetSystemDirectoryW(value, static_cast<DWORD>(valueLength));
+        RETURN_LAST_ERROR_IF(*valueLengthNeededWithNul == 0);
+        if (*valueLengthNeededWithNul < valueLength)
+        {
+            (*valueLengthNeededWithNul)++; // it fit; account for the null
+        }
+        return S_OK;
+    }));
+~~~
+@tparam string_type The string type to produce the result in.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer; tune it to typical result sizes.
+@param result Receives the resulting string on success.
+@param callback Invoked to fill the buffer. It is passed the buffer, the buffer length in characters, and an out pointer that it
+        must set to the number of characters needed including the null terminator. It returns an `HRESULT`, and any failure is
+        propagated to the caller.
+@return `S_OK` on success, or a failure `HRESULT` from `callback` or from allocation. */
 template <typename string_type, size_t stackBufferLength = 256>
 HRESULT AdaptFixedSizeToAllocatedResult(string_type& result, const wistd::function<HRESULT(PWSTR, size_t, size_t*)>& callback) WI_NOEXCEPT
 {
@@ -404,7 +487,7 @@ HRESULT ExpandEnvironmentStringsW(_In_ PCWSTR input, string_type& result) WI_NOE
 }
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
-/** Searches for a specified file in a specified path using ExpandEnvironmentStringsW(); */
+/** Searches for a specified file in a specified path using SearchPathW(). */
 template <typename string_type, size_t stackBufferLength = 256>
 HRESULT SearchPathW(_In_opt_ PCWSTR path, _In_ PCWSTR fileName, _In_opt_ PCWSTR extension, string_type& result) WI_NOEXCEPT
 {
@@ -431,6 +514,15 @@ HRESULT SearchPathW(_In_opt_ PCWSTR path, _In_ PCWSTR fileName, _In_opt_ PCWSTR 
         });
 }
 
+/** Retrieves the full path of the executable image for the specified process, using `QueryFullProcessImageNameW`.
+@tparam string_type The string type to produce the result in.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@param processHandle A handle to the process, opened with `PROCESS_QUERY_INFORMATION` or `PROCESS_QUERY_LIMITED_INFORMATION`
+        access.
+@param flags Passed through to `QueryFullProcessImageNameW`; `0` for the Win32 path form or `PROCESS_NAME_NATIVE` for the native
+        path form.
+@param result Receives the image path on success.
+@return `S_OK` on success, or a failure `HRESULT`. */
 template <typename string_type, size_t stackBufferLength = 256>
 HRESULT QueryFullProcessImageNameW(HANDLE processHandle, _In_ DWORD flags, string_type& result) WI_NOEXCEPT
 {
@@ -499,8 +591,8 @@ HRESULT TryGetEnvironmentVariableW(_In_ PCWSTR key, string_type& result) WI_NOEX
     return S_OK;
 }
 
-/** Retrieves the fully qualified path for the file containing the specified module loaded
-by a given process. Note GetModuleFileNameExW is a macro.*/
+/** Retrieves the fully qualified path for the file containing the specified module loaded by a given process.
+Note GetModuleFileNameExW is a macro. */
 template <typename string_type, size_t initialBufferLength = 128>
 HRESULT GetModuleFileNameExW(_In_opt_ HANDLE process, _In_opt_ HMODULE module, string_type& path) WI_NOEXCEPT
 {
@@ -542,15 +634,19 @@ HRESULT GetModuleFileNameExW(_In_opt_ HANDLE process, _In_opt_ HMODULE module, s
 }
 
 /** Retrieves the fully qualified path for the file that contains the specified module.
-The module must have been loaded by the current process. The path returned will use the
-same format that was specified when the module was loaded. Therefore, the path can be a
-long or short file name, and can have the prefix '\\?\'. */
+The module must have been loaded by the current process. The path returned will use the same format that was specified when the
+module was loaded. Therefore, the path can be a long or short file name, and can have the prefix '\\?\'. */
 template <typename string_type, size_t initialBufferLength = 128>
 HRESULT GetModuleFileNameW(HMODULE module, string_type& path) WI_NOEXCEPT
 {
     return wil::GetModuleFileNameExW<string_type, initialBufferLength>(nullptr, module, path);
 }
 
+/** Retrieves the path of the Windows system directory, using `GetSystemDirectoryW`.
+@tparam string_type The string type to produce the result in.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@param result Receives the system directory path on success.
+@return `S_OK` on success, or a failure `HRESULT`. */
 template <typename string_type, size_t stackBufferLength = 256>
 HRESULT GetSystemDirectoryW(string_type& result) WI_NOEXCEPT
 {
@@ -567,6 +663,11 @@ HRESULT GetSystemDirectoryW(string_type& result) WI_NOEXCEPT
 }
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
+/** Retrieves the path of the Windows directory, using `GetWindowsDirectoryW`.
+@tparam string_type The string type to produce the result in.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@param result Receives the Windows directory path on success.
+@return `S_OK` on success, or a failure `HRESULT`. */
 template <typename string_type, size_t stackBufferLength = 256>
 HRESULT GetWindowsDirectoryW(string_type& result) WI_NOEXCEPT
 {
@@ -594,7 +695,7 @@ string_type ExpandEnvironmentStringsW(_In_ PCWSTR input)
 }
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
-/** Searches for a specified file in a specified path using SearchPathW*/
+/** Searches for a specified file in a specified path using SearchPathW. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
 string_type TrySearchPathW(_In_opt_ PCWSTR path, _In_ PCWSTR fileName, PCWSTR _In_opt_ extension)
 {
@@ -623,6 +724,12 @@ string_type TryGetEnvironmentVariableW(_In_ PCWSTR key)
     return result;
 }
 
+/** Retrieves the fully qualified path for the file that contains the specified module.
+Throws on failure. The module must have been loaded by the current process.
+@tparam string_type The string type to return; defaults to `wil::unique_cotaskmem_string`.
+@tparam initialBufferLength The size, in characters, of the initial stack buffer.
+@param module The module to query, or `nullptr` for the current process's executable.
+@return The module's fully qualified path. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t initialBufferLength = 128>
 string_type GetModuleFileNameW(HMODULE module = nullptr /* current process module */)
 {
@@ -631,6 +738,13 @@ string_type GetModuleFileNameW(HMODULE module = nullptr /* current process modul
     return result;
 }
 
+/** Retrieves the fully qualified path for the file containing the specified module loaded by a given process.
+Throws on failure. Note `GetModuleFileNameExW` is a macro.
+@tparam string_type The string type to return; defaults to `wil::unique_cotaskmem_string`.
+@tparam initialBufferLength The size, in characters, of the initial stack buffer.
+@param process The process that loaded the module, or `nullptr` to use the current process.
+@param module The module to query, or `nullptr` for the process's executable.
+@return The module's fully qualified path. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t initialBufferLength = 128>
 string_type GetModuleFileNameExW(HANDLE process, HMODULE module)
 {
@@ -640,6 +754,11 @@ string_type GetModuleFileNameExW(HANDLE process, HMODULE module)
 }
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
+/** Retrieves the path of the Windows directory, using `GetWindowsDirectoryW`.
+Throws on failure.
+@tparam string_type The string type to return; defaults to `wil::unique_cotaskmem_string`.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@return The Windows directory path. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
 string_type GetWindowsDirectoryW()
 {
@@ -649,6 +768,11 @@ string_type GetWindowsDirectoryW()
 }
 #endif
 
+/** Retrieves the path of the Windows system directory, using `GetSystemDirectoryW`.
+Throws on failure.
+@tparam string_type The string type to return; defaults to `wil::unique_cotaskmem_string`.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@return The system directory path. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
 string_type GetSystemDirectoryW()
 {
@@ -657,6 +781,13 @@ string_type GetSystemDirectoryW()
     return result;
 }
 
+/** Retrieves the full path of the executable image for the specified process, using `QueryFullProcessImageNameW`.
+Throws on failure.
+@tparam string_type The string type to return; defaults to `wil::unique_cotaskmem_string`.
+@tparam stackBufferLength The size, in characters, of the initial stack buffer.
+@param processHandle A handle to the process; defaults to the current process.
+@param flags Passed through to `QueryFullProcessImageNameW`; `0` for the Win32 path form or `PROCESS_NAME_NATIVE`.
+@return The process image path. */
 template <typename string_type = wil::unique_cotaskmem_string, size_t stackBufferLength = 256>
 string_type QueryFullProcessImageNameW(HANDLE processHandle = GetCurrentProcess(), DWORD flags = 0)
 {
@@ -668,6 +799,7 @@ string_type QueryFullProcessImageNameW(HANDLE processHandle = GetCurrentProcess(
 
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 
+/// @cond
 namespace details
 {
     // Lookup a DWORD value under HKLM\...\Image File Execution Options\<current process name>
@@ -704,8 +836,15 @@ namespace details
         return S_OK;
     }
 } // namespace details
+/// @endcond
 
 #ifdef WIL_ENABLE_EXCEPTIONS
+/** Reads a DWORD "Image File Execution Options" value for the current process.
+Throws on failure. Looks up `valueName` under `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
+Options\<exe>`.
+@param valueName The name of the `REG_DWORD` value to read.
+@param defaultValue The value to return when the value is not present.
+@return The configured value, or `defaultValue` if it is not set. */
 inline DWORD GetCurrentProcessExecutionOption(PCWSTR valueName, DWORD defaultValue = 0)
 {
     DWORD result{};
@@ -714,7 +853,11 @@ inline DWORD GetCurrentProcessExecutionOption(PCWSTR valueName, DWORD defaultVal
 }
 #endif // WIL_ENABLE_EXCEPTIONS
 
-// No easy return mechanism for err_returncode_policy so skipping it.
+/** Reads a DWORD "Image File Execution Options" value for the current process, returning `defaultValue` on any failure (including
+when the value is not set).
+@param valueName The name of the `REG_DWORD` value to read.
+@param defaultValue The value to return on failure or when the value is not present.
+@return The configured value, or `defaultValue`. */
 inline DWORD GetCurrentProcessExecutionOptionNoThrow(PCWSTR valueName, DWORD defaultValue = 0)
 {
     DWORD result{};
@@ -725,6 +868,10 @@ inline DWORD GetCurrentProcessExecutionOptionNoThrow(PCWSTR valueName, DWORD def
     return result;
 }
 
+/** Reads a DWORD "Image File Execution Options" value for the current process, fail-fasting on failure.
+@param valueName The name of the `REG_DWORD` value to read.
+@param defaultValue The value to return when the value is not present.
+@return The configured value, or `defaultValue` if it is not set. */
 inline DWORD GetCurrentProcessExecutionOptionFailFast(PCWSTR valueName, DWORD defaultValue = 0)
 {
     DWORD result{};
@@ -743,6 +890,7 @@ inline DWORD GetCurrentProcessExecutionOptionFailFast(PCWSTR valueName, DWORD de
 //     missing or 0 -> don't break
 //     1 -> wait for the debugger, continue execution once it is attached
 //     2 -> wait for the debugger, break here once attached.
+/// @cond
 namespace details
 {
     template <typename error_policy>
@@ -775,19 +923,29 @@ namespace details
         }
     }
 } // namespace details
+/// @endcond
 
 #ifdef WIL_ENABLE_EXCEPTIONS
+/** Waits for a debugger to attach to the current process, based on registry configuration.
+Throws on failure. When `checkRegistryConfig` is `true`, the `WaitForDebuggerPresent` `REG_DWORD` value under this process's Image
+File Execution Options key controls the behavior: missing or `0` returns immediately, `1` waits and then continues, and `2` waits
+and then breaks into the debugger. When `false`, it unconditionally waits for a debugger to attach.
+@param checkRegistryConfig `true` to honor the registry configuration, `false` to always wait. */
 inline void WaitForDebuggerPresent(bool checkRegistryConfig = true)
 {
     details::WaitForDebuggerPresent<err_exception_policy>(checkRegistryConfig);
 }
 #endif // WIL_ENABLE_EXCEPTIONS
 
+/** Like `WaitForDebuggerPresent`, but never throws (uses the error-code policy internally).
+@param checkRegistryConfig `true` to honor the registry configuration, `false` to always wait. */
 inline void WaitForDebuggerPresentNoThrow(bool checkRegistryConfig = true)
 {
     details::WaitForDebuggerPresent<err_returncode_policy>(checkRegistryConfig);
 }
 
+/** Like `WaitForDebuggerPresent`, but fail-fasts instead of throwing on failure.
+@param checkRegistryConfig `true` to honor the registry configuration, `false` to always wait. */
 inline void WaitForDebuggerPresentFailFast(bool checkRegistryConfig = true)
 {
     details::WaitForDebuggerPresent<err_failfast_policy>(checkRegistryConfig);
@@ -796,9 +954,8 @@ inline void WaitForDebuggerPresentFailFast(bool checkRegistryConfig = true)
 #endif // DebugBreak
 #endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 
-/** Retrieve the HINSTANCE for the current DLL or EXE using this symbol that
-the linker provides for every module. This avoids the need for a global HINSTANCE variable
-and provides access to this value for static libraries. */
+/** Retrieve the HINSTANCE for the current DLL or EXE using this symbol that the linker provides for every module.
+This avoids the need for a global HINSTANCE variable and provides access to this value for static libraries. */
 inline HINSTANCE GetModuleInstanceHandle() WI_NOEXCEPT
 {
     return reinterpret_cast<HINSTANCE>(&__ImageBase);
@@ -807,11 +964,27 @@ inline HINSTANCE GetModuleInstanceHandle() WI_NOEXCEPT
 // GetModuleHandleExW was added to the app partition in version 22000 of the SDK
 #if defined(NTDDI_WIN10_CO) ? WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES) \
                             : WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
-// Use this in threads that can outlive the object or API call that created them.
-// Without this COM, or the API caller, can unload the DLL, resulting in a crash.
-// It is very important that this be the first object created in the thread proc
-// as when this runs down the thread exits and no destructors of objects created before
-// it will run.
+/** Keeps the current module loaded for the lifetime of a thread that may outlive the code that created it.
+Call this at the very start of a thread procedure when the thread can outlive the object or API call that created it (for
+example a thread started from a DLL that may be unloaded): without it, COM or the API caller can unload the DLL while the thread
+is still running, resulting in a crash. It must be the first object created in the thread proc so that it is destroyed last; its
+destructor calls `FreeLibraryAndExitThread`, which exits the thread and would otherwise skip the destructors of any objects
+created before it.
+~~~
+DWORD WINAPI MyThreadProc(void*)
+{
+    // Must be the first object created in the thread proc.
+    auto moduleRef = wil::get_module_reference_for_thread();
+
+    DoWorkThatMayOutliveTheCaller();
+    return 0; // moduleRef's destructor releases the module reference and exits the thread via FreeLibraryAndExitThread.
+}
+
+// The DLL that starts the thread may be unloaded before MyThreadProc finishes; the reference above keeps it loaded.
+wil::unique_handle thread{::CreateThread(nullptr, 0, MyThreadProc, nullptr, 0, nullptr)};
+~~~
+@return A `wil::scope_exit` object that, when destroyed, calls `FreeLibraryAndExitThread` to release the module reference and
+        exit the thread. */
 [[nodiscard]] inline auto get_module_reference_for_thread() noexcept
 {
     HMODULE thisModule{};
@@ -1223,6 +1396,12 @@ inline std::basic_string<CharT> ArgvToCommandLine(RangeT&& range, ArgvToCommandL
     return result;
 }
 
+//! Overload of `ArgvToCommandLine` that accepts a C-style `argc`/`argv` pair (e.g. from `wmain`/`main`).
+//! @tparam CharT The character type of the arguments (`wchar_t` or `char`).
+//! @param argc The number of arguments in `argv`.
+//! @param argv The array of argument strings to convert.
+//! @param flags Flags that control quoting behavior. See @ref wil::ArgvToCommandLineFlags.
+//! @return A command line string equivalent to the given arguments; see the primary `ArgvToCommandLine` overload.
 template <typename CharT>
 inline std::basic_string<wistd::remove_cv_t<CharT>> ArgvToCommandLine(
     int argc, CharT* const* argv, ArgvToCommandLineFlags flags = ArgvToCommandLineFlags::None)
@@ -1232,18 +1411,17 @@ inline std::basic_string<wistd::remove_cv_t<CharT>> ArgvToCommandLine(
 #endif
 } // namespace wil
 
-// Macro for calling GetProcAddress(), with type safety for C++ clients
-// using the type information from the specified function.
-// The return value is automatically cast to match the function prototype of the input function.
-//
-// Sample usage:
-//
-// auto sendMail = GetProcAddressByFunctionDeclaration(hinstMAPI, MAPISendMailW);
-// if (sendMail)
-// {
-//    sendMail(0, 0, pmm, MAPI_USE_DEFAULT, 0);
-// }
-//  Declaration
+/** Calls `GetProcAddress` with type safety for C++ clients, using the type information from the named function.
+The return value is automatically cast to match the function prototype of the input function.
+~~~
+auto sendMail = GetProcAddressByFunctionDeclaration(hinstMAPI, MAPISendMailW);
+if (sendMail)
+{
+    sendMail(0, 0, pmm, MAPI_USE_DEFAULT, 0);
+}
+~~~
+@param hinst The module handle to look up the function in.
+@param fn The (unqualified) name of the function whose declaration supplies the type to cast to. */
 #define GetProcAddressByFunctionDeclaration(hinst, fn) (reinterpret_cast<decltype(::fn)*>(GetProcAddress(hinst, #fn)))
 
 #endif // __WIL_WIN32_HELPERS_INCLUDED


### PR DESCRIPTION
Ensuring doc comments (1) exist, (2) are accurate, and (3) are kept up to date has not been a strong suit of ours... I'm going to start going through and let the robots clean things up. Plan is to issue one PR per header file so that the changes are not overwhelming.

Long term - would be nice to have GHCP do this on PRs, issuing change suggestions as necessary.