### PR TITLE
basic_zstring_view: preserve tail substr and backport contains

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -166,6 +166,9 @@ inline wil::unique_bstr make_bstr(std::wstring_view source)
     * A zstring_view can be converted implicitly to a std::string_view because it is always safe to use a nul-terminated
       string_view as a plain string view.
     * A zstring_view can be constructed from a std::string because the data in std::string is nul-terminated.
+    * substr(pos) returns a zstring_view because the tail remains nul-terminated. substr(pos, count) returns a
+      std::string_view because an arbitrary slice may not be nul-terminated.
+    * contains() is available before C++23 through a compatibility implementation.
 */
 template <class TChar>
 class basic_zstring_view : public std::basic_string_view<TChar>
@@ -245,6 +248,36 @@ public:
     {
         WI_ASSERT(this->data() == nullptr || this->data()[this->size()] == 0);
         return this->data();
+    }
+
+    // contains() backport for builds below C++23. Compiles out once the STL provides
+    // basic_string_view::contains natively.
+#if !defined(__cpp_lib_string_contains) || __cpp_lib_string_contains < 202011L
+    WI_NODISCARD constexpr bool contains(std::basic_string_view<TChar> view) const noexcept
+    {
+        return this->find(view) != this->npos;
+    }
+
+    WI_NODISCARD constexpr bool contains(TChar value) const noexcept
+    {
+        return this->find(value) != this->npos;
+    }
+
+    WI_NODISCARD constexpr bool contains(const TChar* value) const
+    {
+        return this->find(value) != this->npos;
+    }
+#endif
+
+    WI_NODISCARD constexpr basic_zstring_view substr(size_type pos = 0) const
+    {
+        const auto tail = std::basic_string_view<TChar>(*this).substr(pos);
+        return tail.data() == nullptr ? basic_zstring_view{} : basic_zstring_view{tail.data(), tail.size()};
+    }
+
+    WI_NODISCARD constexpr std::basic_string_view<TChar> substr(size_type pos, size_type count) const
+    {
+        return std::basic_string_view<TChar>(*this).substr(pos, count);
     }
 
 private:

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -279,4 +279,51 @@ TEST_CASE("StlTests::TestZWStringView", "[stl][zstring_view]")
     REQUIRE(wil::zwstring_view(fake_path) == L"hello");
 }
 
+TEST_CASE("StlTests::TestZStringView substr and contains", "[stl][zstring_view]")
+{
+    const auto test = [](auto value, auto expectedTail, auto prefix, auto missing, auto presentChar, auto missingChar) {
+        using zstring_view_type = decltype(value);
+        using char_type = typename zstring_view_type::value_type;
+        using string_view_type = std::basic_string_view<char_type>;
+
+        STATIC_REQUIRE(std::is_same_v<decltype(value.substr()), zstring_view_type>);
+        STATIC_REQUIRE(std::is_same_v<decltype(value.substr(0, 1)), string_view_type>);
+
+        const auto tail = value.substr(7);
+        REQUIRE(tail == expectedTail);
+        REQUIRE(tail.c_str()[tail.size()] == char_type{});
+
+        const auto whole = value.substr();
+        REQUIRE(whole == value);
+        REQUIRE(whole.data() == value.data());
+
+        const auto end = value.substr(value.size());
+        REQUIRE(end.empty());
+        REQUIRE(end.data() == value.data() + value.size());
+        REQUIRE(end.c_str()[0] == char_type{});
+
+        const auto slice = value.substr(0, 5);
+        REQUIRE(slice == prefix);
+
+        REQUIRE(value.contains(prefix));
+        REQUIRE(!value.contains(missing));
+        REQUIRE(value.contains(presentChar));
+        REQUIRE(!value.contains(missingChar));
+        REQUIRE(value.contains(value));
+
+        zstring_view_type empty;
+        const auto emptyTail = empty.substr();
+        REQUIRE(emptyTail.empty());
+        REQUIRE(emptyTail.data() == nullptr);
+        REQUIRE(empty.contains(string_view_type{}));
+        REQUIRE(!empty.contains(presentChar));
+
+        REQUIRE_THROWS_AS(value.substr(value.size() + 1), std::out_of_range);
+        REQUIRE_THROWS_AS(value.substr(value.size() + 1, 1), std::out_of_range);
+    };
+
+    test(wil::zstring_view{"Hello, World!"}, wil::zstring_view{"World!"}, "Hello", "missing", 'W', 'x');
+    test(wil::zwstring_view{L"Hello, World!"}, wil::zwstring_view{L"World!"}, L"Hello", L"missing", L'W', L'x');
+}
+
 #endif


### PR DESCRIPTION
## Summary

- Add a one-argument `basic_zstring_view::substr(pos)` overload that returns `basic_zstring_view`, since a tail of a null-terminated view remains null-terminated.
- Add an explicit two-argument `substr(pos, count)` overload returning `std::basic_string_view`, since an arbitrary slice may not be null-terminated.
- Backport the C++23 `contains()` overloads for earlier language modes, gated on `__cpp_lib_string_contains`.

This is the focused, independently reviewable subset discussed in #635. The non-null variant and its traits design are intentionally excluded and can be considered separately.

## Validation

- MSVC Debug C++17 `witest.exe "[zstring_view]"`: 96 assertions passed.
- MSVC Debug C++23 `witest.cpplatest.exe "[zstring_view]"`: 98 assertions passed.