### PR TITLE
basic_zstring_view: add opt-in nonnull variants

### DIFF
--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -160,6 +160,58 @@ inline wil::unique_bstr make_bstr(std::wstring_view source)
 #endif // WIL_ENABLE_EXCEPTIONS
 #endif // defined(__WIL_OLEAUTO_H_)
 
+template <class TChar, class Traits = std::char_traits<TChar>>
+class basic_zstring_view;
+
+/**
+    Traits policy for a basic_zstring_view whose constructors reject null pointers and whose default constructor points
+    at an internal empty string. The nested char_traits alias keeps the resulting basic_zstring_view derived from the
+    same std::basic_string_view specialization as the nullable form.
+
+    @note basic_zstring_view publicly inherits from std::basic_string_view. A caller can explicitly cast to a mutable
+    base reference and assign a view with null data, bypassing the policy. Avoid mutating the object through a base
+    reference.
+*/
+template <typename TChar, typename Traits = std::char_traits<TChar>>
+struct nonnull_zstring_view_traits
+{
+    using char_traits = Traits;
+    static constexpr bool empty_strings_are_non_null = true;
+};
+
+namespace details
+{
+    template <typename TChar, typename Traits>
+    struct zstring_view_traits
+    {
+        template <typename T = Traits>
+        static std::bool_constant<T::empty_strings_are_non_null> deduce_empty_strings_are_non_null(int);
+        template <typename = Traits>
+        static std::false_type deduce_empty_strings_are_non_null(...);
+
+        template <typename T = Traits>
+        static typename T::char_traits deduce_char_traits(int);
+        template <typename T = Traits>
+        static T deduce_char_traits(...);
+
+        static constexpr bool empty_strings_are_non_null = decltype(deduce_empty_strings_are_non_null(0))::value;
+        using char_traits = decltype(deduce_char_traits(0));
+    };
+
+    template <typename T>
+    struct is_basic_zstring_view : std::false_type
+    {
+    };
+
+    template <typename TChar, typename Traits>
+    struct is_basic_zstring_view<basic_zstring_view<TChar, Traits>> : std::true_type
+    {
+    };
+
+    template <typename TChar>
+    inline constexpr TChar zstring_view_empty_storage[1]{TChar()};
+} // namespace details
+
 /**
     zstring_view. A zstring_view is identical to a std::string_view except it is always nul-terminated (unless empty).
     * zstring_view can be used for storing string literals without "forgetting" the length or that it is nul-terminated.
@@ -169,11 +221,15 @@ inline wil::unique_bstr make_bstr(std::wstring_view source)
     * substr(pos) returns a zstring_view because the tail remains nul-terminated. substr(pos, count) returns a
       std::string_view because an arbitrary slice may not be nul-terminated.
     * contains() is available before C++23 through a compatibility implementation.
+    * nonnull_zstring_view uses a traits policy so its constructors produce non-null data(), including after default
+      construction.
 */
-template <class TChar>
-class basic_zstring_view : public std::basic_string_view<TChar>
+template <class TChar, class Traits>
+class basic_zstring_view : public std::basic_string_view<TChar, typename details::zstring_view_traits<TChar, Traits>::char_traits>
 {
-    using size_type = typename std::basic_string_view<TChar>::size_type;
+    using ZStringViewTraits = details::zstring_view_traits<TChar, Traits>;
+    using BaseType = std::basic_string_view<TChar, typename ZStringViewTraits::char_traits>;
+    using size_type = typename BaseType::size_type;
 
     template <typename T>
     struct has_c_str
@@ -196,14 +252,24 @@ class basic_zstring_view : public std::basic_string_view<TChar>
     };
 
 public:
-    constexpr basic_zstring_view() noexcept = default;
+    constexpr basic_zstring_view() noexcept : BaseType(default_view())
+    {
+    }
     constexpr basic_zstring_view(const basic_zstring_view&) noexcept = default;
     constexpr basic_zstring_view& operator=(const basic_zstring_view&) noexcept = default;
 
     constexpr basic_zstring_view(const TChar* pStringData, size_type stringLength) noexcept :
-        std::basic_string_view<TChar>(pStringData, stringLength)
+        BaseType(require_non_null(pStringData), stringLength)
     {
-        if (pStringData[stringLength] != 0)
+        if constexpr (ZStringViewTraits::empty_strings_are_non_null)
+        {
+            // The test harness records fail-fast and returns, so do not dereference a rejected null pointer afterward.
+            if ((pStringData != nullptr) && (pStringData[stringLength] != 0))
+            {
+                WI_STL_FAIL_FAST_IF(true);
+            }
+        }
+        else if (pStringData[stringLength] != 0)
         {
             WI_STL_FAIL_FAST_IF(true);
         }
@@ -211,29 +277,63 @@ public:
 
     template <size_t stringArrayLength>
     constexpr basic_zstring_view(const TChar (&stringArray)[stringArrayLength]) noexcept :
-        std::basic_string_view<TChar>(&stringArray[0], length_n(&stringArray[0], stringArrayLength))
+        BaseType(&stringArray[0], length_n(&stringArray[0], stringArrayLength))
     {
     }
+
+    template <typename T = Traits, std::enable_if_t<details::zstring_view_traits<TChar, T>::empty_strings_are_non_null, int> = 0>
+    basic_zstring_view(std::nullptr_t) = delete;
 
     // Construct from nul-terminated char ptr. To prevent this from overshadowing array construction,
     // we disable this constructor if the value is an array (including string literal).
     template <typename TPtr, std::enable_if_t<std::is_convertible<TPtr, const TChar*>::value && !std::is_array<TPtr>::value>* = nullptr>
-    constexpr basic_zstring_view(TPtr&& pStr) noexcept : std::basic_string_view<TChar>(std::forward<TPtr>(pStr))
+    constexpr basic_zstring_view(TPtr&& pStr) noexcept : BaseType(require_non_null(std::forward<TPtr>(pStr)))
     {
     }
 
-    constexpr basic_zstring_view(const std::basic_string<TChar>& str) noexcept :
-        std::basic_string_view<TChar>(&str[0], str.size())
+    constexpr basic_zstring_view(const std::basic_string<TChar>& str) noexcept : BaseType(&str[0], str.size())
     {
     }
 
-    template <typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && has_size<TSrc>::value && std::is_same_v<typename TSrc::value_type, TChar>>* = nullptr>
-    constexpr basic_zstring_view(TSrc const& src) noexcept : std::basic_string_view<TChar>(src.c_str(), src.size())
+    template <
+        typename TSrc,
+        std::enable_if_t<
+            has_c_str<TSrc>::value && has_size<TSrc>::value && std::is_same_v<typename TSrc::value_type, TChar> &&
+            !details::is_basic_zstring_view<std::decay_t<TSrc>>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept : BaseType(require_non_null(src.c_str()), src.size())
     {
     }
 
-    template <typename TSrc, std::enable_if_t<has_c_str<TSrc>::value && !has_size<TSrc>::value && std::is_same_v<typename TSrc::value_type, TChar>>* = nullptr>
-    constexpr basic_zstring_view(TSrc const& src) noexcept : std::basic_string_view<TChar>(src.c_str())
+    template <
+        typename TSrc,
+        std::enable_if_t<
+            has_c_str<TSrc>::value && !has_size<TSrc>::value && std::is_same_v<typename TSrc::value_type, TChar> &&
+            !details::is_basic_zstring_view<std::decay_t<TSrc>>::value>* = nullptr>
+    constexpr basic_zstring_view(TSrc const& src) noexcept : BaseType(require_non_null(src.c_str()))
+    {
+    }
+
+    template <
+        typename OtherTraits,
+        std::enable_if_t<
+            !std::is_same_v<Traits, OtherTraits> &&
+                std::is_same_v<typename ZStringViewTraits::char_traits, typename details::zstring_view_traits<TChar, OtherTraits>::char_traits> &&
+                (!ZStringViewTraits::empty_strings_are_non_null || details::zstring_view_traits<TChar, OtherTraits>::empty_strings_are_non_null),
+            int> = 0>
+    constexpr basic_zstring_view(const basic_zstring_view<TChar, OtherTraits>& other) noexcept :
+        BaseType(other.data(), other.size())
+    {
+    }
+
+    template <
+        typename OtherTraits,
+        std::enable_if_t<
+            !std::is_same_v<Traits, OtherTraits> &&
+                std::is_same_v<typename ZStringViewTraits::char_traits, typename details::zstring_view_traits<TChar, OtherTraits>::char_traits> &&
+                ZStringViewTraits::empty_strings_are_non_null && !details::zstring_view_traits<TChar, OtherTraits>::empty_strings_are_non_null,
+            long> = 0>
+    explicit constexpr basic_zstring_view(const basic_zstring_view<TChar, OtherTraits>& other) noexcept :
+        BaseType(require_non_null(other.data()), other.size())
     {
     }
 
@@ -253,7 +353,7 @@ public:
     // contains() backport for builds below C++23. Compiles out once the STL provides
     // basic_string_view::contains natively.
 #if !defined(__cpp_lib_string_contains) || __cpp_lib_string_contains < 202011L
-    WI_NODISCARD constexpr bool contains(std::basic_string_view<TChar> view) const noexcept
+    WI_NODISCARD constexpr bool contains(BaseType view) const noexcept
     {
         return this->find(view) != this->npos;
     }
@@ -271,20 +371,45 @@ public:
 
     WI_NODISCARD constexpr basic_zstring_view substr(size_type pos = 0) const
     {
-        const auto tail = std::basic_string_view<TChar>(*this).substr(pos);
+        const auto tail = BaseType(*this).substr(pos);
         return tail.data() == nullptr ? basic_zstring_view{} : basic_zstring_view{tail.data(), tail.size()};
     }
 
-    WI_NODISCARD constexpr std::basic_string_view<TChar> substr(size_type pos, size_type count) const
+    WI_NODISCARD constexpr BaseType substr(size_type pos, size_type count) const
     {
-        return std::basic_string_view<TChar>(*this).substr(pos, count);
+        return BaseType(*this).substr(pos, count);
     }
 
 private:
+    static constexpr BaseType default_view() noexcept
+    {
+        if constexpr (ZStringViewTraits::empty_strings_are_non_null)
+        {
+            return BaseType(&details::zstring_view_empty_storage<TChar>[0], 0);
+        }
+        else
+        {
+            return BaseType{};
+        }
+    }
+
+    static constexpr const TChar* require_non_null(const TChar* value) noexcept
+    {
+        if constexpr (ZStringViewTraits::empty_strings_are_non_null)
+        {
+            if (value == nullptr)
+            {
+                WI_STL_FAIL_FAST_IF(true);
+                return &details::zstring_view_empty_storage<TChar>[0];
+            }
+        }
+        return value;
+    }
+
     // Bounds-checked version of char_traits::length, like strnlen. Requires that the input contains a null terminator.
     static constexpr size_type length_n(_In_reads_opt_(buf_size) const TChar* str, size_type buf_size) noexcept
     {
-        const std::basic_string_view<TChar> view(str, buf_size);
+        const BaseType view(str, buf_size);
         auto pos = view.find_first_of(TChar());
         if (pos == view.npos)
         {
@@ -294,17 +419,21 @@ private:
     }
 
     // The following basic_string_view methods must not be allowed because they break the nul-termination.
-    using std::basic_string_view<TChar>::swap;
-    using std::basic_string_view<TChar>::remove_suffix;
+    using BaseType::remove_suffix;
+    using BaseType::swap;
 };
 
 using zstring_view = basic_zstring_view<char>;
 using zwstring_view = basic_zstring_view<wchar_t>;
 
+// Variants that reject null construction and default to a non-null empty string.
+using nonnull_zstring_view = basic_zstring_view<char, nonnull_zstring_view_traits<char>>;
+using nonnull_zwstring_view = basic_zstring_view<wchar_t, nonnull_zstring_view_traits<wchar_t>>;
+
 // str_raw_ptr is an overloaded function that retrieves a const pointer to the first character in a string's buffer.
 // This is the overload for std::wstring.  Other overloads available in resource.h.
-template <typename TChar>
-inline auto str_raw_ptr(basic_zstring_view<TChar> str)
+template <typename TChar, typename Traits>
+inline auto str_raw_ptr(basic_zstring_view<TChar, Traits> str)
 {
     return str.c_str();
 }
@@ -423,8 +552,9 @@ overloaded(T...) -> overloaded<T...>;
 #ifndef WIL_SUPPRESS_STD_FORMAT_USE
 #if (__WI_LIBCPP_STD_VER >= 20) && WI_HAS_INCLUDE(<format>, 1) // Assume present if C++20
 #include <format>
-template <typename TChar>
-struct std::formatter<wil::basic_zstring_view<TChar>, TChar> : std::formatter<std::basic_string_view<TChar>, TChar>
+template <typename TChar, typename Traits>
+struct std::formatter<wil::basic_zstring_view<TChar, Traits>, TChar>
+    : std::formatter<std::basic_string_view<TChar, typename wil::details::zstring_view_traits<TChar, Traits>::char_traits>, TChar>
 {
 };
 #endif

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -346,6 +346,10 @@ public:
 
     WI_NODISCARD constexpr const TChar* c_str() const noexcept
     {
+        if constexpr (ZStringViewTraits::empty_strings_are_non_null)
+        {
+            WI_STL_FAIL_FAST_IF(this->data() == nullptr);
+        }
         WI_ASSERT(this->data() == nullptr || this->data()[this->size()] == 0);
         return this->data();
     }

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -27,6 +27,9 @@
 #ifndef WI_STL_FAIL_FAST_IF
 #define WI_STL_FAIL_FAST_IF FAIL_FAST_IF
 #endif
+#ifndef WI_STL_FAIL_FAST_IF_NULL
+#define WI_STL_FAIL_FAST_IF_NULL FAIL_FAST_IF_NULL
+#endif
 /// @endcond
 
 #if defined(WIL_ENABLE_EXCEPTIONS)
@@ -348,7 +351,7 @@ public:
     {
         if constexpr (ZStringViewTraits::empty_strings_are_non_null)
         {
-            WI_STL_FAIL_FAST_IF(this->data() == nullptr);
+            WI_STL_FAIL_FAST_IF_NULL(this->data());
         }
         WI_ASSERT(this->data() == nullptr || this->data()[this->size()] == 0);
         return this->data();
@@ -401,9 +404,9 @@ private:
     {
         if constexpr (ZStringViewTraits::empty_strings_are_non_null)
         {
+            value = WI_STL_FAIL_FAST_IF_NULL(value);
             if (value == nullptr)
             {
-                WI_STL_FAIL_FAST_IF(true);
                 return &details::zstring_view_empty_storage<TChar>[0];
             }
         }

--- a/include/wil/stl.h
+++ b/include/wil/stl.h
@@ -184,21 +184,18 @@ struct nonnull_zstring_view_traits
 
 namespace details
 {
-    template <typename TChar, typename Traits>
+    template <typename TChar, typename Traits, typename = void>
     struct zstring_view_traits
     {
-        template <typename T = Traits>
-        static std::bool_constant<T::empty_strings_are_non_null> deduce_empty_strings_are_non_null(int);
-        template <typename = Traits>
-        static std::false_type deduce_empty_strings_are_non_null(...);
+        static constexpr bool empty_strings_are_non_null = false;
+        using char_traits = Traits;
+    };
 
-        template <typename T = Traits>
-        static typename T::char_traits deduce_char_traits(int);
-        template <typename T = Traits>
-        static T deduce_char_traits(...);
-
-        static constexpr bool empty_strings_are_non_null = decltype(deduce_empty_strings_are_non_null(0))::value;
-        using char_traits = decltype(deduce_char_traits(0));
+    template <typename TChar, typename Traits>
+    struct zstring_view_traits<TChar, Traits, std::void_t<decltype(Traits::empty_strings_are_non_null)>>
+    {
+        static constexpr bool empty_strings_are_non_null = Traits::empty_strings_are_non_null;
+        using char_traits = typename Traits::char_traits;
     };
 
     template <typename T>
@@ -233,6 +230,9 @@ class basic_zstring_view : public std::basic_string_view<TChar, typename details
     using ZStringViewTraits = details::zstring_view_traits<TChar, Traits>;
     using BaseType = std::basic_string_view<TChar, typename ZStringViewTraits::char_traits>;
     using size_type = typename BaseType::size_type;
+
+    template <class, class>
+    friend class basic_zstring_view;
 
     template <typename T>
     struct has_c_str
@@ -319,8 +319,7 @@ public:
     template <
         typename OtherTraits,
         std::enable_if_t<
-            !std::is_same_v<Traits, OtherTraits> &&
-                std::is_same_v<typename ZStringViewTraits::char_traits, typename details::zstring_view_traits<TChar, OtherTraits>::char_traits> &&
+            !std::is_same_v<Traits, OtherTraits> && std::is_same_v<BaseType, typename basic_zstring_view<TChar, OtherTraits>::BaseType> &&
                 (!ZStringViewTraits::empty_strings_are_non_null || details::zstring_view_traits<TChar, OtherTraits>::empty_strings_are_non_null),
             int> = 0>
     constexpr basic_zstring_view(const basic_zstring_view<TChar, OtherTraits>& other) noexcept :
@@ -331,14 +330,18 @@ public:
     template <
         typename OtherTraits,
         std::enable_if_t<
-            !std::is_same_v<Traits, OtherTraits> &&
-                std::is_same_v<typename ZStringViewTraits::char_traits, typename details::zstring_view_traits<TChar, OtherTraits>::char_traits> &&
+            !std::is_same_v<Traits, OtherTraits> && std::is_same_v<BaseType, typename basic_zstring_view<TChar, OtherTraits>::BaseType> &&
                 ZStringViewTraits::empty_strings_are_non_null && !details::zstring_view_traits<TChar, OtherTraits>::empty_strings_are_non_null,
             long> = 0>
     explicit constexpr basic_zstring_view(const basic_zstring_view<TChar, OtherTraits>& other) noexcept :
         BaseType(require_non_null(other.data()), other.size())
     {
     }
+
+    template <
+        typename OtherTraits,
+        std::enable_if_t<!std::is_same_v<Traits, OtherTraits> && !std::is_same_v<BaseType, typename basic_zstring_view<TChar, OtherTraits>::BaseType>, short> = 0>
+    basic_zstring_view(const basic_zstring_view<TChar, OtherTraits>&) = delete;
 
     // basic_string_view [] precondition won't let us read view[view.size()]; so we define our own.
     WI_NODISCARD constexpr const TChar& operator[](size_type idx) const noexcept
@@ -351,7 +354,7 @@ public:
     {
         if constexpr (ZStringViewTraits::empty_strings_are_non_null)
         {
-            WI_STL_FAIL_FAST_IF_NULL(this->data());
+            WI_ASSERT(this->data() != nullptr);
         }
         WI_ASSERT(this->data() == nullptr || this->data()[this->size()] == 0);
         return this->data();

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -201,6 +201,20 @@ TEST_CASE("StlTests::TestZStringView formatting", "[stl][zstring_view]")
         auto fmtStr = std::format("Hello {}", str);
         REQUIRE(fmtStr == "Hello kittens");
     }
+
+    SECTION("nonnull_zstring_view can be used with std::format")
+    {
+        wil::nonnull_zstring_view str{"kittens"};
+        auto fmtStr = std::format("Hello {}", str);
+        REQUIRE(fmtStr == "Hello kittens");
+    }
+
+    SECTION("nonnull_zwstring_view can be used with std::format")
+    {
+        wil::nonnull_zwstring_view str{L"kittens"};
+        auto fmtStr = std::format(L"Hello {}", str);
+        REQUIRE(fmtStr == L"Hello kittens");
+    }
 }
 
 #endif
@@ -324,6 +338,63 @@ TEST_CASE("StlTests::TestZStringView substr and contains", "[stl][zstring_view]"
 
     test(wil::zstring_view{"Hello, World!"}, wil::zstring_view{"World!"}, "Hello", "missing", 'W', 'x');
     test(wil::zwstring_view{L"Hello, World!"}, wil::zwstring_view{L"World!"}, L"Hello", L"missing", L'W', L'x');
+}
+
+TEST_CASE("StlTests::TestNonNullZStringView", "[stl][zstring_view][nonnull]")
+{
+    const auto test = [](auto nonnullDefault, auto nullableDefault, auto text) {
+        using nonnull_type = decltype(nonnullDefault);
+        using nullable_type = decltype(nullableDefault);
+        using char_type = typename nonnull_type::value_type;
+        using string_view_type = std::basic_string_view<char_type>;
+
+        STATIC_REQUIRE(sizeof(nonnull_type) == sizeof(nullable_type));
+        STATIC_REQUIRE(std::is_trivially_copyable_v<nonnull_type>);
+        STATIC_REQUIRE(!std::is_constructible_v<nonnull_type, std::nullptr_t>);
+        STATIC_REQUIRE(std::is_convertible_v<nonnull_type, nullable_type>);
+        STATIC_REQUIRE(!std::is_convertible_v<nullable_type, nonnull_type>);
+        STATIC_REQUIRE(std::is_constructible_v<nonnull_type, nullable_type>);
+
+        REQUIRE(nullableDefault.data() == nullptr);
+        REQUIRE(nonnullDefault.data() != nullptr);
+        REQUIRE(nonnullDefault.empty());
+        REQUIRE(nonnullDefault.c_str()[0] == char_type{});
+
+        nonnull_type fromLiteral{text};
+        REQUIRE(fromLiteral.data() != nullptr);
+        REQUIRE(fromLiteral.c_str()[fromLiteral.size()] == char_type{});
+        REQUIRE(wil::str_raw_ptr(fromLiteral) == fromLiteral.c_str());
+
+        string_view_type& baseReference = fromLiteral;
+        REQUIRE(baseReference.data() == fromLiteral.data());
+        REQUIRE(baseReference.size() == fromLiteral.size());
+
+        nullable_type nullable = fromLiteral;
+        REQUIRE(nullable.data() == fromLiteral.data());
+        REQUIRE(nullable.size() == fromLiteral.size());
+
+        nonnull_type checked{nullable};
+        REQUIRE(checked.data() == nullable.data());
+        REQUIRE(checked.size() == nullable.size());
+
+        auto emptyTail = nonnullDefault.substr();
+        REQUIRE(emptyTail.data() != nullptr);
+        REQUIRE(emptyTail.empty());
+
+        const char_type* nullPointer = nullptr;
+        REQUIRE_ERROR((nonnull_type{nullPointer}));
+        REQUIRE_ERROR((nonnull_type{nullPointer, 0}));
+        REQUIRE_ERROR((nonnull_type{nullableDefault}));
+    };
+
+    test(wil::nonnull_zstring_view{}, wil::zstring_view{}, "hello");
+    test(wil::nonnull_zwstring_view{}, wil::zwstring_view{}, L"hello");
+
+    struct custom_char_traits : std::char_traits<char>
+    {
+    };
+    using custom_nonnull = wil::basic_zstring_view<char, wil::nonnull_zstring_view_traits<char, custom_char_traits>>;
+    STATIC_REQUIRE(std::is_base_of_v<std::basic_string_view<char, custom_char_traits>, custom_nonnull>);
 }
 
 #endif

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -369,11 +369,6 @@ TEST_CASE("StlTests::TestNonNullZStringView", "[stl][zstring_view][nonnull]")
         REQUIRE(baseReference.data() == fromLiteral.data());
         REQUIRE(baseReference.size() == fromLiteral.size());
 
-        nonnull_type corrupted{text};
-        string_view_type& mutableBaseReference = corrupted;
-        mutableBaseReference = string_view_type{};
-        REQUIRE_ERROR(corrupted.c_str());
-
         nullable_type nullable = fromLiteral;
         REQUIRE(nullable.data() == fromLiteral.data());
         REQUIRE(nullable.size() == fromLiteral.size());
@@ -399,7 +394,13 @@ TEST_CASE("StlTests::TestNonNullZStringView", "[stl][zstring_view][nonnull]")
     {
     };
     using custom_nonnull = wil::basic_zstring_view<char, wil::nonnull_zstring_view_traits<char, custom_char_traits>>;
+    using custom_nullable = wil::basic_zstring_view<char, custom_char_traits>;
+    using custom_base = std::basic_string_view<char, typename wil::details::zstring_view_traits<char, custom_char_traits>::char_traits>;
     STATIC_REQUIRE(std::is_base_of_v<std::basic_string_view<char, custom_char_traits>, custom_nonnull>);
+    STATIC_REQUIRE(!std::is_same_v<std::string_view, custom_base>);
+    STATIC_REQUIRE(!std::is_constructible_v<wil::zstring_view, custom_nullable>);
+    STATIC_REQUIRE(!std::is_constructible_v<custom_nonnull, wil::zstring_view>);
+    STATIC_REQUIRE(!std::is_constructible_v<wil::nonnull_zstring_view, custom_nullable>);
 }
 
 #endif

--- a/tests/StlTests.cpp
+++ b/tests/StlTests.cpp
@@ -369,6 +369,11 @@ TEST_CASE("StlTests::TestNonNullZStringView", "[stl][zstring_view][nonnull]")
         REQUIRE(baseReference.data() == fromLiteral.data());
         REQUIRE(baseReference.size() == fromLiteral.size());
 
+        nonnull_type corrupted{text};
+        string_view_type& mutableBaseReference = corrupted;
+        mutableBaseReference = string_view_type{};
+        REQUIRE_ERROR(corrupted.c_str());
+
         nullable_type nullable = fromLiteral;
         REQUIRE(nullable.data() == fromLiteral.data());
         REQUIRE(nullable.size() == fromLiteral.size());


### PR DESCRIPTION
## Summary

`wil::zstring_view` is a non-owning view of a null-terminated string. Its default constructor follows `std::string_view`: the view is empty and `data()` is null. Existing callers may use that null pointer to mean "no string."

Some callers instead need an empty view that can be passed directly to a C API without first checking for null. This PR adds `wil::nonnull_zstring_view` and `wil::nonnull_zwstring_view` for that use case. Their default constructors point at an internal empty string, while default-constructed `wil::zstring_view` and `wil::zwstring_view` continue to hold null.

```cpp
wil::zstring_view nullable;         // data() == nullptr
wil::nonnull_zstring_view nonnull;  // data() != nullptr, c_str()[0] == '\0'

printf("%s", nonnull.c_str());
```

The non-null empty state also appears in the C++29 proposal [P3655R5, `std::cstring_view`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3655r5.html), which describes a non-owning, null-terminated string view whose default constructor refers to a static null terminator.

## Public API

```cpp
template <typename TChar, typename Traits = std::char_traits<TChar>>
struct nonnull_zstring_view_traits
{
    using char_traits = Traits;
    static constexpr bool empty_strings_are_non_null = true;
};

template <class TChar, class Traits = std::char_traits<TChar>>
class basic_zstring_view;

using nonnull_zstring_view =
    basic_zstring_view<char, nonnull_zstring_view_traits<char>>;
using nonnull_zwstring_view =
    basic_zstring_view<wchar_t, nonnull_zstring_view_traits<wchar_t>>;
```

The policy selects non-null behavior separately from the character traits, which supply operations such as character comparison and string-length calculation. Its `char_traits` member determines the underlying `std::basic_string_view` type. With the default character traits, both narrow variants derive from `std::string_view`, and both wide variants derive from `std::wstring_view`.

Custom character traits can be supplied through `nonnull_zstring_view_traits<TChar, Traits>`. Policy detection requires both `empty_strings_are_non_null` and `char_traits`; otherwise the supplied type is treated as ordinary character traits.

## Construction, conversion, and assignment

Direct `nullptr` construction is deleted for both nullable and non-null variants. The nullable variants otherwise retain their original construction preconditions and failure paths. The non-null variants reject typed null pointer inputs through WIL's fail-fast mechanism, which reports the contract violation and terminates the process.

| Construction | Nullable variant | Non-null variant |
|---|---|---|
| Default construction | Empty, null data | Empty, non-null data |
| Direct `nullptr` | Compile-time error | Compile-time error |
| Typed null pointer, without length | Original invalid-input path | Fail-fast |
| Null pointer plus zero length | Original invalid-input path | Fail-fast |
| Null pointer plus non-zero length | Original invalid-input path | Fail-fast |
| Non-null empty string buffer plus zero length | Preserves the pointer and zero length | Preserves the pointer and zero length |
| String-like object with `c_str() == nullptr`, `size() == 0` | Empty, null data | Fail-fast |

For non-null views, pointer-plus-length construction checks the pointer and trailing null terminator together. Initialization avoids passing a null pointer with a non-zero length to the standard-library base, so WIL can report the failure in the constructor body. Pointer-only construction similarly avoids calculating the length of a null pointer before validation.

Converting construction and assignment require matching underlying `std::basic_string_view` types. Conversion from a non-null view to a nullable view is implicit. The reverse conversion requires explicit construction and checks the source pointer:

```cpp
wil::zstring_view source{"hello"};
wil::nonnull_zstring_view checked{source}; // explicit, checked construction
wil::zstring_view nullable = checked;      // implicit conversion
```

Assignment is supported in both compatible directions. Assigning a nullable view into a non-null view checks the source before modifying the destination. Same-type copy assignment stays defaulted, and construction or assignment between incompatible underlying character traits is deleted.

WIL's unit test harness intercepts fail-fast to record the failure and allow execution to continue instead of terminating the test process. When this happens during a rejected assignment, the assignment operator returns without changing the destination's pointer or size.

`substr(pos)` preserves the selected view type and its default-state behavior. `str_raw_ptr` and `std::format` accept the new variants as well.

## Inheritance limitation

All `basic_zstring_view` variants publicly inherit from `std::basic_string_view`. A mutable base reference can therefore assign null data or a view that is not null-terminated, bypassing the derived type's validation:

```cpp
wil::nonnull_zstring_view value{"hello"};
std::string_view& base = value;
base = std::string_view{}; // bypasses the non-null policy
```

Avoid mutating these objects through a base reference. The derived `c_str()` has debug assertions for the non-null policy and trailing terminator; calls made directly through the base class bypass those checks.

## Compatibility

`wil::zstring_view` and `wil::zwstring_view` retain their names, nullable default state, and original runtime construction paths. Direct `nullptr` construction now fails to compile for both nullable and non-null variants; stronger runtime null checks are confined to the non-null policy.

Adding the defaulted `Traits` parameter changes the compiler-generated linker names for types and functions that expose `basic_zstring_view`. The object representation remains a pointer and length, and the views remain trivially copyable.

## Tests

Regression coverage includes narrow and wide default states, nullable string-like empty states, non-null null-input rejection for zero and non-zero lengths, zero-length buffer validation, compile-time nullable construction and substrings, compatible and incompatible conversions and assignments, destination preservation after rejected assignment, partial-policy detection, and integration with `str_raw_ptr` and `std::format`.

The traits-policy design builds on Duncan's feedback in #635.
